### PR TITLE
[Backend, Registry] chore: Removed null `useCaseCategory` values from filters

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemod-com/backend",
-	"version": "0.0.50",
+	"version": "0.0.51",
 	"scripts": {
 		"build": "node esbuild.config.js",
 		"start": "prisma -v && pnpm run db:migrate:apply && node build/index.js",

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -437,6 +437,11 @@ const publicRoutes: FastifyPluginCallback = (instance, _opts, done) => {
 				_count: {
 					_all: true,
 				},
+				where: {
+					useCaseCategory: {
+						not: null,
+					},
+				},
 			}),
 			prisma.codemod.groupBy({
 				by: ["author"],


### PR DESCRIPTION
- Removed  null `useCaseCategory` values from filters.
- Bumped version to 0.0.51