### PR TITLE
feat: React Compiler useContext codemod (CDMD-2578)

### DIFF
--- a/apps/registry/codemods/react/19/use-context-hook/README.md
+++ b/apps/registry/codemods/react/19/use-context-hook/README.md
@@ -8,33 +8,20 @@ This codemod will convert the usage of `useContext` to the new hook format, intr
 
 ### Before:
 
-```jsx
-import PropTypes from 'prop-types';
-import React from 'react';
+```tsx
+import { useContext } from "react";
+import ThemeContext from "./ThemeContext";
 
-export function MyComponent(props) {
-	return <span />;
-}
-
-MyComponent.propTypes = {
-	bar: PropTypes.string.isRequired,
-	foo: PropTypes.number,
-};
+const theme = useContext(ThemeContext);
 ```
 
 ### After:
 
 ```tsx
-import React from 'react';
+import { use } from "react";
+import ThemeContext from "./ThemeContext";
 
-interface MyComponentProps {
-	bar: string;
-	foo?: number;
-}
-
-export function MyComponent(props: MyComponentProps) {
-	return <span />;
-}
+const theme = use(ThemeContext);
 ```
 
 ## Applicability Criteria
@@ -65,3 +52,4 @@ jscodeshift
 
 ### Links for more info
 
+- https://react.dev/reference/react/use#reading-context-with-use

--- a/apps/registry/codemods/react/19/use-context-hook/README.md
+++ b/apps/registry/codemods/react/19/use-context-hook/README.md
@@ -1,0 +1,67 @@
+# Change useContext usage to use hook
+
+## Description
+
+This codemod will convert the usage of `useContext` to the new hook format, introduced in React v19.
+
+## Example
+
+### Before:
+
+```jsx
+import PropTypes from 'prop-types';
+import React from 'react';
+
+export function MyComponent(props) {
+	return <span />;
+}
+
+MyComponent.propTypes = {
+	bar: PropTypes.string.isRequired,
+	foo: PropTypes.number,
+};
+```
+
+### After:
+
+```tsx
+import React from 'react';
+
+interface MyComponentProps {
+	bar: string;
+	foo?: number;
+}
+
+export function MyComponent(props: MyComponentProps) {
+	return <span />;
+}
+```
+
+## Applicability Criteria
+
+React <=18
+
+## Other Metadata
+
+### Codemod Version
+
+v1.0.0
+
+### Change Mode
+
+**Autonomous**: Changes can safely be pushed and merged without further human involvement.
+
+### **Codemod Engine**
+
+jscodeshift
+
+### Estimated Time Saving
+
+~5 minutes per occurrence
+
+### Owner
+
+[Codemod.com](https://github.com/codemod-com)
+
+### Links for more info
+

--- a/apps/registry/codemods/react/19/use-context-hook/config.json
+++ b/apps/registry/codemods/react/19/use-context-hook/config.json
@@ -1,0 +1,5 @@
+{
+	"schemaVersion": "1.0.0",
+	"engine": "jscodeshift",
+	"owner": "Codemod.com"
+}

--- a/apps/registry/codemods/react/19/use-context-hook/index.d.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/index.d.ts
@@ -1,0 +1,3 @@
+import type { API, FileInfo } from 'jscodeshift';
+
+export default function transform(file: FileInfo, api: API): string;

--- a/apps/registry/codemods/react/19/use-context-hook/index.d.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/index.d.ts
@@ -1,3 +1,3 @@
-import type { API, FileInfo } from 'jscodeshift';
+import type { API, FileInfo } from "jscodeshift";
 
 export default function transform(file: FileInfo, api: API): string;

--- a/apps/registry/codemods/react/19/use-context-hook/package.json
+++ b/apps/registry/codemods/react/19/use-context-hook/package.json
@@ -20,11 +20,6 @@
 		"test:watch": "vitest watch",
 		"coverage": "vitest run --coverage"
 	},
-	"files": [
-		"README.md",
-		"config.json",
-		"./dist/index.cjs",
-		"./index.d.ts"
-	],
+	"files": ["README.md", "config.json", "./dist/index.cjs", "./index.d.ts"],
 	"type": "module"
 }

--- a/apps/registry/codemods/react/19/use-context-hook/package.json
+++ b/apps/registry/codemods/react/19/use-context-hook/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@codemod-com/codemod-react-19-use-context",
+	"dependencies": {},
+	"devDependencies": {
+		"@codemod-com/utilities": "workspace:*",
+		"@codemod-com/registry-cjs-builder": "workspace:*",
+		"typescript": "^5.2.2",
+		"esbuild": "0.19.5",
+		"ts-node": "^10.9.1",
+		"jscodeshift": "^0.15.1",
+		"@types/jscodeshift": "^0.11.10",
+		"vitest": "^1.0.1",
+		"@vitest/coverage-v8": "^1.0.1"
+	},
+	"main": "./dist/index.cjs",
+	"types": "/dist/index.d.ts",
+	"scripts": {
+		"build:cjs": "cjs-builder ./src/index.ts",
+		"test": "vitest run",
+		"test:watch": "vitest watch",
+		"coverage": "vitest run --coverage"
+	},
+	"files": [
+		"README.md",
+		"config.json",
+		"./dist/index.cjs",
+		"./index.d.ts"
+	],
+	"type": "module"
+}

--- a/apps/registry/codemods/react/19/use-context-hook/src/index.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/src/index.ts
@@ -1,5 +1,4 @@
 import type { API, FileInfo, Options } from "jscodeshift";
-import { Identifier } from "jscodeshift";
 
 export default function transform(
 	file: FileInfo,
@@ -14,19 +13,6 @@ export default function transform(
 			const newIdentifier = j.identifier.from({ name: "use" });
 
 			path.replace(newIdentifier);
-		}
-	});
-
-	root.find(j.ImportSpecifier).forEach((path) => {
-		if (path.node.type === "ImportSpecifier") {
-			if ((path.node.imported as Identifier).name === "useContext") {
-				const newImportSpecifier = j.importSpecifier.from({
-					local: j.identifier("use"),
-					imported: j.identifier("use"),
-				});
-
-				path.replace(newImportSpecifier);
-			}
 		}
 	});
 

--- a/apps/registry/codemods/react/19/use-context-hook/src/index.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/src/index.ts
@@ -1,17 +1,34 @@
-// import type { NodePath } from 'ast-types/lib/node-path.js';
-// import type {
-// 	API,
-// 	Collection,
-// 	CommentBlock,
-// 	CommentLine,
-// 	FileInfo,
-// 	Identifier,
-// 	JSCodeshift,
-// 	Literal,
-// 	Options,
-// 	TSAnyKeyword,
-// 	TSFunctionType,
-// } from 'jscodeshift';
+import type { API, FileInfo, Options } from "jscodeshift";
+import { Identifier } from "jscodeshift";
 
-// export default function transform(file: FileInfo, api: API, opts: Options) {
-// }
+export default function transform(
+	file: FileInfo,
+	api: API,
+	options?: Options,
+): string | undefined {
+	const j = api.jscodeshift;
+	const root = j(file.source);
+
+	root.find(j.Identifier, { name: "useContext" }).forEach((path) => {
+		if (path.node.type === "Identifier") {
+			const newIdentifier = j.identifier.from({ name: "use" });
+
+			path.replace(newIdentifier);
+		}
+	});
+
+	root.find(j.ImportSpecifier).forEach((path) => {
+		if (path.node.type === "ImportSpecifier") {
+			if ((path.node.imported as Identifier).name === "useContext") {
+				const newImportSpecifier = j.importSpecifier.from({
+					local: j.identifier("use"),
+					imported: j.identifier("use"),
+				});
+
+				path.replace(newImportSpecifier);
+			}
+		}
+	});
+
+	return root.toSource();
+}

--- a/apps/registry/codemods/react/19/use-context-hook/src/index.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/src/index.ts
@@ -1,0 +1,17 @@
+// import type { NodePath } from 'ast-types/lib/node-path.js';
+// import type {
+// 	API,
+// 	Collection,
+// 	CommentBlock,
+// 	CommentLine,
+// 	FileInfo,
+// 	Identifier,
+// 	JSCodeshift,
+// 	Literal,
+// 	Options,
+// 	TSAnyKeyword,
+// 	TSFunctionType,
+// } from 'jscodeshift';
+
+// export default function transform(file: FileInfo, api: API, opts: Options) {
+// }

--- a/apps/registry/codemods/react/19/use-context-hook/test/test.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/test/test.ts
@@ -1,0 +1,6 @@
+// import assert from 'node:assert';
+// import { buildApi } from '@codemod-com/utilities';
+// import { describe, it } from 'vitest';
+// import transform from '../src/index.js';
+
+describe('useContext -> use', () => {});

--- a/apps/registry/codemods/react/19/use-context-hook/test/test.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/test/test.ts
@@ -34,4 +34,31 @@ describe("useContext -> use", () => {
 			output.replace(/\W/gm, ""),
 		);
 	});
+
+	it("should replace React.useContext with use", async () => {
+		const input = `
+    import React from "react";
+    import ThemeContext from "./ThemeContext";
+
+		const theme = React.useContext(ThemeContext);
+		`;
+
+		const output = `
+    import React from "react";
+    import ThemeContext from "./ThemeContext";
+
+		const theme = React.use(ThemeContext);
+		`;
+
+		const fileInfo: FileInfo = {
+			path: "index.js",
+			source: input,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi("js"), {
+			quote: "single",
+		});
+
+		assert.deepEqual(actualOutput, output);
+	});
 });

--- a/apps/registry/codemods/react/19/use-context-hook/test/test.ts
+++ b/apps/registry/codemods/react/19/use-context-hook/test/test.ts
@@ -1,6 +1,37 @@
-// import assert from 'node:assert';
-// import { buildApi } from '@codemod-com/utilities';
-// import { describe, it } from 'vitest';
-// import transform from '../src/index.js';
+import assert from "node:assert/strict";
+import { buildApi } from "@codemod-com/utilities";
+import type { FileInfo } from "jscodeshift";
+import { describe, it } from "vitest";
+import transform from "../src/index.js";
 
-describe('useContext -> use', () => {});
+describe("useContext -> use", () => {
+	it("should replace useContext with use", async () => {
+		const input = `
+    import { useContext } from "react";
+    import ThemeContext from "./ThemeContext";
+
+		const theme = useContext(ThemeContext);
+		`;
+
+		const output = `
+    import { use } from "react";
+    import ThemeContext from "./ThemeContext";
+
+		const theme = use(ThemeContext);
+		`;
+
+		const fileInfo: FileInfo = {
+			path: "index.js",
+			source: input,
+		};
+
+		const actualOutput = transform(fileInfo, buildApi("js"), {
+			quote: "single",
+		});
+
+		assert.deepEqual(
+			actualOutput?.replace(/\W/gm, ""),
+			output.replace(/\W/gm, ""),
+		);
+	});
+});

--- a/apps/registry/codemods/react/19/use-context-hook/tsconfig.json
+++ b/apps/registry/codemods/react/19/use-context-hook/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@codemod-com/tsconfig/codemod.json",
+	"include": [
+		"./src/**/*.ts",
+		"./src/**/*.js",
+		"./test/**/*.ts",
+		"./test/**/*.js"
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3829,6 +3829,36 @@ importers:
         specifier: ^1.0.1
         version: 1.0.4(@types/node@20.10.5)
 
+  apps/registry/codemods/react/19/use-context-hook:
+    devDependencies:
+      '@codemod-com/registry-cjs-builder':
+        specifier: workspace:*
+        version: link:../../../../cjs-builder
+      '@codemod-com/utilities':
+        specifier: workspace:*
+        version: link:../../../../../../packages/utilities
+      '@types/jscodeshift':
+        specifier: ^0.11.10
+        version: 0.11.11
+      '@vitest/coverage-v8':
+        specifier: ^1.0.1
+        version: 1.2.2(vitest@1.1.0)
+      esbuild:
+        specifier: 0.19.5
+        version: 0.19.5
+      jscodeshift:
+        specifier: ^0.15.1
+        version: 0.15.1(@babel/preset-env@7.23.9)
+      ts-node:
+        specifier: ^10.9.1
+        version: 10.9.2(@types/node@20.10.5)(typescript@5.3.3)
+      typescript:
+        specifier: ^5.2.2
+        version: 5.3.3
+      vitest:
+        specifier: ^1.0.1
+        version: 1.1.0(@types/node@20.10.5)
+
   apps/registry/codemods/react/prop-types-typescript:
     devDependencies:
       '@codemod-com/registry-cjs-builder':
@@ -13037,7 +13067,30 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.0.4(@types/node@20.10.4)
+      vitest: 1.0.4(@types/node@18.11.9)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitest/coverage-v8@1.2.2(vitest@1.1.0):
+    resolution: {integrity: sha512-IHyKnDz18SFclIEEAHb9Y4Uxx0sPKC2VO1kdDCs1BF6Ip4S8rQprs971zIsooLUn7Afs71GRxWMWpkCGZpRMhw==}
+    peerDependencies:
+      vitest: ^1.0.0
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.3.4(supports-color@5.5.0)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.6
+      magic-string: 0.30.7
+      magicast: 0.3.3
+      picocolors: 1.0.0
+      std-env: 3.7.0
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.2.0
+      vitest: 1.1.0(@types/node@20.10.5)
     transitivePeerDependencies:
       - supports-color
     dev: true


### PR DESCRIPTION
This PR adds a codemod that would migrate context usages in React v19 to using `use` hook.