### PR TITLE
[CODEMOD: FN, FP]: remove 2 FN, 1 FP

### DIFF
--- a/packages/codemods/react/19/remove-forward-ref/src/index.ts
+++ b/packages/codemods/react/19/remove-forward-ref/src/index.ts
@@ -57,11 +57,10 @@ const buildRefArgVariableDeclaration = (
 const getRefTypeFromRefArg = (j: JSCodeshift, refArg: Identifier) => {
 	const typeReference = refArg.typeAnnotation?.typeAnnotation;
 
-	if (!j.TSTypeReference.check(typeReference)) {
-		return null;
-	}
-
-	if (!j.TSQualifiedName.check(typeReference.typeName)) {
+	if (
+		!j.TSTypeReference.check(typeReference) ||
+		!j.TSQualifiedName.check(typeReference.typeName)
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
-  should not remove type imports
- should handle case where generic params are not used, but wrapped function is typed
- should handle arg names