### PR TITLE
[CLI] feat: add check for required args (CDMD-3041)

### DIFF
--- a/apps/cli/src/buildCodemodOptions.ts
+++ b/apps/cli/src/buildCodemodOptions.ts
@@ -76,7 +76,7 @@ const extractMainScriptPath = async (
 export const buildSourcedCodemodOptions = async (
 	fs: IFs,
 	codemodOptions: CodemodSettings & { kind: "runSourced" },
-): Promise<Codemod & { source: "fileSystem" }> => {
+): Promise<Codemod> => {
 	const isDirectorySource = await fs.promises
 		.lstat(codemodOptions.source)
 		.then((pathStat) => pathStat.isDirectory());
@@ -87,7 +87,7 @@ export const buildSourcedCodemodOptions = async (
 		}
 
 		return {
-			source: "fileSystem" as const,
+			source: "standalone",
 			engine: codemodOptions.codemodEngine,
 			indexPath: codemodOptions.source,
 		};
@@ -124,8 +124,11 @@ export const buildSourcedCodemodOptions = async (
 	}
 
 	return {
-		source: "fileSystem" as const,
+		source: "package",
 		engine,
+		name: codemodConfig.name,
 		indexPath: mainScriptPath,
+		arguments: codemodConfig.arguments,
+		directoryPath: codemodOptions.source,
 	};
 };

--- a/apps/cli/src/buildSurfaceAgnosticJob.ts
+++ b/apps/cli/src/buildSurfaceAgnosticJob.ts
@@ -30,8 +30,8 @@ export const buildSurfaceAgnosticJob = (
 		return {
 			kind: JOB_KIND.COPY_FILE,
 			jobHashDigest,
-			sourceUri: command.oldPath,
-			targetUri: command.newPath,
+			sourcePathUri: command.oldPath,
+			targetPathUri: command.newPath,
 		};
 	}
 

--- a/apps/cli/src/codemod.ts
+++ b/apps/cli/src/codemod.ts
@@ -2,7 +2,7 @@ import { type Arguments, type KnownEngines } from "@codemod-com/utilities";
 
 export type Codemod =
 	| Readonly<{
-			source: "registry";
+			source: "package";
 			name: string;
 			include?: string[];
 			engine: "recipe";
@@ -11,7 +11,7 @@ export type Codemod =
 			arguments: Arguments;
 	  }>
 	| Readonly<{
-			source: "registry";
+			source: "package";
 			name: string;
 			include?: string[];
 			engine: KnownEngines;
@@ -20,7 +20,7 @@ export type Codemod =
 			arguments: Arguments;
 	  }>
 	| Readonly<{
-			source: "registry";
+			source: "package";
 			name: string;
 			include?: string[];
 			engine: "piranha";
@@ -28,7 +28,7 @@ export type Codemod =
 			arguments: Arguments;
 	  }>
 	| Readonly<{
-			source: "fileSystem";
+			source: "standalone";
 			include?: string[];
 			engine: KnownEngines;
 			indexPath: string;

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -12,7 +12,7 @@ import { TarService } from "./services/tarService.js";
 import { boldText, colorizeText } from "./utils.js";
 
 export type CodemodDownloaderBlueprint = Readonly<{
-	download(name: string): Promise<Codemod & { source: "registry" }>;
+	download(name: string): Promise<Codemod & { source: "package" }>;
 }>;
 
 export class CodemodDownloader implements CodemodDownloaderBlueprint {
@@ -26,7 +26,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 
 	public async download(
 		name: string,
-	): Promise<Codemod & { source: "registry" }> {
+	): Promise<Codemod & { source: "package" }> {
 		this.__printer.printConsoleMessage(
 			"info",
 			colorizeText(
@@ -84,7 +84,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 				const yamlPath = join(directoryPath, "rule.yaml");
 
 				return {
-					source: "registry",
+					source: "package",
 					name,
 					engine: config.engine,
 					include: config.include,
@@ -108,7 +108,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 			const rulesPath = join(directoryPath, "rules.toml");
 
 			return {
-				source: "registry",
+				source: "package",
 				name,
 				engine: config.engine,
 				include: config.include,
@@ -126,7 +126,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 			const indexPath = join(directoryPath, "index.cjs");
 
 			return {
-				source: "registry",
+				source: "package",
 				name,
 				engine: config.engine,
 				include: config.include,
@@ -145,7 +145,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 			}
 
 			return {
-				source: "registry",
+				source: "package",
 				name,
 				engine: config.engine,
 				include: config.include,

--- a/apps/cli/src/repositoryConfiguration.ts
+++ b/apps/cli/src/repositoryConfiguration.ts
@@ -13,12 +13,12 @@ import { argumentRecordSchema } from "./schemata/argumentRecordSchema.js";
 
 const preCommitCodemodSchema = union([
 	object({
-		source: literal("fileSystem"),
+		source: literal("standalone"),
 		path: string(),
 		arguments: optional(argumentRecordSchema, {}),
 	}),
 	object({
-		source: literal("registry"),
+		source: literal("package"),
 		name: string(),
 		arguments: optional(argumentRecordSchema, {}),
 	}),

--- a/apps/cli/src/runner.ts
+++ b/apps/cli/src/runner.ts
@@ -145,7 +145,7 @@ export class Runner {
 				const { preCommitCodemods } = await this._loadRepositoryConfiguration();
 
 				for (const preCommitCodemod of preCommitCodemods) {
-					if (preCommitCodemod.source === "registry") {
+					if (preCommitCodemod.source === "package") {
 						const codemod = await this._codemodDownloader.download(
 							preCommitCodemod.name,
 						);

--- a/apps/cli/src/safeArgumentRecord.ts
+++ b/apps/cli/src/safeArgumentRecord.ts
@@ -7,7 +7,7 @@ export const buildSafeArgumentRecord = (
 	codemod: Codemod,
 	argumentRecord: SafeArgumentRecord,
 ): SafeArgumentRecord => {
-	if (codemod.source === "fileSystem") {
+	if (codemod.source === "standalone") {
 		// no checks performed for local codemods
 		// b/c no source of truth for the arguments
 		return argumentRecord;
@@ -15,12 +15,17 @@ export const buildSafeArgumentRecord = (
 
 	const safeArgumentRecord: SafeArgumentRecord = {};
 
+	const missing: typeof codemod.arguments = [];
 	codemod.arguments.forEach((descriptor) => {
-		if (!argumentRecord[descriptor.name]) {
-			return;
-		}
-
 		const unsafeValue = argumentRecord[descriptor.name];
+
+		if (
+			descriptor.required &&
+			unsafeValue === undefined &&
+			descriptor.default === undefined
+		) {
+			missing.push(descriptor);
+		}
 
 		if (unsafeValue !== undefined && typeof unsafeValue === descriptor.kind) {
 			safeArgumentRecord[descriptor.name] = unsafeValue;
@@ -28,6 +33,15 @@ export const buildSafeArgumentRecord = (
 			safeArgumentRecord[descriptor.name] = descriptor.default;
 		}
 	});
+
+	if (missing.length > 0) {
+		const missingString = `- ${missing
+			.map(({ kind, name }) => `"${name}" (${kind})`)
+			.join("\n- ")}`;
+		throw new Error(
+			`Missing required arguments:\n\n${missingString}\n\nPlease provide them as "--<arg-name> <value>".`,
+		);
+	}
 
 	return safeArgumentRecord;
 };

--- a/apps/cli/src/schemata/codemodSettingsSchema.ts
+++ b/apps/cli/src/schemata/codemodSettingsSchema.ts
@@ -14,6 +14,7 @@ const codemodEngineSchema = union([
 	literal("repomod-engine"),
 	literal("filemod"),
 	literal("ts-morph"),
+	literal("ast-grep"),
 ]);
 
 export const codemodSettingsSchema = object({

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -38,6 +38,7 @@ describe("Runner", () => {
 
 		const ifs = createFsFromVolume(volume);
 		const printer: PrinterBlueprint = {
+			__jsonOutput: false,
 			printMessage: () => {},
 			printOperationMessage: () => {},
 			printConsoleMessage: () => {},
@@ -46,7 +47,7 @@ describe("Runner", () => {
 		const codemodDownloader: CodemodDownloaderBlueprint = {
 			download: async (name: string) => {
 				return {
-					source: "registry",
+					source: "package",
 					name,
 					engine: "jscodeshift",
 					indexPath: `/codemods/${name}/index.ts`,
@@ -71,7 +72,7 @@ describe("Runner", () => {
 			Promise.resolve<RepositoryConfiguration>({
 				preCommitCodemods: [
 					{
-						source: "registry",
+						source: "package",
 						name: "d",
 						arguments: {
 							argA: 1,
@@ -79,7 +80,7 @@ describe("Runner", () => {
 						},
 					},
 					{
-						source: "registry",
+						source: "package",
 						name: "e",
 						arguments: {
 							argA: 3,
@@ -103,6 +104,8 @@ describe("Runner", () => {
 			noCache: false,
 			json: true,
 			threads: 1,
+			skipInstall: false,
+			"skip-install": false,
 		};
 
 		const currentWorkingDirectory = "/";


### PR DESCRIPTION
- Adjusts logical distribution of sourced and registry codemod runs to "standalone" and "package", because we can infer data from codemod package if it's a valid codemod directory.
- Adds a check for required args and a corresponding message:
<img width="377" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/29e55b8f-6f76-431b-83da-fd7a5fe04c13">

