### PR TITLE
[CLI] feat: ast-grep compatible implementation

### DIFF
--- a/apps/cli/src/buildCodemodOptions.ts
+++ b/apps/cli/src/buildCodemodOptions.ts
@@ -37,25 +37,29 @@ const extractMainScriptPath = async (
 	codemodRc: CodemodConfig,
 	source: string,
 ) => {
+	let globSearchPattern: string;
 	let actualMainFileName: string;
 	let errorOnMissing: string;
 
 	switch (codemodRc.engine) {
 		case "ast-grep":
+			globSearchPattern = "**/rule.yaml";
 			actualMainFileName = "rule.yaml";
 			errorOnMissing = `Please create the main "rule.yaml" file first.`;
 			break;
 		case "piranha":
+			globSearchPattern = "**/rules.toml";
 			actualMainFileName = "rules.toml";
 			errorOnMissing = `Please create the main "rules.toml" file first.`;
 			break;
 		default:
+			globSearchPattern = "dist/index.cjs";
 			actualMainFileName = "index.cjs";
 			errorOnMissing = `Did you forget to run "codemod build"?`;
 	}
 
 	const mainFiles = await glob(
-		join(source, codemodRc.build?.output ?? `**/${actualMainFileName}`),
+		join(source, codemodRc.build?.output ?? globSearchPattern),
 		{ absolute: true },
 	);
 

--- a/apps/cli/src/buildCodemodOptions.ts
+++ b/apps/cli/src/buildCodemodOptions.ts
@@ -1,45 +1,28 @@
-import path from "node:path";
-import { IFs } from "memfs";
-import { object, parse, string } from "valibot";
+import { readFile } from "node:fs/promises";
+import path, { join } from "node:path";
 import {
-	Codemod,
-	JavaScriptCodemodEngine,
-	javaScriptCodemodEngineSchema,
-} from "./codemod.js";
+	CodemodConfig,
+	KnownEngines,
+	knownEnginesSchema,
+	parseCodemodConfig,
+} from "@codemod-com/utilities";
+import { glob } from "fast-glob";
+import { IFs } from "memfs";
+import { object, parse } from "valibot";
+import { Codemod } from "./codemod.js";
 import { CodemodSettings } from "./schemata/codemodSettingsSchema.js";
