### PR TITLE
[VSCE] Comment out business logic for Codemod Arguments - CDMD-3015

### DIFF
--- a/apps/vsce/src/components/webview/MainProvider.ts
+++ b/apps/vsce/src/components/webview/MainProvider.ts
@@ -14,9 +14,7 @@ import { Store } from "../../data";
 import { actions } from "../../data/slice";
 import { SEARCH_PARAMS_KEYS } from "../../extension";
 import { createIssueResponseCodec } from "../../github/types";
-import {
-	relativeToAbsolutePath,
-} from "../../selectors/selectCodemodTree";
+import { relativeToAbsolutePath } from "../../selectors/selectCodemodTree";
 import { selectMainWebviewViewProps } from "../../selectors/selectMainWebviewViewProps";
 import { buildGlobPattern } from "../../utilities";
 import { EngineService } from "../engineService";

--- a/apps/vsce/src/components/webview/MainProvider.ts
+++ b/apps/vsce/src/components/webview/MainProvider.ts
@@ -15,12 +15,10 @@ import { actions } from "../../data/slice";
 import { SEARCH_PARAMS_KEYS } from "../../extension";
 import { createIssueResponseCodec } from "../../github/types";
 import {
-	CodemodNodeHashDigest,
 	relativeToAbsolutePath,
-	selectCodemodArguments,
 } from "../../selectors/selectCodemodTree";
 import { selectMainWebviewViewProps } from "../../selectors/selectMainWebviewViewProps";
-import { buildGlobPattern, isNeitherNullNorUndefined } from "../../utilities";
+import { buildGlobPattern } from "../../utilities";
 import { EngineService } from "../engineService";
 import { MessageBus, MessageKind } from "../messageBus";
 import { UserService } from "../userService";
@@ -415,22 +413,23 @@ export class MainViewProvider implements WebviewViewProvider {
 			const uri = Uri.file(executionPath);
 
 			// if missing some required arguments, open arguments popup
-			const argumentsSpecified = selectCodemodArguments(
-				this.__store.getState(),
-				hashDigest as unknown as CodemodNodeHashDigest,
-			).every(
-				({ required, value }) =>
-					!required || (isNeitherNullNorUndefined(value) && value !== ""),
-			);
+			// TODO: support codemod arguments
+			// const argumentsSpecified = selectCodemodArguments(
+			// 	this.__store.getState(),
+			// 	hashDigest as unknown as CodemodNodeHashDigest,
+			// ).every(
+			// 	({ required, value }) =>
+			// 		!required || (isNeitherNullNorUndefined(value) && value !== ""),
+			// );
 
-			if (!argumentsSpecified) {
-				this.__store.dispatch(
-					actions.setCodemodArgumentsPopupHashDigest(
-						hashDigest as unknown as CodemodNodeHashDigest,
-					),
-				);
-				return;
-			}
+			// if (!argumentsSpecified) {
+			// 	this.__store.dispatch(
+			// 		actions.setCodemodArgumentsPopupHashDigest(
+			// 			hashDigest as unknown as CodemodNodeHashDigest,
+			// 		),
+			// 	);
+			// 	return;
+			// }
 
 			commands.executeCommand("codemod.executeCodemod", uri, hashDigest);
 		}

--- a/apps/vsce/src/extension.ts
+++ b/apps/vsce/src/extension.ts
@@ -35,9 +35,7 @@ import {
 import { HomeDirectoryService } from "./data/readHomeDirectoryCases";
 import { actions } from "./data/slice";
 import { CodemodHash } from "./packageJsonAnalyzer/types";
-import {
-	CodemodNodeHashDigest,
-} from "./selectors/selectCodemodTree";
+import { CodemodNodeHashDigest } from "./selectors/selectCodemodTree";
 import { selectExplorerTree } from "./selectors/selectExplorerTree";
 import { buildCaseHash } from "./telemetry/hashes";
 import { VscodeTelemetry } from "./telemetry/vscodeTelemetry";
@@ -672,7 +670,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					const targetUriIsDirectory = Boolean(
 						fileStat.type & vscode.FileType.Directory,
 					);
-					
+
 					// TODO: support codemod arguments
 					// const args = selectCodemodArguments(
 					// 	store.getState(),

--- a/apps/vsce/src/extension.ts
+++ b/apps/vsce/src/extension.ts
@@ -37,7 +37,6 @@ import { actions } from "./data/slice";
 import { CodemodHash } from "./packageJsonAnalyzer/types";
 import {
 	CodemodNodeHashDigest,
-	selectCodemodArguments,
 } from "./selectors/selectCodemodTree";
 import { selectExplorerTree } from "./selectors/selectExplorerTree";
 import { buildCaseHash } from "./telemetry/hashes";
@@ -514,10 +513,11 @@ export async function activate(context: vscode.ExtensionContext) {
 						);
 					}
 
