### PR TITLE
feat: execute list command on codemod not found (CDMD-2590)

### DIFF
--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -106,7 +106,9 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 			await handleListNamesCommand(this.__printer);
 
 			throw new Error(
-				`Could not find codemod ${name} in the registry. Verify the name to be in the list above and try again.`,
+				`Could not find codemod ${boldText(
+					name,
+				)} in the registry. Verify the name to be in the list above and try again.`,
 			);
 		}
 

--- a/apps/cli/src/handleListCliCommand.ts
+++ b/apps/cli/src/handleListCliCommand.ts
@@ -8,7 +8,7 @@ import { glob } from 'fast-glob';
 import * as v from 'valibot';
 import { syncRegistryOperation } from './executeMainThread.js';
 import { FileDownloadService } from './fileDownloadService.js';
-import type { Printer } from './printer.js';
+import type { Printer, PrinterBlueprint } from './printer.js';
 import { TarService } from './services/tarService.js';
 import { boldText, colorizeText } from './utils.js';
 
@@ -18,7 +18,7 @@ const configJsonSchema = v.object({
 	owner: v.optional(v.string()),
 });
 
-export const handleListNamesCommand = async (printer: Printer) => {
+export const handleListNamesCommand = async (printer: PrinterBlueprint) => {
 	const configurationDirectoryPath = join(homedir(), '.codemod');
 
 	await mkdir(configurationDirectoryPath, { recursive: true });

--- a/apps/cli/src/printer.ts
+++ b/apps/cli/src/printer.ts
@@ -28,7 +28,9 @@ export class Printer implements PrinterBlueprint {
 	public printOperationMessage(message: OperationMessage) {
 		if (this.__jsonOutput) {
 			if (message.kind === 'error') {
-				console.error(JSON.stringify(message));
+				console.error(
+					colorizeText(`\n${JSON.stringify(message)}\n`, 'red'),
+				);
 				return;
 			}
 
@@ -39,17 +41,13 @@ export class Printer implements PrinterBlueprint {
 		if (message.kind === 'error') {
 			const { message: text, path } = message;
 
+			let errorText: string = text;
+
 			if (path) {
-				console.error(
-					colorizeText(
-						`\n${boldText(`Error at ${path}:`)}\n\n${text}\n`,
-						'red',
-					),
-				);
-				return;
+				errorText = `${boldText(`Error at ${path}:`)}\n\n${text}`;
 			}
 
-			console.error(text);
+			console.error(colorizeText(`\n${errorText}\n`, 'red'));
 		}
 
 		if (message.kind === 'progress') {

--- a/apps/cli/src/runner.ts
+++ b/apps/cli/src/runner.ts
@@ -171,6 +171,11 @@ export class Runner {
 			}
 
 			if (this._name !== null) {
+				const codemod = await this._codemodDownloader.download(
+					this._name,
+					this._flowSettings.noCache,
+				);
+
 				this._printer.printConsoleMessage(
 					'info',
 					colorizeText(
@@ -189,11 +194,6 @@ export class Runner {
 						EXTENSION_LINK_START,
 					);
 				}
-
-				const codemod = await this._codemodDownloader.download(
-					this._name,
-					this._flowSettings.noCache,
-				);
 
 				const codemodHashDigest = createHash('ripemd160')
 					.update(codemod.name)

--- a/apps/cli/src/schemata/codemodConfigSchema.ts
+++ b/apps/cli/src/schemata/codemodConfigSchema.ts
@@ -49,3 +49,5 @@ export const codemodConfigSchema = S.union(
 		arguments: optionalArgumentsSchema,
 	}),
 );
+
+export type CodemodConfig = S.To<typeof codemodConfigSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4643,8 +4643,6 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(@types/node@20.10.5)
 
-  apps/studio-backend/build-ncc: {}
-
   apps/vsce:
     dependencies:
       '@effect/schema':
@@ -13670,7 +13668,7 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.0.4(@types/node@18.11.9)
+      vitest: 1.0.4(@types/node@20.10.4)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -26033,6 +26031,9 @@ packages:
   /sqlite3@5.1.7:
     resolution: {integrity: sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==}
     requiresBuild: true
+    peerDependenciesMeta:
+      node-gyp:
+        optional: true
     dependencies:
       bindings: 1.5.0
       node-addon-api: 7.1.0


### PR DESCRIPTION
- Does not show that codemod is executing before actual download happens.

<img width="289" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/10b62431-ad36-4a46-b0c1-d9107c2a39a4">

- Now instead of showing 403 request error from axios, we show clear error saying that codemod wasn't found and show user a list of commands.

<img width="874" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/bdb7b7a9-24c0-4ae2-a84b-4a6092f6c1c2">