-
-const extractMainScriptRelativePath = async (
-	fs: IFs,
-	filePath: string,
-): Promise<string | null> => {
-	try {
-		const data = await fs.promises.readFile(filePath, {
-			encoding: "utf-8",
-		});
-
-		const schema = object({
-			main: string(),
-		});
-
-		const { main } = parse(schema, JSON.parse(data.toString()));
-
-		return main;
-	} catch {
-		return null;
-	}
-};
 
 const extractEngine = async (
 	fs: IFs,
 	filePath: string,
-): Promise<JavaScriptCodemodEngine | null> => {
+): Promise<KnownEngines | null> => {
 	try {
 		const data = await fs.promises.readFile(filePath, {
 			encoding: "utf-8",
 		});
 
 		const schema = object({
-			engine: javaScriptCodemodEngineSchema,
+			engine: knownEnginesSchema,
 		});
 
 		const { engine } = parse(schema, JSON.parse(data.toString()));
@@ -48,6 +31,41 @@ const extractEngine = async (
 	} catch {
 		return null;
 	}
+};
+
+const extractMainScriptPath = async (
+	codemodRc: CodemodConfig,
+	source: string,
+) => {
+	let actualMainFileName: string;
+	let errorOnMissing: string;
+
+	switch (codemodRc.engine) {
+		case "ast-grep":
+			actualMainFileName = "rule.yaml";
+			errorOnMissing = `Please create the main "rule.yaml" file first.`;
+			break;
+		case "piranha":
+			actualMainFileName = "rules.toml";
+			errorOnMissing = `Please create the main "rules.toml" file first.`;
+			break;
+		default:
+			actualMainFileName = "index.cjs";
+			errorOnMissing = `Did you forget to run "codemod build"?`;
+	}
+
+	const mainFiles = await glob(
+		join(source, codemodRc.build?.output ?? `**/${actualMainFileName}`),
+		{ absolute: true },
+	);
+
+	if (mainFiles.length === 0) {
+		throw new Error(
+			`Could not find the main file of the codemod with name ${actualMainFileName}. ${errorOnMissing}`,
+		);
+	}
+
+	return mainFiles.at(0)!;
 };
 
 export const buildSourcedCodemodOptions = async (
@@ -70,32 +88,23 @@ export const buildSourcedCodemodOptions = async (
 		};
 	}
 
-	if (
-		![".codemodrc.json", "package.json"]
-			.map((lookedupFilePath) =>
-				path.join(codemodOptions.source, lookedupFilePath),
-			)
-			.every(fs.existsSync)
-	) {
+	let codemodRcContent: string;
+	try {
+		codemodRcContent = await readFile(
+			path.join(codemodOptions.source, ".codemodrc.json"),
+			{ encoding: "utf-8" },
+		);
+	} catch (err) {
 		throw new Error(
 			`Codemod directory is of incorrect structure at ${codemodOptions.source}`,
 		);
 	}
 
-	const mainScriptRelativePath = await extractMainScriptRelativePath(
-		fs,
-		path.join(codemodOptions.source, "package.json"),
-	);
+	const codemodConfig = parseCodemodConfig(JSON.parse(codemodRcContent));
 
-	if (!mainScriptRelativePath) {
-		throw new Error(
-			`No main script specified for codemod at ${codemodOptions.source}`,
-		);
-	}
-
-	const mainScriptPath = path.join(
+	const mainScriptPath = await extractMainScriptPath(
+		codemodConfig,
 		codemodOptions.source,
-		mainScriptRelativePath,
 	);
 
 	const engine = await extractEngine(

--- a/apps/cli/src/codemod.ts
+++ b/apps/cli/src/codemod.ts
@@ -1,16 +1,4 @@
-import { type Arguments } from "@codemod-com/utilities";
-import { type Output, literal, union } from "valibot";
-
-export const javaScriptCodemodEngineSchema = union([
-	literal("jscodeshift"),
-	literal("repomod-engine"),
-	literal("filemod"),
-	literal("ts-morph"),
-]);
-
-export type JavaScriptCodemodEngine = Output<
-	typeof javaScriptCodemodEngineSchema
->;
+import { type Arguments, type KnownEngines } from "@codemod-com/utilities";
 
 export type Codemod =
 	| Readonly<{
@@ -26,16 +14,7 @@ export type Codemod =
 			source: "registry";
 			name: string;
 			include?: string[];
-			engine: "ast-grep";
-			directoryPath: string;
-			arguments: Arguments;
-			yamlPath: string;
-	  }>
-	| Readonly<{
-			source: "registry";
-			name: string;
-			include?: string[];
-			engine: JavaScriptCodemodEngine;
+			engine: KnownEngines;
 			directoryPath: string;
 			indexPath: string;
 			arguments: Arguments;
@@ -51,6 +30,6 @@ export type Codemod =
 	| Readonly<{
 			source: "fileSystem";
 			include?: string[];
-			engine: JavaScriptCodemodEngine;
+			engine: KnownEngines;
 			indexPath: string;
 	  }>;

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -88,7 +88,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 					name,
 					engine: config.engine,
 					include: config.include,
-					yamlPath,
+					indexPath: yamlPath,
 					directoryPath,
 					arguments: config.arguments,
 				};

--- a/apps/cli/src/executeWorkerThread.ts
+++ b/apps/cli/src/executeWorkerThread.ts
@@ -1,9 +1,10 @@
 import { parentPort } from "node:worker_threads";
-import { buildFormattedFileCommands } from "./fileCommands.js";
+import { FileCommand, buildFormattedFileCommands } from "./fileCommands.js";
 import {
 	type MainThreadMessage,
 	decodeMainThreadMessage,
 } from "./mainThreadMessages.js";
+import { runAstGrepCodemod } from "./runAstgrepCodemod.js";
 import { runJscodeshiftCodemod } from "./runJscodeshiftCodemod.js";
 import { runTsMorphCodemod } from "./runTsMorphCodemod.js";
 import { ConsoleKind } from "./schemata/consoleKindSchema.js";
@@ -32,7 +33,13 @@ let initializationMessage:
 
 const messageHandler = async (m: unknown) => {
 	try {
-		const message = decodeMainThreadMessage(m);
+		let message: MainThreadMessage;
+		try {
+			message = decodeMainThreadMessage(m);
+		} catch (err) {
+			console.dir(err, { depth: 10 });
+			throw new Error(`Failed to decode message: ${String(err)}`);
+		}
 
 		if (message.kind === "initialization") {
 			initializationMessage = message;
@@ -49,24 +56,43 @@ const messageHandler = async (m: unknown) => {
 		}
 
 		try {
-			const fileCommands =
-				initializationMessage.codemodEngine === "jscodeshift"
-					? runJscodeshiftCodemod(
-							initializationMessage.codemodSource,
-							message.path,
-							message.data,
-							initializationMessage.disablePrettier,
-							initializationMessage.safeArgumentRecord,
-							consoleCallback,
-					  )
-					: runTsMorphCodemod(
-							initializationMessage.codemodSource,
-							message.path,
-							message.data,
-							initializationMessage.disablePrettier,
-							initializationMessage.safeArgumentRecord,
-							consoleCallback,
-					  );
+			let fileCommands: readonly FileCommand[] = [];
+			switch (initializationMessage.codemodEngine) {
+				case "jscodeshift":
+					fileCommands = runJscodeshiftCodemod(
+						initializationMessage.codemodSource,
+						message.path,
+						message.data,
+						initializationMessage.disablePrettier,
+						initializationMessage.safeArgumentRecord,
+						consoleCallback,
+					);
+					break;
+				case "ts-morph":
+					fileCommands = runTsMorphCodemod(
+						initializationMessage.codemodSource,
+						message.path,
+						message.data,
+						initializationMessage.disablePrettier,
+						initializationMessage.safeArgumentRecord,
+						consoleCallback,
+					);
+					break;
+				case "ast-grep":
+					fileCommands = await runAstGrepCodemod(
+						initializationMessage.codemodSource,
+						message.path,
+						message.data,
+						initializationMessage.disablePrettier,
+						initializationMessage.safeArgumentRecord,
+						consoleCallback,
+					);
+					break;
+				default:
+					throw new Error(
+						`Unknown codemod engine: ${initializationMessage.codemodEngine}`,
+					);
+			}
 
 			const commands = await buildFormattedFileCommands(fileCommands);
 

--- a/apps/cli/src/handleInstallDependencies.ts
+++ b/apps/cli/src/handleInstallDependencies.ts
@@ -111,7 +111,11 @@ export const handleInstallDependencies = async (options: {
 
 		if (detectedPackageManager === null) {
 			for (const packageJsonPath of packageJsons) {
-				const packageJson = await import(packageJsonPath);
+				const packageJsonContent = await readFile(packageJsonPath, {
+					encoding: "utf-8",
+				});
+				const packageJson = JSON.parse(packageJsonContent);
+
 				if (packageJson.packageManager) {
 					detectedPackageManager = packageJson.packageManager.split("@").at(0);
 					break;

--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { codemodNameRegex, parseCodemodConfig } from "@codemod-com/utilities";
 import { AxiosError } from "axios";
+import { glob } from "fast-glob";
 import FormData from "form-data";
 import { publish, validateAccessToken } from "./apis.js";
 import type { PrinterBlueprint } from "./printer.js";
@@ -84,36 +85,33 @@ export const handlePublishCliCommand = async (
 
 	if (codemodRc.engine !== "recipe") {
 		let actualMainFileName: string;
-		let ruleOrExecutablePath: string | null;
 		let errorOnMissing: string;
 
 		switch (codemodRc.engine) {
 			case "ast-grep":
-				ruleOrExecutablePath = "rule.yaml";
 				actualMainFileName = "rule.yaml";
 				errorOnMissing = `Please create the main "rule.yaml" file first.`;
 				break;
 			case "piranha":
-				ruleOrExecutablePath = "rules.toml";
 				actualMainFileName = "rules.toml";
 				errorOnMissing = `Please create the main "rules.toml" file first.`;
 				break;
 			default:
-				ruleOrExecutablePath = codemodRc.build?.output ?? "dist/index.cjs";
 				actualMainFileName = "index.cjs";
 				errorOnMissing = `Did you forget to run "codemod build"?`;
 		}
 
-		try {
-			const mainFileBuf = await fs.promises.readFile(
-				join(source, ruleOrExecutablePath),
-			);
-			formData.append(actualMainFileName, mainFileBuf);
-		} catch (err) {
+		const mainFiles = await glob(
+			join(source, codemodRc.build?.output ?? `**/${actualMainFileName}`),
+			{ absolute: true },
+		);
+
+		if (mainFiles.length === 0) {
 			throw new Error(
-				`Could not find the main file of the codemod in ${ruleOrExecutablePath}. ${errorOnMissing}`,
+				`Could not find the main file of the codemod with name ${actualMainFileName}. ${errorOnMissing}`,
 			);
 		}
+		formData.append(actualMainFileName, mainFiles.at(0));
 	}
 
 	try {

--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -84,25 +84,29 @@ export const handlePublishCliCommand = async (
 	);
 
 	if (codemodRc.engine !== "recipe") {
+		let globSearchPattern: string;
 		let actualMainFileName: string;
 		let errorOnMissing: string;
 
 		switch (codemodRc.engine) {
 			case "ast-grep":
+				globSearchPattern = "**/rule.yaml";
 				actualMainFileName = "rule.yaml";
 				errorOnMissing = `Please create the main "rule.yaml" file first.`;
 				break;
 			case "piranha":
+				globSearchPattern = "**/rules.toml";
 				actualMainFileName = "rules.toml";
 				errorOnMissing = `Please create the main "rules.toml" file first.`;
 				break;
 			default:
+				globSearchPattern = "dist/index.cjs";
 				actualMainFileName = "index.cjs";
 				errorOnMissing = `Did you forget to run "codemod build"?`;
 		}
 
 		const mainFiles = await glob(
-			join(source, codemodRc.build?.output ?? `**/${actualMainFileName}`),
+			join(source, codemodRc.build?.output ?? globSearchPattern),
 			{ absolute: true },
 		);
 
@@ -111,6 +115,7 @@ export const handlePublishCliCommand = async (
 				`Could not find the main file of the codemod with name ${actualMainFileName}. ${errorOnMissing}`,
 			);
 		}
+
 		formData.append(actualMainFileName, mainFiles.at(0));
 	}
 

--- a/apps/cli/src/mainThreadMessages.ts
+++ b/apps/cli/src/mainThreadMessages.ts
@@ -14,7 +14,11 @@ const mainThreadMessageSchema = union([
 		kind: literal("initialization"),
 		codemodPath: string(),
 		codemodSource: string(),
-		codemodEngine: union([literal("jscodeshift"), literal("ts-morph")]),
+		codemodEngine: union([
+			literal("jscodeshift"),
+			literal("ts-morph"),
+			literal("ast-grep"),
+		]),
 		disablePrettier: boolean(),
 		safeArgumentRecord: argumentRecordSchema,
 	}),

--- a/apps/cli/src/runAstgrepCodemod.ts
+++ b/apps/cli/src/runAstgrepCodemod.ts
@@ -38,7 +38,7 @@ export const runAstgrep = async (
 				if (fileExtension !== extension) {
 					continue;
 				}
-				const astCommand = "sg scan -r ${rulePath} ${entryPath} -U";
+				const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
 				if (process.platform === "win32") {
 					execSync(`powershell -Command "${astCommand}"`);
 				} else {

--- a/apps/cli/src/runAstgrepCodemod.ts
+++ b/apps/cli/src/runAstgrepCodemod.ts
@@ -1,87 +1,210 @@
-import fs from "fs";
+// import { execSync } from "node:child_process";
+// import { readFile } from "node:fs/promises";
+// import * as yaml from "js-yaml";
+// import { PrinterBlueprint } from "./printer.js";
+
+// export const runAstgrep = async (
+// 	printer: PrinterBlueprint,
+// 	rulePath: string,
+// 	targetDirectory: string,
+// ): Promise<void> => {
+// 	const yamlString = await readFile(rulePath, { encoding: "utf8" });
+// 	const yamlObject = yaml.load(yamlString);
+// 	const extension = languageToExtension(yamlObject.language);
+
+// 	try {
+// 		// Use `which` command to check if the command is available
+// 		execSync("which sg");
+// 	} catch (error) {
+// 		// If `which` command fails, the command is not available
+// 		printer.printConsoleMessage(
+// 			"info",
+// 			"ast-grep is not available, installing it globally",
+// 		);
+// 		const astInstallCommand = "npm install -g @ast-grep/cli";
+// 		if (process.platform === "win32") {
+// 			execSync(`powershell -Command ${astInstallCommand}`);
+// 		} else {
+// 			execSync(astInstallCommand);
+// 		}
+// 	}
+
+// 	printer.printConsoleMessage(
+// 		"info",
+// 		`Executing ast-grep for language : ${extension}`,
+// 	);
+
+// 	// Function to recursively iterate over files in the directory
+// 	const iterateFiles = async (dirPath: string) => {
+// 		const entries = await fs.promises.readdir(dirPath, {
+// 			withFileTypes: true,
+// 		});
+
+// 		// Iterate over each entry in the directory
+// 		for (const entry of entries) {
+// 			const entryPath = path.join(dirPath, entry.name);
+// 			// Check if the entry is a directory
+// 			if (entry.isDirectory()) {
+// 				// Recursively call the function for subdirectories
+// 				await iterateFiles(entryPath);
+// 			} else if (entry.isFile()) {
+// 				// If the entry is a file, log its path
+// 				const fileExtension = path.extname(entryPath).slice(1);
+// 				if (fileExtension !== extension) {
+// 					continue;
+// 				}
+// 				const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
+// 				if (process.platform === "win32") {
+// 					execSync(`powershell -Command "${astCommand}"`);
+// 				} else {
+// 					execSync(astCommand);
+// 				}
+// 			}
+// 		}
+// 	};
+
+// 	// await iterateFiles(targetDirectory);
+// 	return;
+// };
+
+// function languageToExtension(language: string) {
+// 	const lang = language.toLocaleLowerCase();
+// 	switch (lang) {
+// 		case "python":
+// 			return "py";
+// 		case "javascript":
+// 			return "js";
+// 		default:
+// 			throw new Error(
+// 				`Unsupported Language ${language} in codemod cli for ast-grep engine`,
+// 			);
+// 	}
+// }
+
 import { execSync } from "node:child_process";
-import { readFile } from "node:fs/promises";
-import path from "path";
-import * as yaml from "js-yaml";
-import { PrinterBlueprint } from "./printer.js";
+import vm from "node:vm";
+import jscodeshift, { API, FileInfo } from "jscodeshift";
+import { nullish, parse, string } from "valibot";
+import { buildVmConsole } from "./buildVmConsole.js";
+import { CONSOLE_OVERRIDE } from "./consoleOverride.js";
+import type { FileCommand } from "./fileCommands.js";
+import type { SafeArgumentRecord } from "./safeArgumentRecord.js";
+import { ConsoleKind } from "./schemata/consoleKindSchema.js";
 
-export const runAstgrep = async (
-	printer: PrinterBlueprint,
-	rulePath: string,
-	targetDirectory: string,
-): Promise<void> => {
-	const yamlString = await readFile(rulePath, { encoding: "utf8" });
-	const yamlObject = yaml.load(yamlString);
-	const extension = languageToExtension(yamlObject.language);
-	installSgCommandIfNotAvailable(printer);
-	printer.printConsoleMessage(
-		"info",
-		`Executing ast-grep for language : ${extension}`,
-	);
+export const buildApi = (parser: string): API => ({
+	j: jscodeshift.withParser(parser),
+	jscodeshift: jscodeshift.withParser(parser),
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	stats: () => {},
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	report: () => {},
+});
 
-	// Function to recursively iterate over files in the directory
-	const iterateFiles = async (dirPath: string) => {
-		const entries = await fs.promises.readdir(dirPath, {
-			withFileTypes: true,
-		});
+const transform = (
+	codemodSource: string,
+	fileInfo: FileInfo,
+	api: API,
+	options: {
+		// the options will be of type ArgumentRecord
+		// after the removal of the createFile function
+		[x: string]: unknown;
+		createFile: (newPath: string, newData: string) => void;
+	},
+	consoleCallback: (kind: ConsoleKind, message: string) => void,
+): string | undefined | null => {
+	const codeToExecute = `
+		${CONSOLE_OVERRIDE}
 
-		// Iterate over each entry in the directory
-		for (const entry of entries) {
-			const entryPath = path.join(dirPath, entry.name);
-			// Check if the entry is a directory
-			if (entry.isDirectory()) {
-				// Recursively call the function for subdirectories
-				await iterateFiles(entryPath);
-			} else if (entry.isFile()) {
-				// If the entry is a file, log its path
-				const fileExtension = path.extname(entryPath).slice(1);
-				if (fileExtension !== extension) {
-					continue;
-				}
-				const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
-				if (process.platform === "win32") {
-					execSync(`powershell -Command "${astCommand}"`);
-				} else {
-					execSync(astCommand);
-				}
-			}
-		}
-	};
+		const __module__ = { exports: {} };
 
-	await iterateFiles(targetDirectory);
-	return;
+		const keys = ['module', 'exports'];
+		const values = [__module__, __module__.exports];
+
+		new Function(...keys, __CODEMOD_SOURCE__).apply(null, values);
+
+		const transform = typeof __module__.exports === 'function'
+			? __module__.exports
+			: __module__.exports.__esModule &&
+			typeof __module__.exports.default === 'function'
+			? __module__.exports.default
+			: null;
+
+		transform(__CODEMODCOM__file, __CODEMODCOM__api, __CODEMODCOM__options);
+	`;
+
+	// Create a new context for the code execution
+	const exports = Object.freeze({});
+
+	const context = vm.createContext({
+		module: Object.freeze({
+			exports,
+		}),
+		exports,
+		__CODEMODCOM__file: fileInfo,
+		__CODEMODCOM__api: api,
+		__CODEMODCOM__options: options,
+		__CODEMODCOM__console__: buildVmConsole(consoleCallback),
+		__CODEMOD_SOURCE__: codemodSource,
+	});
+
+	const value = vm.runInContext(codeToExecute, context);
+
+	return parse(nullish(string()), value);
 };
 
-function languageToExtension(language: string) {
-	const lang = language.toLocaleLowerCase();
-	switch (lang) {
-		case "python":
-			return "py";
-		case "javascript":
-			return "js";
-		default:
-			throw new Error(
-				`Unsupported Language ${language} in codemod cli for ast-grep engine`,
-			);
-	}
-}
+export const runAstGrepCodemod = (
+	codemodSource: string,
+	oldPath: string,
+	oldData: string,
+	disablePrettier: boolean,
+	safeArgumentRecord: SafeArgumentRecord,
+	consoleCallback: (kind: ConsoleKind, message: string) => void,
+): readonly FileCommand[] => {
+	const commands: FileCommand[] = [];
 
-// Function to check if ast-grep is available or not
-const installSgCommandIfNotAvailable = (printer: PrinterBlueprint): void => {
-	try {
-		// Use `which` command to check if the command is available
-		execSync("which sg");
-	} catch (error) {
-		// If `which` command fails, the command is not available
-		printer.printConsoleMessage(
-			"info",
-			"ast-grep is not available, installing it globally",
-		);
-		const astInstallCommand = "npm install -g @ast-grep/cli";
-		if (process.platform === "win32") {
-			execSync(`powershell -Command ${astInstallCommand}`);
-		} else {
-			execSync(astInstallCommand);
-		}
+	const createFile = (newPath: string, newData: string): void => {
+		commands.push({
+			kind: "createFile",
+			newPath,
+			newData,
+			formatWithPrettier: !disablePrettier,
+		});
+	};
+
+	const api = buildApi("tsx");
+
+	const newData = transform(
+		codemodSource,
+		{
+			path: oldPath,
+			source: oldData,
+		},
+		api,
+		{
+			...safeArgumentRecord,
+			createFile,
+		},
+		consoleCallback,
+	);
+
+	const astCommand = `sg scan -r ${rulePath} ${entryPath} -U`;
+	if (process.platform === "win32") {
+		execSync(`powershell -Command "${astCommand}"`);
+	} else {
+		execSync(astCommand);
 	}
+
+	if (typeof newData !== "string" || oldData === newData) {
+		return commands;
+	}
+
+	commands.push({
+		kind: "updateFile",
+		oldPath,
+		oldData: oldData,
+		newData,
+		formatWithPrettier: !disablePrettier,
+	});
+
+	return commands;
 };

--- a/apps/cli/src/runCodemod.ts
+++ b/apps/cli/src/runCodemod.ts
@@ -12,7 +12,6 @@ import {
 import { getTransformer, transpile } from "./getTransformer.js";
 import { OperationMessage } from "./messages.js";
 import { PrinterBlueprint } from "./printer.js";
-import { runAstgrep } from "./runAstgrepCodemod.js";
 import { Dependencies, runRepomod } from "./runRepomod.js";
 import { SafeArgumentRecord } from "./safeArgumentRecord.js";
 import { FlowSettings } from "./schemata/flowSettingsSchema.js";
@@ -247,11 +246,6 @@ export const runCodemod = async (
 			await onCommand(command);
 		}
 
-		return;
-	}
-
-	if (codemod.engine === "ast-grep") {
-		await runAstgrep(printer, codemod.indexPath, flowSettings.target);
 		return;
 	}
 

--- a/apps/cli/src/runCodemod.ts
+++ b/apps/cli/src/runCodemod.ts
@@ -251,7 +251,7 @@ export const runCodemod = async (
 	}
 
 	if (codemod.engine === "ast-grep") {
-		await runAstgrep(printer, codemod.yamlPath, flowSettings.target);
+		await runAstgrep(printer, codemod.indexPath, flowSettings.target);
 		return;
 	}
 

--- a/apps/cli/src/safeArgumentRecord.ts
+++ b/apps/cli/src/safeArgumentRecord.ts
@@ -5,7 +5,7 @@ export type SafeArgumentRecord = ArgumentRecord;
 
 export const buildSafeArgumentRecord = (
 	codemod: Codemod,
-	argumentRecord: Record<string, string | number | boolean>,
+	argumentRecord: SafeArgumentRecord,
 ): SafeArgumentRecord => {
 	if (codemod.source === "fileSystem") {
 		// no checks performed for local codemods
@@ -13,7 +13,7 @@ export const buildSafeArgumentRecord = (
 		return argumentRecord;
 	}
 
-	const safeArgumentRecord: { [x: string]: string | number | boolean } = {};
+	const safeArgumentRecord: SafeArgumentRecord = {};
 
 	codemod.arguments.forEach((descriptor) => {
 		if (!argumentRecord[descriptor.name]) {

--- a/apps/cli/src/schemata/argumentRecordSchema.ts
+++ b/apps/cli/src/schemata/argumentRecordSchema.ts
@@ -1,8 +1,16 @@
-import { type Output, boolean, number, record, string, union } from "valibot";
+import {
+	type Output,
+	array,
+	boolean,
+	number,
+	record,
+	string,
+	union,
+} from "valibot";
 
 export const argumentRecordSchema = record(
 	string(),
-	union([string(), number(), boolean()]),
+	union([string(), number(), boolean(), array(string())]),
 );
 
 export type ArgumentRecord = Output<typeof argumentRecordSchema>;

--- a/apps/cli/src/workerThreadManager.ts
+++ b/apps/cli/src/workerThreadManager.ts
@@ -33,7 +33,7 @@ export class WorkerThreadManager {
 		) => Promise<void>,
 		private readonly __pathGenerator: AsyncGenerator<string, void, void>,
 		codemodPath: string,
-		codemodEngine: "ts-morph" | "jscodeshift",
+		codemodEngine: "ts-morph" | "jscodeshift" | "ast-grep",
 		codemodSource: string,
 		disablePrettier: boolean,
 		safeArgumentRecord: SafeArgumentRecord,

--- a/packages/utilities/src/schemata/codemodConfigSchema.ts
+++ b/packages/utilities/src/schemata/codemodConfigSchema.ts
@@ -39,6 +39,10 @@ const getFirstValibotIssue = (issues: Issues) => {
 		}
 	}
 
+	if (!reasonableError) {
+		reasonableError = issues.at(0)?.message;
+	}
+
 	return reasonableError;
 };
 


### PR DESCRIPTION
This PR makes it so that ast-grep codemods are executed in the same fashion as our adopted engines. This allows proper messaging like `Processed X files out of Y` and in general makes the execution flow more predictable.