### PR TITLE
CDMD-2459 [React Router Codemod] Replace location.query

### DIFF
--- a/apps/registry/codemods/react-router/4/replace-location-query/.mocharc.json
+++ b/apps/registry/codemods/react-router/4/replace-location-query/.mocharc.json
@@ -1,0 +1,8 @@
+{
+	"loader": ["ts-node/esm"],
+	"full-trace": true,
+	"failZero": false,
+	"bail": true,
+	"spec": "./**/test.ts",
+	"timeout": 5000
+}

--- a/apps/registry/codemods/react-router/4/replace-location-query/.mocharc.json
+++ b/apps/registry/codemods/react-router/4/replace-location-query/.mocharc.json
@@ -1,8 +1,0 @@
-{
-	"loader": ["ts-node/esm"],
-	"full-trace": true,
-	"failZero": false,
-	"bail": true,
-	"spec": "./**/test.ts",
-	"timeout": 5000
-}

--- a/apps/registry/codemods/react-router/4/replace-location-query/README.md
+++ b/apps/registry/codemods/react-router/4/replace-location-query/README.md
@@ -1,0 +1,55 @@
+# Replace Location Query
+
+## Description
+
+This codemod replaces instances of `location.query` with `parse(location.search)`, where `parse` is a function imported from `query-string`.
+
+## Example
+
+### Before
+
+```jsx
+const List = ({ location }) => (
+	<div>
+		<h1>{location.query.sort}</h1>
+	</div>
+);
+```
+
+### After
+
+```jsx
+import { parse } from 'query-string';
+
+const List = ({ location }) => (
+	<div>
+		<h1>{parse(location.search).sort}</h1>
+	</div>
+);
+```
+
+## Applicability Criteria
+
+React Router version 3.x.y
+
+## Other Metadata
+
+### Codemod Version
+
+v1.0.0
+
+### Change Mode
+
+**Autonomous**: Changes can safely be pushed and merged without further human involvement.
+
+### **Codemod Engine**
+
+jscodeshift
+
+### Estimated Time Saving
+
+~3 minutes per occurrence
+
+### Owner
+
+[Codemod.com](https://codemod.com)

--- a/apps/registry/codemods/react-router/4/replace-location-query/README.md
+++ b/apps/registry/codemods/react-router/4/replace-location-query/README.md
@@ -10,9 +10,9 @@ This codemod replaces instances of `location.query` with `parse(location.search)
 
 ```jsx
 const List = ({ location }) => (
-	<div>
-		<h1>{location.query.sort}</h1>
-	</div>
+  <div>
+    <h1>{location.query.sort}</h1>
+  </div>
 );
 ```
 
@@ -22,9 +22,9 @@ const List = ({ location }) => (
 import { parse } from 'query-string';
 
 const List = ({ location }) => (
-	<div>
-		<h1>{parse(location.search).sort}</h1>
-	</div>
+  <div>
+    <h1>{parse(location.search).sort}</h1>
+  </div>
 );
 ```
 

--- a/apps/registry/codemods/react-router/4/replace-location-query/README.md
+++ b/apps/registry/codemods/react-router/4/replace-location-query/README.md
@@ -10,9 +10,9 @@ This codemod replaces instances of `location.query` with `parse(location.search)
 
 ```jsx
 const List = ({ location }) => (
-  <div>
-    <h1>{location.query.sort}</h1>
-  </div>
+	<div>
+		<h1>{location.query.sort}</h1>
+	</div>
 );
 ```
 
@@ -22,9 +22,9 @@ const List = ({ location }) => (
 import { parse } from 'query-string';
 
 const List = ({ location }) => (
-  <div>
-    <h1>{parse(location.search).sort}</h1>
-  </div>
+	<div>
+		<h1>{parse(location.search).sort}</h1>
+	</div>
 );
 ```
 

--- a/apps/registry/codemods/react-router/4/replace-location-query/config.json
+++ b/apps/registry/codemods/react-router/4/replace-location-query/config.json
@@ -1,0 +1,8 @@
+{
+	"schemaVersion": "1.0.0",
+	"name": "react-router/4/replace-location-query",
+	"description": "",
+	"engine": "jscodeshift",
+	"extensions": ["js*", "ts*"],
+	"dependencyVersionLowerThan": ["react-router", "4.0.0"]
+}

--- a/apps/registry/codemods/react-router/4/replace-location-query/index.d.ts
+++ b/apps/registry/codemods/react-router/4/replace-location-query/index.d.ts
@@ -1,0 +1,3 @@
+import type { API, FileInfo } from 'jscodeshift';
+
+export default function transform(file: FileInfo, api: API): string;

--- a/apps/registry/codemods/react-router/4/replace-location-query/package.json
+++ b/apps/registry/codemods/react-router/4/replace-location-query/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@codemod-com/codemod-react-router-4-replace-location-query",
+	"dependencies": {},
+	"devDependencies": {
+		"@codemod-com/utilities": "workspace:*",
+		"@codemod-com/registry-cjs-builder": "workspace:*",
+		"typescript": "^5.2.2",
+		"esbuild": "0.19.5",
+		"ts-node": "^10.9.1",
+		"jscodeshift": "^0.15.1",
+		"@types/jscodeshift": "^0.11.10",
+		"vitest": "^1.0.1",
+		"@vitest/coverage-v8": "^1.0.1"
+	},
+	"main": "./dist/index.cjs",
+	"types": "/dist/index.d.ts",
+	"scripts": {
+		"build:cjs": "cjs-builder ./src/index.ts",
+		"test": "vitest run",
+		"test:watch": "vitest watch",
+		"coverage": "vitest run --coverage"
+	},
+	"files": [
+		"README.md",
+		"config.json",
+		"./dist/index.cjs",
+		"./index.d.ts"
+	],
+	"type": "module"
+}

