### PR TITLE
CDMD-2624 part 1: Use the existing config.json on `codemod publish` command

### DIFF
--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -15,6 +15,12 @@ const packageJsonSchema = object({
 	license: optional(string()),
 });
 
+const configJsonSchema = object({
+	schemaVersion: string(),
+	name: string(),
+	engine: string(),
+});
+
 const getToken = (): Promise<string> => {
 	const configurationDirectoryPath = join(homedir(), ".codemod");
 	const tokenTxtPath = join(configurationDirectoryPath, "token.txt");
@@ -41,7 +47,12 @@ export const handlePublishCliCommand = async (
 		);
 	}
 
-	printer.printConsoleMessage("info", `You are logged in as '${username}'.`);
+	printer.printConsoleMessage(
+		"info",
+		`You are logged in as '${boldText(
+			username,
+		)}' and able to publish a codemod to our public registry.`,
+	);
 
 	const packageJsonData = await fs.promises.readFile(
 		join(source, "package.json"),
@@ -71,16 +82,19 @@ export const handlePublishCliCommand = async (
 		encoding: "utf-8",
 	});
 
-	// We currently support publishing jscodeshift codemods only
-	const configJsonData = JSON.stringify(
+	const configJsonData = await fs.promises.readFile(
+		join(source, "config.json"),
 		{
-			schemaVersion: "1.0.0",
-			name: pkg.name,
-			engine: "jscodeshift",
+			encoding: "utf-8",
 		},
-		null,
-		2,
 	);
+	const configJson = parse(configJsonSchema, JSON.parse(configJsonData));
+
+	if (configJson.name !== pkg.name) {
+		throw new Error(
+			`The "name" field in package.json must match with that in config.json.\nIt must must start with your GitHub username and a slash ("@${username}/")and contain allowed characters (a-z, A-Z, 0-9, _, / or -).`,
+		);
+	}
 
 	let descriptionMdData: string | null = null;
 

--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -74,7 +74,7 @@ export const handlePublishCliCommand = async (
 		!/[a-zA-Z0-9_/-]+/.test(pkg.name)
 	) {
 		throw new Error(
-			`The "name" field in package.json must start with your GitHub username and a slash ("@${username}/")and contain allowed characters (a-z, A-Z, 0-9, _, / or -)`,
+			`The "name" field in package.json must start with your GitHub username with a slash ("@${username}/") and contain allowed characters (a-z, A-Z, 0-9, _, / or -)`,
 		);
 	}
 
@@ -92,7 +92,7 @@ export const handlePublishCliCommand = async (
 
 	if (configJson.name !== pkg.name) {
 		throw new Error(
-			`The "name" field in package.json must match with that in config.json.\nIt must must start with your GitHub username and a slash ("@${username}/")and contain allowed characters (a-z, A-Z, 0-9, _, / or -).`,
+			`The "name" field in package.json must match with that in config.json.\nIt must must start with your GitHub username with a slash ("@${username}/") and contain allowed characters (a-z, A-Z, 0-9, _, / or -).`,
 		);
 	}
 

--- a/apps/studio-backend/src/publishHandler.ts
+++ b/apps/studio-backend/src/publishHandler.ts
@@ -68,7 +68,7 @@ export const publishHandler =
 					!/[a-zA-Z0-9_/-]+/.test(config.name)
 				) {
 					throw new Error(
-						"The package name must start with your username and contain allowed characters",
+						`The "name" field in package.json must start with your GitHub username with a slash (e.g., "@${user.username}/") and contain allowed characters (a-z, A-Z, 0-9, _, / or -)`,
 					);
 				}
 

--- a/apps/studio-backend/src/publishHandler.ts
+++ b/apps/studio-backend/src/publishHandler.ts
@@ -8,9 +8,9 @@ import { CLAIM_PUBLISHING, TokenService } from "./services/tokenService.js";
 import { areClerkKeysSet, getCustomAccessToken } from "./util.js";
 
 const configSchema = object({
-	schemaVersion: literal("1.0.0"),
+	schemaVersion: string(),
 	name: string(),
-	engine: literal("jscodeshift"),
+	engine: string(),
 });
 
 export const publishHandler =

--- a/apps/studio/src/utils/download.ts
+++ b/apps/studio/src/utils/download.ts
@@ -131,12 +131,16 @@ const configJson = ({
 		changeCase.kebabCase(name),
 	]
 		.filter(Boolean)
-		.join("/");
+		.join("-");
+
+	const finalName = user?.username
+		? `@${user.username}/${configName}`
+		: configName;
 
 	return beautify(`
       {
         "schemaVersion": "1.0.0",
-        "name": "${user?.username ? `@${user.username}/` : ""}${configName}",
+        "name": "${finalName}",
         "engine": "${engine}"
       }
   `);

--- a/apps/studio/src/utils/download.ts
+++ b/apps/studio/src/utils/download.ts
@@ -120,7 +120,11 @@ const configJson = ({
 	version,
 	name,
 	engine,
-}: Pick<ProjectDownloadInput, "framework" | "version" | "name" | "engine">) => {
+	user,
+}: Pick<
+	ProjectDownloadInput,
+	"framework" | "version" | "name" | "engine" | "user"
+>) => {
 	const configName = [
 		framework?.toLowerCase(),
 		version,
@@ -132,7 +136,7 @@ const configJson = ({
 	return beautify(`
       {
         "schemaVersion": "1.0.0",
-        "name": "${configName}",
+        "name": "${user?.username ? `@${user.username}/` : ""}${configName}",
         "engine": "${engine}"
       }
   `);


### PR DESCRIPTION
Currently, we create `config.json` on the spot when `codemod publish` is called.