### PR TITLE
[VSCE, CLI] fix: `--json` option is not applied to command list - CDMD-2702

### DIFF
--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -181,6 +181,8 @@ export const executeMainThread = async () => {
 	}
 
 	if (String(argv._) === "list") {
+		const printer = new Printer(argv.json);
+
 		try {
 			await handleListNamesAfterSyncing(
 				argv.noCache,


### PR DESCRIPTION
this causes JSON.parse() in VSCE to fail to load registry codemods
e.g.,
```
const childProcess = spawn(
			CODEMOD_ENGINE_NODE_COMMAND,
			["list", "--json", "--short"],
			{
				stdio: "pipe",
				shell: true,
				detached: false,
			},
		);
const codemodListJSON = await streamToString(childProcess.stdout);
const codemodListOrError = codemodNamesCodec.decode(
  JSON.parse(codemodListJSON),
);
```