### PR TITLE
Add ast-grep as an engine 

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -36,6 +36,7 @@
 		"@svgr/hast-util-to-babel-ast": "^7.0.0",
 		"@types/babel__traverse": "^7.20.1",
 		"@types/columnify": "^1.5.4",
+		"@types/js-yaml": "4.0.9",
 		"@types/jscodeshift": "^0.11.5",
 		"@types/node": "18.11.9",
 		"@types/sinon": "^10.0.20",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -5,7 +5,9 @@
 	"description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
 	"type": "module",
 	"exports": null,
-	"repository": { "type": "git" },
+	"repository": {
+		"type": "git"
+	},
 	"keywords": [
 		"codemod",
 		"jscodeshift",
@@ -30,6 +32,7 @@
 		"@babel/parser": "^7.22.10",
 		"@babel/preset-env": "^7.20.2",
 		"@babel/traverse": "7.23.2",
+		"@biomejs/biome": "1.5.3",
 		"@codemod-com/filemod": "workspace:*",
 		"@codemod-com/utilities": "workspace:*",
 		"@effect/schema": "0.27.0",
@@ -70,8 +73,7 @@
 		"unist-util-visit": "^5.0.0",
 		"valibot": "^0.24.1",
 		"vitest": "^1.0.1",
-		"yargs": "^17.6.2",
-		"@biomejs/biome": "1.5.3"
+		"yargs": "^17.6.2"
 	},
 	"packageManager": "pnpm@8.6.7",
 	"scripts": {
@@ -80,9 +82,22 @@
 		"test": "TEST=1 vitest run",
 		"coverage": "TEST=1 vitest run --coverage"
 	},
-	"engines": { "node": ">=18.5.0" },
-	"pkg": { "outputPath": "./package/" },
+	"engines": {
+		"node": ">=18.5.0"
+	},
+	"pkg": {
+		"outputPath": "./package/"
+	},
 	"license": "Apache License, Version 2.0",
-	"files": ["./dist/index.cjs", "LICENSE", "README.md"],
-	"publishConfig": { "access": "public" }
+	"files": [
+		"./dist/index.cjs",
+		"LICENSE",
+		"README.md"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"dependencies": {
+		"js-yaml": "4.1.0"
+	}
 }