-					const args = selectCodemodArguments(
-						store.getState(),
-						codemodHash as unknown as CodemodNodeHashDigest,
-					);
+					// TODO: support codemod arguments
+					// const args = selectCodemodArguments(
+					// 	store.getState(),
+					// 	codemodHash as unknown as CodemodNodeHashDigest,
+					// );
 					const command: Command =
 						// @ts-ignore TODO: Remove this logic in the next PR
 						codemod.kind === "piranhaRule"
@@ -535,13 +535,13 @@ export async function activate(context: vscode.ExtensionContext) {
 									// @ts-ignore TODO: Remove this logic in the next PR
 									language: codemod.language,
 									name: codemod.name,
-									arguments: args,
+									arguments: [],
 							  }
 							: {
 									kind: "executeCodemod",
 									codemodHash,
 									name: codemod.name,
-									arguments: args,
+									arguments: [],
 							  };
 
 					store.dispatch(
@@ -672,11 +672,12 @@ export async function activate(context: vscode.ExtensionContext) {
 					const targetUriIsDirectory = Boolean(
 						fileStat.type & vscode.FileType.Directory,
 					);
-
-					const args = selectCodemodArguments(
-						store.getState(),
-						codemodEntry.hashDigest as unknown as CodemodNodeHashDigest,
-					);
+					
+					// TODO: support codemod arguments
+					// const args = selectCodemodArguments(
+					// 	store.getState(),
+					// 	codemodEntry.hashDigest as unknown as CodemodNodeHashDigest,
+					// );
 
 					const command: Command =
 						// @ts-ignore TODO: Remove this logic in the next PR
@@ -695,13 +696,13 @@ export async function activate(context: vscode.ExtensionContext) {
 									// @ts-ignore TODO: Remove this logic in the next PR
 									language: codemodEntry.language,
 									name: codemodEntry.name,
-									arguments: args,
+									arguments: [],
 							  }
 							: {
 									kind: "executeCodemod",
 									codemodHash: codemodEntry.hashDigest as CodemodHash,
 									name: codemodEntry.name,
-									arguments: args,
+									arguments: [],
 							  };
 
 					messageBus.publish({

--- a/apps/vsce/src/selectors/selectCodemodTree.ts
+++ b/apps/vsce/src/selectors/selectCodemodTree.ts
@@ -150,17 +150,18 @@ export const selectCodemodTree = (
 					rootPath ?? "",
 				);
 
-				const args = selectCodemodArguments(
-					state,
-					codemod.hashDigest as CodemodNodeHashDigest,
-				);
+				// TODO: support codemod arguments
+				// const args = selectCodemodArguments(
+				// 	state,
+				// 	codemod.hashDigest as CodemodNodeHashDigest,
+				// );
 
 				currNode = buildCodemodNode(
 					codemod,
 					part,
 					executionRelativePath,
 					executionQueue.includes(codemod.hashDigest as CodemodHash),
-					args,
+					[],
 				);
 			} else {
 				currNode = buildDirectoryNode(part, codemodDirName);

--- a/apps/vsce/webview/src/campaignManager/App.tsx
+++ b/apps/vsce/webview/src/campaignManager/App.tsx
@@ -35,8 +35,7 @@ export const App = (
 		// no workspace is chosen
 		return (
 			<p className={styles.welcomeMessage}>
-				No change to review! Run some codemods via Codemod Discovery or VSCode
-				Command & check back later!
+				No change to review! Run some codemod from "Codemods" tab!
 			</p>
 		);
 	}
@@ -47,8 +46,7 @@ export const App = (
 			<LoadingProgress description="Executing codemod..." />
 		) : (
 			<p className={styles.welcomeMessage}>
-				No change to review! Run some codemods via Codemod Discovery or VSCode
-				Command & check back later!
+				No change to review! Run some codemod from "Codemods" tab!
 			</p>
 		);
 	}

--- a/apps/vsce/webview/src/codemodList/CodemodNodeRenderer/Codemod.tsx
+++ b/apps/vsce/webview/src/codemodList/CodemodNodeRenderer/Codemod.tsx
@@ -60,14 +60,14 @@ const renderActionButtons = (
 
 		return (
 			<>
-				<ActionButton
+				{/* <ActionButton
 					id={`${hashDigest}-dryRunButton`}
 					content="Set codemod arguments"
 					onClick={handleCodemodArgumentsClick}
 					active={argumentsExpanded}
 				>
 					<span className={cn("codicon", "codicon-settings-gear")} />
-				</ActionButton>
+				</ActionButton> */}
 				<ActionButton
 					id={`${hashDigest}-dryRunButton`}
 					content="Dry-run this codemod (without making change to file system)."


### PR DESCRIPTION
Previously, we had info about arguments via config.json files and, using this info, we conditionally showed UI for codemod arguments. We no longer store config.json files locally, so I am commenting out all code related to Codemod Arguments and drop the support for it. In the future, we can create some backend API that returns arguments related information and use this in VSCE to show UI for codemod arguments.