### PR TITLE
[CLI, Backend] feat: allow publishing codemods of any engine (CDMD-2826)

### DIFF
--- a/apps/backend/src/publishHandler.ts
+++ b/apps/backend/src/publishHandler.ts
@@ -64,7 +64,8 @@ export const publishHandler =
 
 			let codemodRcBuffer: Buffer | null = null;
 			let codemodRc: CodemodConfig | null = null;
-			let indexCjsBuffer: Buffer | null = null;
+			let mainFileBuffer: Buffer | null = null;
+			let mainFileName: string | null = null;
 			let descriptionMdBuffer: Buffer | null = null;
 
 			for await (const multipartFile of request.files()) {
@@ -89,8 +90,13 @@ export const publishHandler =
 					// TODO: add check for organization
 				}
 
-				if (multipartFile.fieldname === "index.cjs") {
-					indexCjsBuffer = buffer;
+				if (
+					["index.cjs", "rules.toml", "rule.yaml"].includes(
+						multipartFile.fieldname,
+					)
+				) {
+					mainFileName = multipartFile.fieldname;
+					mainFileBuffer = buffer;
 				}
 
 				if (multipartFile.fieldname === "description.md") {
@@ -105,9 +111,12 @@ export const publishHandler =
 				});
 			}
 
-			if (!isNeitherNullNorUndefined(indexCjsBuffer)) {
+			if (
+				!isNeitherNullNorUndefined(mainFileBuffer) ||
+				!isNeitherNullNorUndefined(mainFileName)
+			) {
 				return reply.code(400).send({
-					error: "No index.cjs file was provided",
+					error: "No main file was provided",
 					success: false,
 				});
 			}
@@ -136,8 +145,8 @@ export const publishHandler =
 					data: codemodRcBuffer,
 				},
 				{
-					name: "index.cjs",
-					data: indexCjsBuffer,
+					name: mainFileName,
+					data: mainFileBuffer,
 				},
 			];
 

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -61,7 +61,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 
 			await this._tarService.extract(directoryPath, buffer);
 		} catch (error) {
-			await handleListNamesCommand(this.__printer);
+			await handleListNamesCommand({ printer: this.__printer });
 
 			throw new Error(
 				`Could not find codemod ${boldText(


### PR DESCRIPTION
Until now, we only supported publishing of js codemods. We want to allow publishing for all the engines we support, since publishing is now the only way to get codemods into the registry.