--- a/apps/cli/src/codemod.ts
+++ b/apps/cli/src/codemod.ts
@@ -24,13 +24,13 @@ export type Codemod =
 	| Readonly<{
 			source: "registry";
 			name: string;
-			engine: 'ast-grep';
+			engine: "ast-grep";
 			directoryPath: string;
 			arguments: Arguments;
 			yamlPath: string;
 	  }>
 	| Readonly<{
-			source: 'registry';
+			source: "registry";
 			name: string;
 			engine: JavaScriptCodemodEngine;
 			directoryPath: string;

--- a/apps/cli/src/codemod.ts
+++ b/apps/cli/src/codemod.ts
@@ -24,6 +24,14 @@ export type Codemod =
 	| Readonly<{
 			source: "registry";
 			name: string;
+			engine: 'ast-grep';
+			directoryPath: string;
+			arguments: Arguments;
+			yamlPath: string;
+	  }>
+	| Readonly<{
+			source: 'registry';
+			name: string;
 			engine: JavaScriptCodemodEngine;
 			directoryPath: string;
 			indexPath: string;

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -124,10 +124,10 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 
 		if (config.engine === "ast-grep") {
 			try {
-				const yamlPath = join(directoryPath, 'rule.yaml');
+				const yamlPath = join(directoryPath, "rule.yaml");
 
 				return {
-					source: 'registry',
+					source: "registry",
 					name,
 					engine: config.engine,
 					yamlPath,
@@ -136,18 +136,18 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 				};
 			} catch (error) {
 				if (!(error instanceof Error)) {
-					throw new Error('Error while downloading ast-grep codemod');
+					throw new Error("Error while downloading ast-grep codemod");
 				}
 
 				this.__printer.printOperationMessage({
-					kind: 'error',
+					kind: "error",
 					message: error.message,
 				});
 			}
 		}
 
 		if (config.engine === "piranha") {
-			const rulesPath = join(directoryPath, 'rules.toml');
+			const rulesPath = join(directoryPath, "rules.toml");
 
 			await this._fileDownloadService.download(
 				`${CODEMOD_REGISTRY_URL}/${hashDigest}/rules.toml`,

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -123,22 +123,27 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 		}
 
 		if (config.engine === "ast-grep") {
-			const yamlPath = join(directoryPath, 'rule.yaml');
-			const yamlData = await this._fileDownloadService.download(
-				`${CODEMOD_REGISTRY_URL}/${hashDigest}/rule.yaml`,
-				yamlPath,
-			);
+			try {
+				const yamlPath = join(directoryPath, 'rule.yaml');
 
-			await writeFile(yamlPath, yamlData);
+				return {
+					source: 'registry',
+					name,
+					engine: config.engine,
+					yamlPath,
+					directoryPath,
+					arguments: config.arguments,
+				};
+			} catch (error) {
+				if (!(error instanceof Error)) {
+					throw new Error('Error while downloading ast-grep codemod');
+				}
 
-			return {
-				source: 'registry',
-				name,
-				engine: config.engine,
-				yamlPath: yamlPath,
-				directoryPath,
-				arguments: config.arguments,
-			};
+				this.__printer.printOperationMessage({
+					kind: 'error',
+					message: error.message,
+				});
+			}
 		}
 
 		if (config.engine === "piranha") {

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -122,8 +122,27 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 			// do nothing, descriptions might not exist
 		}
 
+		if (config.engine === "ast-grep") {
+			const yamlPath = join(directoryPath, 'rule.yaml');
+			const yamlData = await this._fileDownloadService.download(
+				`${CODEMOD_REGISTRY_URL}/${hashDigest}/rule.yaml`,
+				yamlPath,
+			);
+
+			await writeFile(yamlPath, yamlData);
+
+			return {
+				source: 'registry',
+				name,
+				engine: config.engine,
+				yamlPath: yamlPath,
+				directoryPath,
+				arguments: config.arguments,
+			};
+		}
+
 		if (config.engine === "piranha") {
-			const rulesPath = join(directoryPath, "rules.toml");
+			const rulesPath = join(directoryPath, 'rules.toml');
 
 			await this._fileDownloadService.download(
 				`${CODEMOD_REGISTRY_URL}/${hashDigest}/rules.toml`,

--- a/apps/cli/src/runAstgrepCodemod.ts
+++ b/apps/cli/src/runAstgrepCodemod.ts
@@ -12,10 +12,11 @@ export const runAstgrep = async (
 ): Promise<void> => {
 	const yamlString = await readFile(rulePath, { encoding: 'utf8' });
 	const yamlObject = yaml.load(yamlString);
-	const language = languageToExtension(yamlObject.language);
+	const extension = languageToExtension(yamlObject.language);
+	installSgCommandIfNotAvailable(printer);
 	printer.printConsoleMessage(
 		'info',
-		`Executing ast-grep for language : ${language}`,
+		`Executing ast-grep for language : ${extension}`,
 	);
 
 	// Function to recursively iterate over files in the directory
@@ -34,7 +35,7 @@ export const runAstgrep = async (
 			} else if (entry.isFile()) {
 				// If the entry is a file, log its path
 				const fileExtension = path.extname(entryPath).slice(1);
-				if (fileExtension !== language) {
+				if (fileExtension !== extension) {
 					continue;
 				}
 				const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
@@ -60,3 +61,18 @@ function languageToExtension(language: string) {
 			);
 	}
 }
+
+// Function to check if ast-grep is available or not
+const installSgCommandIfNotAvailable = (printer: PrinterBlueprint): void => {
+	try {
+		// Use `which` command to check if the command is available
+		execSync(`which sg`);
+	} catch (error) {
+		// If `which` command fails, the command is not available
+		printer.printConsoleMessage(
+			'info',
+			'ast-grep is not avialable, installing it globally',
+		);
+		execSync('npm install -g @ast-grep/cli');
+	}
+};

--- a/apps/cli/src/runAstgrepCodemod.ts
+++ b/apps/cli/src/runAstgrepCodemod.ts
@@ -39,7 +39,11 @@ export const runAstgrep = async (
 					continue;
 				}
 				const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
-				execSync(astCommand);
+				if (process.platform == 'win32') {
+					execSync(`powershell -Command "${astCommand}"`);
+				} else {
+					execSync(astCommand);
+				}
 			}
 		}
 	};
@@ -73,6 +77,11 @@ const installSgCommandIfNotAvailable = (printer: PrinterBlueprint): void => {
 			'info',
 			'ast-grep is not avialable, installing it globally',
 		);
-		execSync('npm install -g @ast-grep/cli');
+		const astInstallCommand = `npm install -g @ast-grep/cli`;
+		if (process.platform == 'win32') {
+			execSync(`powershell -Command "${astInstallCommand}"`);
+		} else {
+			execSync(astInstallCommand);
+		}
 	}
 };

--- a/apps/cli/src/runAstgrepCodemod.ts
+++ b/apps/cli/src/runAstgrepCodemod.ts
@@ -75,7 +75,7 @@ const installSgCommandIfNotAvailable = (printer: PrinterBlueprint): void => {
 		// If `which` command fails, the command is not available
 		printer.printConsoleMessage(
 			'info',
-			'ast-grep is not avialable, installing it globally',
+			'ast-grep is not available, installing it globally',
 		);
 		const astInstallCommand = `npm install -g @ast-grep/cli`;
 		if (process.platform == 'win32') {

--- a/apps/cli/src/runAstgrepCodemod.ts
+++ b/apps/cli/src/runAstgrepCodemod.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import { execSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'path';
+import * as yaml from 'js-yaml';
+import { PrinterBlueprint } from './printer.js';
+
+export const runAstgrep = async (
+	printer: PrinterBlueprint,
+	rulePath: string,
+	targetDirectory: string,
+): Promise<void> => {
+	const yamlString = await readFile(rulePath, { encoding: 'utf8' });
+	const yamlObject = yaml.load(yamlString);
+	const language = languageToExtension(yamlObject.language);
+	printer.printConsoleMessage(
+		'info',
+		`Executing ast-grep for language : ${language}`,
+	);
+
+	// Function to recursively iterate over files in the directory
+	const iterateFiles = async (dirPath: string) => {
+		const entries = await fs.promises.readdir(dirPath, {
+			withFileTypes: true,
+		});
+
+		// Iterate over each entry in the directory
+		for (const entry of entries) {
+			const entryPath = path.join(dirPath, entry.name);
+			// Check if the entry is a directory
+			if (entry.isDirectory()) {
+				// Recursively call the function for subdirectories
+				await iterateFiles(entryPath);
+			} else if (entry.isFile()) {
+				// If the entry is a file, log its path
+				const fileExtension = path.extname(entryPath).slice(1);
+				if (fileExtension !== language) {
+					continue;
+				}
+				const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
+				execSync(astCommand);
+			}
+		}
+	};
+
+	await iterateFiles(targetDirectory);
+	return;
+};
+
+function languageToExtension(language: string) {
+	language = language.toLocaleLowerCase();
+	switch (language) {
+		case 'python':
+			return 'py';
+		case 'javascript':
+			return 'js';
+		default:
+			throw new Error(
+				`Unsupported Language ${language} in codemod cli for ast-grep engine`,
+			);
+	}
+}

--- a/apps/cli/src/runAstgrepCodemod.ts
+++ b/apps/cli/src/runAstgrepCodemod.ts
@@ -1,21 +1,21 @@
-import fs from 'fs';
-import { execSync } from 'node:child_process';
-import { readFile } from 'node:fs/promises';
-import path from 'path';
-import * as yaml from 'js-yaml';
-import { PrinterBlueprint } from './printer.js';
+import fs from "fs";
+import { execSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "path";
+import * as yaml from "js-yaml";
+import { PrinterBlueprint } from "./printer.js";
 
 export const runAstgrep = async (
 	printer: PrinterBlueprint,
 	rulePath: string,
 	targetDirectory: string,
 ): Promise<void> => {
-	const yamlString = await readFile(rulePath, { encoding: 'utf8' });
+	const yamlString = await readFile(rulePath, { encoding: "utf8" });
 	const yamlObject = yaml.load(yamlString);
 	const extension = languageToExtension(yamlObject.language);
 	installSgCommandIfNotAvailable(printer);
 	printer.printConsoleMessage(
-		'info',
+		"info",
 		`Executing ast-grep for language : ${extension}`,
 	);
 
@@ -38,8 +38,8 @@ export const runAstgrep = async (
 				if (fileExtension !== extension) {
 					continue;
 				}
-				const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
-				if (process.platform == 'win32') {
+				const astCommand = "sg scan -r ${rulePath} ${entryPath} -U";
+				if (process.platform === "win32") {
 					execSync(`powershell -Command "${astCommand}"`);
 				} else {
 					execSync(astCommand);
@@ -53,12 +53,12 @@ export const runAstgrep = async (
 };
 
 function languageToExtension(language: string) {
-	language = language.toLocaleLowerCase();
-	switch (language) {
-		case 'python':
-			return 'py';
-		case 'javascript':
-			return 'js';
+	const lang = language.toLocaleLowerCase();
+	switch (lang) {
+		case "python":
+			return "py";
+		case "javascript":
+			return "js";
 		default:
 			throw new Error(
 				`Unsupported Language ${language} in codemod cli for ast-grep engine`,
@@ -70,16 +70,16 @@ function languageToExtension(language: string) {
 const installSgCommandIfNotAvailable = (printer: PrinterBlueprint): void => {
 	try {
 		// Use `which` command to check if the command is available
-		execSync(`which sg`);
+		execSync("which sg");
 	} catch (error) {
 		// If `which` command fails, the command is not available
 		printer.printConsoleMessage(
-			'info',
-			'ast-grep is not available, installing it globally',
+			"info",
+			"ast-grep is not available, installing it globally",
 		);
-		const astInstallCommand = `npm install -g @ast-grep/cli`;
-		if (process.platform == 'win32') {
-			execSync(`powershell -Command "${astInstallCommand}"`);
+		const astInstallCommand = "npm install -g @ast-grep/cli";
+		if (process.platform === "win32") {
+			execSync(`powershell -Command ${astInstallCommand}`);
 		} else {
 			execSync(astInstallCommand);
 		}

--- a/apps/cli/src/runCodemod.ts
+++ b/apps/cli/src/runCodemod.ts
@@ -12,6 +12,7 @@ import {
 import { getTransformer, transpile } from "./getTransformer.js";
 import { OperationMessage } from "./messages.js";
 import { PrinterBlueprint } from "./printer.js";
+import { runAstgrep } from "./runAstgrepCodemod.js";
 import { Dependencies, runRepomod } from "./runRepomod.js";
 import { SafeArgumentRecord } from "./safeArgumentRecord.js";
 import { FlowSettings } from "./schemata/flowSettingsSchema.js";
@@ -261,7 +262,7 @@ export const runCodemod = async (
 		return;
 	}
 
-	if (codemod.engine === 'ast-grep') {
+	if (codemod.engine === "ast-grep") {
 		await runAstgrep(printer, codemod.yamlPath, flowSettings.target);
 		return;
 	}

--- a/apps/cli/src/runCodemod.ts
+++ b/apps/cli/src/runCodemod.ts
@@ -261,6 +261,11 @@ export const runCodemod = async (
 		return;
 	}
 
+	if (codemod.engine === 'ast-grep') {
+		await runAstgrep(printer, codemod.yamlPath, flowSettings.target);
+		return;
+	}
+
 	const codemodSource = await getCodemodSource(codemod.indexPath);
 
 	const transpiledSource = codemod.indexPath.endsWith(".ts")

--- a/apps/cli/src/schemata/codemodConfigSchema.ts
+++ b/apps/cli/src/schemata/codemodConfigSchema.ts
@@ -48,6 +48,11 @@ export const codemodConfigSchema = S.union(
 		names: S.array(S.string),
 		arguments: optionalArgumentsSchema,
 	}),
+	S.struct({
+		schemaVersion: S.literal('1.0.0'),
+		engine: S.literal('ast-grep'),
+		arguments: optionalArgumentsSchema,
+	}),
 );
 
 export type CodemodConfig = S.To<typeof codemodConfigSchema>;

--- a/apps/cli/src/schemata/codemodConfigSchema.ts
+++ b/apps/cli/src/schemata/codemodConfigSchema.ts
@@ -49,8 +49,8 @@ export const codemodConfigSchema = S.union(
 		arguments: optionalArgumentsSchema,
 	}),
 	S.struct({
-		schemaVersion: S.literal('1.0.0'),
-		engine: S.literal('ast-grep'),
+		schemaVersion: S.literal("1.0.0"),
+		engine: S.literal("ast-grep"),
 		arguments: optionalArgumentsSchema,
 	}),
 );

--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -114,25 +114,24 @@
 			"destination": "https://blog.codemod.com/"
 		},
 		{
-		  "source": "/blog/eslint-to-biome",
-		  "destination": "https://blog.codemod.com/eslint-to-biome"
+			"source": "/blog/eslint-to-biome",
+			"destination": "https://blog.codemod.com/eslint-to-biome"
 		},
 		{
 			"source": "/blog/codemodable",
 			"destination": "https://blog.codemod.com/codemodable"
 		},
 		{
-		  "source": "/blog/cal-next-migration",
-		  "destination": "https://blog.codemod.com/cal-next-migration"
+			"source": "/blog/cal-next-migration",
+			"destination": "https://blog.codemod.com/cal-next-migration"
 		},
 		{
-		  "source": "/blog/mocha-to-vitest-migration",
-		  "destination": "https://blog.codemod.com/mocha-to-vitest-migration"
+			"source": "/blog/mocha-to-vitest-migration",
+			"destination": "https://blog.codemod.com/mocha-to-vitest-migration"
 		},
 		{
-		  "source": "/blog/dream-migration",
-		  "destination": "https://blog.codemod.com/dream-migration"
+			"source": "/blog/dream-migration",
+			"destination": "https://blog.codemod.com/dream-migration"
 		}
-	  ]
-	  
+	]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       '@types/columnify':
         specifier: ^1.5.4
         version: 1.5.4
+      '@types/js-yaml':
+        specifier: 4.0.9
+        version: 4.0.9
       '@types/jscodeshift':
         specifier: ^0.11.5
         version: 0.11.11
@@ -13140,29 +13143,6 @@ packages:
       - supports-color
     dev: true
 
-  /@vitest/coverage-v8@1.2.2(vitest@1.0.4):
-    resolution: {integrity: sha512-IHyKnDz18SFclIEEAHb9Y4Uxx0sPKC2VO1kdDCs1BF6Ip4S8rQprs971zIsooLUn7Afs71GRxWMWpkCGZpRMhw==}
-    peerDependencies:
-      vitest: ^1.0.0
-    dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.4(supports-color@5.5.0)
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.1.6
-      magic-string: 0.30.7
-      magicast: 0.3.3
-      picocolors: 1.0.0
-      std-env: 3.7.0
-      test-exclude: 6.0.0
-      v8-to-istanbul: 9.2.0
-      vitest: 1.0.4(@types/node@20.10.4)
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@vitest/coverage-v8@1.2.2(vitest@1.1.0):
     resolution: {integrity: sha512-IHyKnDz18SFclIEEAHb9Y4Uxx0sPKC2VO1kdDCs1BF6Ip4S8rQprs971zIsooLUn7Afs71GRxWMWpkCGZpRMhw==}
     peerDependencies:
@@ -25186,6 +25166,9 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13143,6 +13143,29 @@ packages:
       - supports-color
     dev: true
 
+  /@vitest/coverage-v8@1.2.2(vitest@1.0.4):
+    resolution: {integrity: sha512-IHyKnDz18SFclIEEAHb9Y4Uxx0sPKC2VO1kdDCs1BF6Ip4S8rQprs971zIsooLUn7Afs71GRxWMWpkCGZpRMhw==}
+    peerDependencies:
+      vitest: ^1.0.0
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.3.4(supports-color@5.5.0)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.6
+      magic-string: 0.30.7
+      magicast: 0.3.3
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.2.0
+      vitest: 1.0.4(@types/node@20.10.4)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vitest/coverage-v8@1.2.2(vitest@1.1.0):
     resolution: {integrity: sha512-IHyKnDz18SFclIEEAHb9Y4Uxx0sPKC2VO1kdDCs1BF6Ip4S8rQprs971zIsooLUn7Afs71GRxWMWpkCGZpRMhw==}
     peerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,10 @@ importers:
         version: 1.0.4(@types/node@20.10.4)
 
   apps/cli:
+    dependencies:
+      js-yaml:
+        specifier: 4.1.0
+        version: 4.1.0
     devDependencies:
       '@babel/core':
         specifier: ^7.20.2
@@ -13161,7 +13165,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.0.4(@types/node@20.10.4)
+      vitest: 1.0.4(@types/node@18.11.9)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
# This Diff 
**Summary**
- In commit 1, adding no-op ast-grep engine to codemod cli 
- In commit 2, added implementation of ast-grep engine to cli 

**Testing**

I put the following code in a file called abc.js in folder `/Users/harshgupta/Desktop/src/codemod/apps/cli/ast/abc.js`
```
import { A, B, C } from './barrel';

function Component() {
    const [name, setName] = useState < string > ('React')
}
``` 

In directory `/Users/harshgupta/.codemod`, chose a random folder `XG6X5ceI2dzkLW7CoBI0aD3W_7Q`, and updated it's config.json to have engine `ast-grep`. 

config.json after update 
```
"schemaVersion":"1.0.0","engine":"ast-grep","arguments":[],"name":"cal.com/app-directory-boilerplate-calcom"}
```

Also added a file called rule.yaml in `XG6X5ceI2dzkLW7CoBI0aD3W_7Q` and content of yaml file was 
```
id: change_js
language: javascript
rule:
  pattern: import {$$$IDENTS} from './barrel'
rewriters:
- id: rewrite-identifer
  rule:
    pattern: $IDENT
    kind: identifier
  fix: import $IDENT from './barrel/$IDENT'
transform:
  IMPORTS:
    rewrite:
      rewriters: [rewrite-identifer]
      source: $$$IDENTS
      joinBy: "\n"
fix: $IMPORTS
```

Built the codemod using 
```npm run build && npm link```

Executed 
```codemod cal.com/app-directory-boilerplate-calcom``` with useCache true and --target=/Users/harshgupta/Desktop/src/codemod/apps/cli/ast 

**useCache set to true so that it doesn't redownload the codemod from S3 which would update config.json and overwrite the engine.


**Resources**
https://ast-grep.github.io/guide/introduction.html 

# Follow up 
- Come up with some codemod for ast-grep and publish to registry 
- Add a script to execute ast-grep codemods in a batch manner and create PRs from it 