### PR TITLE
chore: inform the user when the token is written

### DIFF
--- a/apps/engine/src/handleLoginCliCommand.ts
+++ b/apps/engine/src/handleLoginCliCommand.ts
@@ -43,6 +43,11 @@ export const handleLoginCliCommand = async (
 
 	printer.printConsoleMessage(
 		'info',
+		`The access token was written into ${tokenTxtPath}`,
+	);
+
+	printer.printConsoleMessage(
+		'info',
 		'You are successfully logged in with the Codemod CLI!',
 	);
 };


### PR DESCRIPTION
For instance, you will see something like this:

```
The access token was written into /home/gpp/.codemod/token.txt
You are successfully logged in with the Codemod CLI!
```