### PR TITLE
[CLI, Backend] feat: Add fuzzy-search command and make it interchangeable by list (CDMD-2768)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -54,6 +54,7 @@
 		"chromadb": "1.7.2",
 		"dotenv": "^16.4.5",
 		"fastify": "4.25.1",
+		"fuse.js": "^7.0.0",
 		"langchain": "0.0.209",
 		"lru-cache": "10.1.0",
 		"openai": "4.23.0",

--- a/apps/backend/src/schemata/query.ts
+++ b/apps/backend/src/schemata/query.ts
@@ -1,5 +1,4 @@
 import {
-	Output,
 	boolean,
 	coerce,
 	number,
@@ -16,22 +15,23 @@ export const getCodemodsQuerySchema = object({
 	page: optional(coerce(number(), Number)),
 	size: optional(coerce(number(), Number)),
 });
-export type GetCodemodsQuery = Output<typeof getCodemodsQuerySchema>;
 export const parseGetCodemodsQuery = (input: unknown) =>
 	parse(getCodemodsQuerySchema, input);
 
 export const getCodemodBySlugParamsSchema = object({
 	slug: string(),
 });
-export type GetCodemodBySlug = Output<typeof getCodemodBySlugParamsSchema>;
 export const parseGetCodemodBySlugParams = (input: unknown) =>
 	parse(getCodemodBySlugParamsSchema, input);
 
 export const getCodemodLatestVersionParamsSchema = object({
 	name: string(),
 });
-export type GetCodemodLatestVersion = Output<
-	typeof getCodemodBySlugParamsSchema
->;
 export const parseGetCodemodLatestVersionParams = (input: unknown) =>
 	parse(getCodemodLatestVersionParamsSchema, input);
+
+export const listCodemodsQuerySchema = object({
+	name: optional(string()),
+});
+export const parseListCodemodsQuery = (input: unknown) =>
+	parse(listCodemodsQuerySchema, input);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -9,6 +9,7 @@ import fastifyRateLimit from "@fastify/rate-limit";
 import { Codemod, CodemodVersion } from "@prisma/client";
 import { OpenAIStream } from "ai";
 import Fastify, { FastifyPluginCallback, RouteHandlerMethod } from "fastify";
+import Fuse from "fuse.js";
 import * as openAiEdge from "openai-edge";
 import { buildSafeChromaService } from "./chroma.js";
 import { ClaudeService } from "./claudeService.js";
@@ -30,6 +31,7 @@ import {
 	parseGetCodemodBySlugParams,
 	parseGetCodemodLatestVersionParams,
 	parseGetCodemodsQuery,
+	parseListCodemodsQuery,
 } from "./schemata/query.js";
 import {
 	parseCreateIssueBody,
@@ -447,6 +449,16 @@ const publicRoutes: FastifyPluginCallback = (instance, _opts, done) => {
 				);
 
 				codemodData = codemods.filter(Boolean);
+			}
+
+			const query = parseListCodemodsQuery(request.query);
+
+			if (query.name) {
+				const fuse = new Fuse(codemodData, {
+					keys: ["name"],
+				});
+
+				codemodData = fuse.search(query.name).map((res) => res.item);
 			}
 
 			reply.type("application/json").code(200);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -456,6 +456,7 @@ const publicRoutes: FastifyPluginCallback = (instance, _opts, done) => {
 			if (query.name) {
 				const fuse = new Fuse(codemodData, {
 					keys: ["name"],
+					isCaseSensitive: false,
 				});
 
 				codemodData = fuse.search(query.name).map((res) => res.item);

--- a/apps/cli/src/apis.ts
+++ b/apps/cli/src/apis.ts
@@ -84,8 +84,7 @@ export const getCodemodList = async (options?: {
 		headers[X_CODEMOD_ACCESS_TOKEN] = accessToken;
 	}
 
-	// const url = new URL("https://backend.codemod.com/codemods/list");
-	const url = new URL("http://localhost:8081/codemods/list");
+	const url = new URL("https://backend.codemod.com/codemods/list");
 	if (name) {
 		url.searchParams.set("name", name);
 	}

--- a/apps/cli/src/apis.ts
+++ b/apps/cli/src/apis.ts
@@ -73,18 +73,27 @@ export type CodemodListReturn = {
 	author: string;
 	engine: AllEngines;
 }[];
-export const getCodemodList = async (
-	accessToken?: string,
-): Promise<CodemodListReturn> => {
-	const res = await Axios.get<CodemodListReturn>(
-		"https://backend.codemod.com/codemods/list",
-		{
-			headers: {
-				[X_CODEMOD_ACCESS_TOKEN]: accessToken,
-			},
-			timeout: 10000,
-		},
-	);
+export const getCodemodList = async (options?: {
+	accessToken?: string;
+	name?: string;
+}): Promise<CodemodListReturn> => {
+	const { accessToken, name } = options ?? {};
+
+	const headers: { [key: string]: string } = {};
+	if (accessToken) {
+		headers[X_CODEMOD_ACCESS_TOKEN] = accessToken;
+	}
+
+	// const url = new URL("https://backend.codemod.com/codemods/list");
+	const url = new URL("http://localhost:8081/codemods/list");
+	if (name) {
+		url.searchParams.set("name", name);
+	}
+
+	const res = await Axios.get<CodemodListReturn>(url.toString(), {
+		headers,
+		timeout: 10000,
+	});
 
 	return res.data;
 };

--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -89,8 +89,13 @@ export const executeMainThread = async () => {
 		)
 		.command(
 			"list",
-			"lists all the codemods & recipes in the public registry",
+			"lists all the codemods & recipes in the public registry. can be used similar to search to filter by name",
 			(y) => buildUseJsonOption(buildUseCacheOption(y)),
+		)
+		.command(
+			"search",
+			"searches codemods that resemble given string from user input using fuzzy search",
+			(y) => buildUseJsonOption(y),
 		)
 		.command(
 			"learn",
@@ -192,9 +197,27 @@ export const executeMainThread = async () => {
 		tarService,
 	);
 
-	if (String(argv._) === "list") {
+	if (argv._.at(0) === "list" || argv._.at(0) === "search") {
 		try {
-			await handleListNamesCommand(printer, false);
+			const lastArgument = argv._.length > 1 ? String(argv._.at(-1)) : null;
+
+			let searchTerm: string | null = null;
+			if (lastArgument) {
+				if (lastArgument.length < 2) {
+					printer.printOperationMessage({
+						kind: "error",
+						message:
+							"Search term must be at least 2 characters long. Aborting...",
+					});
+					return;
+				}
+				searchTerm = lastArgument;
+			}
+
+			await handleListNamesCommand({
+				printer,
+				name: searchTerm ?? undefined,
+			});
 		} catch (error) {
 			if (!(error instanceof Error)) {
 				return;

--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -199,7 +199,8 @@ export const executeMainThread = async () => {
 
 	if (argv._.at(0) === "list" || argv._.at(0) === "search") {
 		try {
-			const lastArgument = argv._.length > 1 ? String(argv._.at(-1)) : null;
+			const lastArgument =
+				argv._.length > 1 ? String(argv._.at(-1)).trim() : null;
 
 			let searchTerm: string | null = null;
 			if (lastArgument) {

--- a/apps/cli/src/handleListCliCommand.ts
+++ b/apps/cli/src/handleListCliCommand.ts
@@ -3,11 +3,14 @@ import { getCodemodList } from "./apis.js";
 import type { PrinterBlueprint } from "./printer.js";
 import { boldText, colorizeText } from "./utils.js";
 
-export const handleListNamesCommand = async (
-	printer: PrinterBlueprint,
-	short?: boolean,
-) => {
-	const configObjects = await getCodemodList();
+export const handleListNamesCommand = async (options: {
+	printer: PrinterBlueprint;
+	name?: string;
+	short?: boolean;
+}) => {
+	const { printer, name, short } = options;
+
+	const configObjects = await getCodemodList({ name });
 
 	// required for vsce
 	if (short) {
@@ -41,8 +44,10 @@ export const handleListNamesCommand = async (
 		}),
 	);
 
-	printer.printConsoleMessage(
-		"info",
-		"\nColored codemods are verified by the Codemod.com engineering team",
-	);
+	if (configObjects.length > 0) {
+		printer.printConsoleMessage(
+			"info",
+			"\nColored codemods are verified by the Codemod.com engineering team",
+		);
+	}
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       fastify:
         specifier: 4.25.1
         version: 4.25.1
+      fuse.js:
+        specifier: ^7.0.0
+        version: 7.0.0
       langchain:
         specifier: 0.0.209
         version: 0.0.209(@aws-sdk/client-s3@3.525.0)(@aws-sdk/credential-provider-node@3.525.0)(axios@1.6.2)(chromadb@1.7.2)(pg@8.11.3)(replicate@0.25.2)
@@ -16990,6 +16993,11 @@ packages:
 
   /functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
+
+  /fuse.js@7.0.0:
+    resolution: {integrity: sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==}
+    engines: {node: '>=10'}
+    dev: false
 
   /fuzzysort@2.0.4:
     resolution: {integrity: sha512-Api1mJL+Ad7W7vnDZnWq5pGaXJjyencT+iKGia2PlHUcSsSzWwIQ3S1isiMpwpavjYtGd2FzhUIhnnhOULZgDw==}


### PR DESCRIPTION
- Adds `codemod search` command that behaves similarly to `codemod list` but allows perfoming fuzzy-find by name on codemod list
- Changes `codemod list` to work exactly the same as search and those two commands to work similarly