### PR TITLE
[CLI] fix: remove short arg, add arguments to the output (CDMD-3019)

### DIFF
--- a/apps/cli/src/apis.ts
+++ b/apps/cli/src/apis.ts
@@ -1,4 +1,4 @@
-import type { AllEngines } from "@codemod-com/utilities";
+import type { CodemodListReturn } from "@codemod-com/utilities";
 import Axios from "axios";
 import type FormData from "form-data";
 import { type Output, nullable, object, parse, string } from "valibot";
@@ -72,13 +72,6 @@ export const getCodemodDownloadURI = async (
 	return res.data.link;
 };
 
-export type CodemodListReturn = {
-	name: string;
-	author: string;
-	engine: AllEngines;
-	tags: string[];
-	verified: boolean;
-}[];
 export const getCodemodList = async (options?: {
 	accessToken?: string;
 	search?: string;

--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -49,14 +49,7 @@ export const executeMainThread = async () => {
 		.command(
 			["list", "ls", "search"],
 			"lists all the codemods & recipes in the public registry. can be used to search by name and tags",
-			(y) =>
-				buildUseJsonOption(buildUseCacheOption(y))
-					// prints only names consumed by VSCE
-					.option("short", {
-						type: "boolean",
-						description: "",
-						default: false,
-					}),
+			(y) => buildUseJsonOption(buildUseCacheOption(y)),
 		)
 		.command(
 			"learn",
@@ -174,7 +167,6 @@ export const executeMainThread = async () => {
 			await handleListNamesCommand({
 				printer,
 				search: searchTerm ?? undefined,
-				short: argv.short,
 			});
 		} catch (error) {
 			if (!(error instanceof Error)) {

--- a/apps/cli/src/handleListCliCommand.ts
+++ b/apps/cli/src/handleListCliCommand.ts
@@ -6,11 +6,10 @@ import { boldText, colorizeText } from "./utils.js";
 export const handleListNamesCommand = async (options: {
 	printer: PrinterBlueprint;
 	search?: string;
-	short?: boolean;
 }) => {
-	const { printer, search, short } = options;
+	const { printer, search } = options;
 
-	if (search && !short) {
+	if (search && printer.__jsonOutput) {
 		printer.printConsoleMessage(
 			"info",
 			boldText(colorizeText(`Searching for ${search}...`, "cyan")),
@@ -19,10 +18,11 @@ export const handleListNamesCommand = async (options: {
 
 	const configObjects = await getCodemodList(options);
 
-	// required for vsce
-	if (short) {
-		const names = configObjects.map(({ name }) => name);
-		printer.printOperationMessage({ kind: "names", names });
+	if (printer.__jsonOutput) {
+		printer.printOperationMessage({
+			kind: "codemodList",
+			codemods: configObjects,
+		});
 		return;
 	}
 

--- a/apps/cli/src/messages.ts
+++ b/apps/cli/src/messages.ts
@@ -1,3 +1,5 @@
+import { CodemodListReturn } from "./apis";
+
 export type RewriteMessage = Readonly<{
 	kind: "rewrite";
 	oldPath: string;
@@ -54,8 +56,8 @@ export type StatusUpdateMessage = Readonly<{
 }>;
 
 export type NamesMessage = Readonly<{
-	kind: "names";
-	names: ReadonlyArray<string>;
+	kind: "codemodList";
+	codemods: CodemodListReturn;
 }>;
 
 export type OperationMessage =

--- a/apps/cli/src/printer.ts
+++ b/apps/cli/src/printer.ts
@@ -4,6 +4,7 @@ import { boldText, colorizeText } from "./utils.js";
 import { WorkerThreadMessage } from "./workerThreadMessages.js";
 
 export type PrinterBlueprint = Readonly<{
+	__jsonOutput: boolean;
 	printMessage(
 		message: OperationMessage | (WorkerThreadMessage & { kind: "console" }),
 	): void;
@@ -12,7 +13,7 @@ export type PrinterBlueprint = Readonly<{
 }>;
 
 export class Printer implements PrinterBlueprint {
-	public constructor(private readonly __jsonOutput: boolean) {}
+	public constructor(public readonly __jsonOutput: boolean) {}
 
 	public printMessage(
 		message: OperationMessage | (WorkerThreadMessage & { kind: "console" }),

--- a/apps/vsce/src/components/engineService.ts
+++ b/apps/vsce/src/components/engineService.ts
@@ -304,7 +304,7 @@ export class EngineService {
 	public async __getCodemodNames(): Promise<ReadonlyArray<string>> {
 		const childProcess = spawn(
 			CODEMOD_ENGINE_NODE_COMMAND,
-			["list", "--json", "--short"],
+			["list", "--json"],
 			{
 				stdio: "pipe",
 				shell: true,

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -16,6 +16,7 @@ export {
 	type CodemodConfigInput,
 	type KnownEngines,
 } from "./schemata/codemodConfigSchema.js";
+export { type CodemodListReturn } from "./schemata/codemodListResponse.js";
 export {
 	JOB_KIND,
 	parseSurfaceAgnosticJob,

--- a/packages/utilities/src/schemata/codemodListResponse.ts
+++ b/packages/utilities/src/schemata/codemodListResponse.ts
@@ -1,0 +1,10 @@
+import { AllEngines, Arguments } from "./codemodConfigSchema.js";
+
+export type CodemodListReturn = {
+	name: string;
+	author: string;
+	engine: AllEngines;
+	tags: string[];
+	verified: boolean;
+	arguments: Arguments;
+}[];


### PR DESCRIPTION
Sample output:
```json
{
	"kind": "codemodList",
	"codemods": [
		{
			"name": "rename-data-to-data-legacy",
			"engine": "jscodeshift",
			"author": "alexbit-codemod",
			"tags": []
		},
		{
			"name": "replace-from-global-id-with-get-object-id",
			"engine": "jscodeshift",
			"author": "sibelius",
			"tags": []
		},
		{
			"name": "next-i18next/copy-keys",
			"engine": "filemod",
			"author": "codemod.com",
			"tags": []
		},
		{
			"name": "react/prop-types-typescript",
			"engine": "jscodeshift",
			"author": "codemod.com",
			"tags": ["react"]
		},
		{
			"name": "react-redux/0/add-state-type",
			"engine": "jscodeshift",
			"author": "codemod.com",
			"tags": []
		},
		{
			"name": "generate-url-patterns",
			"engine": "filemod",
			"author": "codemod.com",
			"tags": []
		}
	]
}
```