### PR TITLE
CDMD-2521 temporary fix for `codemod publish` bugginess

### DIFF
--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -113,10 +113,11 @@ export const handlePublishCliCommand = async (
 	try {
 		await publish(token, formData);
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		const errorMessage = `Could not publish the "${pkg.name}" codemod: ${message}`;
-		printer.printConsoleMessage('error', errorMessage);
-		throw new Error(errorMessage);
+		// TODO: Investigate why the error is thrown even if publishing is successful.
+		// const message = error instanceof Error ? error.message : String(error);
+		// const errorMessage = `Could not publish the "${pkg.name}" codemod: ${message}`;
+		// printer.printConsoleMessage('error', errorMessage);
+		// throw new Error(errorMessage);
 	}
 
 	printer.printConsoleMessage(


### PR DESCRIPTION
This is a quick, temporary solution since `codemod publish` command actually works (i confirmed this by checking `codemod syncRegistry && codemod list` and also check the VSCode registry. The error message is misleading for some reason. It's to be investigated.