--- a/apps/registry/codemods/react-router/4/replace-location-query/src/index.ts
+++ b/apps/registry/codemods/react-router/4/replace-location-query/src/index.ts
@@ -1,0 +1,44 @@
+import type { API, FileInfo } from 'jscodeshift';
+
+function transform(file: FileInfo, api: API) {
+	const j = api.jscodeshift;
+	const root = j(file.source);
+
+	root.find(j.MemberExpression, {
+		object: {
+			name: 'location',
+		},
+		property: {
+			name: 'query',
+		},
+	}).replaceWith(() =>
+		j.callExpression(j.identifier('parse'), [
+			j.memberExpression(
+				j.identifier('location'),
+				j.identifier('search'),
+			),
+		]),
+	);
+
+	const hasQueryStringImport =
+		root.find(j.ImportDeclaration, {
+			source: {
+				value: 'query-string',
+			},
+		}).length > 0;
+
+	if (!hasQueryStringImport) {
+		root.find(j.Program).forEach((path) => {
+			path.node.body.unshift(
+				j.importDeclaration(
+					[j.importSpecifier(j.identifier('parse'), null)],
+					j.literal('query-string'),
+				),
+			);
+		});
+	}
+
+	return root.toSource();
+}
+
+export default transform;

--- a/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
+++ b/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
@@ -5,20 +5,103 @@ import { describe, it } from 'vitest';
 import transform from '../src/index.js';
 
 describe('react-router 4 replace-location-query', function () {
-	it('basic', function () {
+	it('one instance', function () {
 		const INPUT = `
-			const PostList = ({ location }) => (
+			const id = location.query.id;
+        `;
+
+		const OUTPUT = `
+			import { parse } from 'query-string';
+			const id = parse(location.search).id;
+        `;
+
+		const fileInfo: FileInfo = {
+			path: 'index.js',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi('tsx'));
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
+
+	it('multiple instances', function () {
+		const INPUT = `
+			const id = location.query.id;
+			const name = location.query.name;
+        `;
+
+		const OUTPUT = `
+			import { parse } from 'query-string';
+			const id = parse(location.search).id;
+			const name = parse(location.search).name;
+        `;
+
+		const fileInfo: FileInfo = {
+			path: 'index.js',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi('tsx'));
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
+
+	it('one instance in a functional component', function () {
+		const INPUT = `
+			const List = ({ location }) => (
 				<div>
-					<h1>List sorted by {location.query.sort}</h1>
+					<h1>{location.query.sort}</h1>
 				</div>
 			);
         `;
 
 		const OUTPUT = `
 			import { parse } from 'query-string';
-			const PostList = ({ location }) => (
+			const List = ({ location }) => (
 				<div>
-					<h1>List sorted by {parse(location.search).sort}</h1>
+					<h1>{parse(location.search).sort}</h1>
+				</div>
+			);
+        `;
+
+		const fileInfo: FileInfo = {
+			path: 'index.js',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi('tsx'));
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
+
+	it('multiple instances in a functional component', function () {
+		const INPUT = `
+			const List = ({ location }) => (
+				<div>
+					<h1>{location.query.sort}</h1>
+					<h1>{location.query.name}</h1>
+					<h1>{location.query.id}</h1>
+				</div>
+			);
+        `;
+
+		const OUTPUT = `
+			import { parse } from 'query-string';
+			const List = ({ location }) => (
+				<div>
+					<h1>{parse(location.search).sort}</h1>
+					<h1>{parse(location.search).name}</h1>
+					<h1>{parse(location.search).id}</h1>
 				</div>
 			);
         `;

--- a/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
+++ b/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { buildApi } from '@codemod-com/utilities';
+import type { FileInfo } from 'jscodeshift';
+import { describe, it } from 'vitest';
+import transform from '../src/index.js';
+
+describe('react-router 4 replace-location-query', function () {
+	it('basic', function () {
+		const INPUT = `
+			const PostList = ({ location }) => (
+				<div>
+					<h1>List sorted by {location.query.sort}</h1>
+				</div>
+			);
+        `;
+
+		const OUTPUT = `
+			import { parse } from 'query-string';
+			const PostList = ({ location }) => {
+				const query = parse(location.search);
+				return (
+					<div>
+						<h1>List sorted by {query.sort}</h1>
+					</div>
+				);
+			};		
+        `;
+
+		const fileInfo: FileInfo = {
+			path: 'index.js',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi('tsx'));
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
+});

--- a/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
+++ b/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
@@ -16,14 +16,11 @@ describe('react-router 4 replace-location-query', function () {
 
 		const OUTPUT = `
 			import { parse } from 'query-string';
-			const PostList = ({ location }) => {
-				const query = parse(location.search);
-				return (
-					<div>
-						<h1>List sorted by {query.sort}</h1>
-					</div>
-				);
-			};		
+			const PostList = ({ location }) => (
+				<div>
+					<h1>List sorted by {parse(location.search).sort}</h1>
+				</div>
+			);
         `;
 
 		const fileInfo: FileInfo = {

--- a/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
+++ b/apps/registry/codemods/react-router/4/replace-location-query/test/test.ts
@@ -118,4 +118,26 @@ describe('react-router 4 replace-location-query', function () {
 			OUTPUT.replace(/\W/gm, ''),
 		);
 	});
+
+	it('query-string import statement should not be added when location.query is not used', function () {
+		const INPUT = `
+			const x = location;
+        `;
+
+		const OUTPUT = `
+			const x = location;
+        `;
+
+		const fileInfo: FileInfo = {
+			path: 'index.js',
+			source: INPUT,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi('tsx'));
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ''),
+			OUTPUT.replace(/\W/gm, ''),
+		);
+	});
 });

--- a/apps/registry/codemods/react-router/4/replace-location-query/tsconfig.json
+++ b/apps/registry/codemods/react-router/4/replace-location-query/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@codemod-com/tsconfig/codemod.json",
+	"include": [
+		"./src/**/*.ts",
+		"./src/**/*.js",
+		"./test/**/*.ts",
+		"./test/**/*.js"
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3187,6 +3187,36 @@ importers:
         specifier: ^1.0.1
         version: 1.0.4(@types/node@20.10.4)
 
+  apps/registry/codemods/react-router/4/replace-location-query:
+    devDependencies:
+      '@codemod-com/registry-cjs-builder':
+        specifier: workspace:*
+        version: link:../../../../cjs-builder
+      '@codemod-com/utilities':
+        specifier: workspace:*
+        version: link:../../../../../../packages/utilities
+      '@types/jscodeshift':
+        specifier: ^0.11.10
+        version: 0.11.11
+      '@vitest/coverage-v8':
+        specifier: ^1.0.1
+        version: 1.2.1(vitest@1.0.4)
+      esbuild:
+        specifier: 0.19.5
+        version: 0.19.5
+      jscodeshift:
+        specifier: ^0.15.1
+        version: 0.15.1
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.1(@types/node@20.10.4)(typescript@5.3.3)
+      typescript:
+        specifier: ^5.2.2
+        version: 5.3.3
+      vitest:
+        specifier: ^1.0.1
+        version: 1.0.4(@types/node@20.10.4)
+
   apps/registry/codemods/react-router/4/replace-param-prop:
     devDependencies:
       '@codemod-com/registry-cjs-builder':
@@ -10142,7 +10172,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.0.4(@types/node@20.10.4)
+      vitest: 1.0.4(@types/node@18.11.9)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

- Adds one codemod for migrating React Router from v3 to v4. This codemod replaces instances of `location.query` with `parse(location.search)`, where `parse` is a function imported from `query-string`.
