### PR TITLE
[CLI, Studio] fix: codemod package boilerplate for engines other than jscodeshift and ts-morph, fix tree-shaking in utils, improve success shutdown perf

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "codemod",
 	"author": "Codemod, Inc.",
-	"version": "0.9.7",
+	"version": "0.9.8",
 	"description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
 	"type": "module",
 	"exports": null,

--- a/apps/cli/src/handleInitCliCommand.ts
+++ b/apps/cli/src/handleInitCliCommand.ts
@@ -152,48 +152,46 @@ export const handleInitCliCommand = async (
 		),
 	);
 
-	printer.printConsoleMessage(
-		"info",
-		colorizeText(
-			`\nRun ${boldText("`codemod build`")} to build the codemod.`,
-			"cyan",
-		),
-	);
+	const isJsCodemod =
+		answers?.engine === "jscodeshift" ||
+		answers?.engine === "ts-morph" ||
+		answers?.engine === "filemod" ||
+		answers === null;
+	if (isJsCodemod) {
+		printer.printConsoleMessage(
+			"info",
+			colorizeText(
+				`\nRun ${boldText("`codemod build`")} to build the codemod.`,
+				"cyan",
+			),
+		);
+	}
 
-	printer.printConsoleMessage(
-		"info",
-		colorizeText(
-			`Run ${boldText(
-				`\`codemod --source ${codemodBaseDir}\``,
-			)} to run the codemod on current working directory (or specify a target using ${colorizeText(
-				"--target",
-				"orange",
-			)} option).`,
-			"cyan",
-		),
-	);
+	const howToRunText = `Run ${boldText(
+		`\`codemod --source ${codemodBaseDir}\``,
+	)} to run the codemod on current working directory (or specify a target using ${colorizeText(
+		"--target",
+		"orange",
+	)} option).`;
+	printer.printConsoleMessage("info", colorizeText(howToRunText, "cyan"));
 
-	printer.printConsoleMessage(
-		"info",
-		colorizeText(
-			`Run ${boldText(
-				"`codemod publish`",
-			)} to publish the codemod to the Codemod registry. ${colorizeText(
-				"NOTE: Your codemod has to be built using the build command",
-				"orange",
-			)}`,
-			"cyan",
-		),
-	);
+	let publishText = `Run ${boldText(
+		"`codemod publish`",
+	)} to publish the codemod to the Codemod registry.`;
+	if (isJsCodemod) {
+		publishText += colorizeText(
+			"NOTE: Your codemod has to be built using the build command",
+			"orange",
+		);
+	}
+	printer.printConsoleMessage("info", colorizeText(publishText, "cyan"));
 
+	const otherGuidelinesText = `For other guidelines, please visit our documentation at ${terminalLink(
+		boldText("https://docs.codemod.com"),
+		"https://docs.codemod.com",
+	)} or type ${boldText("`codemod --help`")}.`;
 	printer.printConsoleMessage(
 		"info",
-		colorizeText(
-			`For other guidelines, please visit our documentation at ${terminalLink(
-				boldText("https://docs.codemod.com"),
-				"https://docs.codemod.com",
-			)} or type ${boldText("`codemod --help`")}.`,
-			"cyan",
-		),
+		colorizeText(otherGuidelinesText, "cyan"),
 	);
 };

--- a/apps/cli/src/workerThreadManager.ts
+++ b/apps/cli/src/workerThreadManager.ts
@@ -109,6 +109,7 @@ export class WorkerThreadManager {
 		if (iteratorResult.done) {
 			this.__totalFileCount = this.__currentFileCount;
 
+			await this.__work();
 			return;
 		}
 
@@ -203,7 +204,7 @@ export class WorkerThreadManager {
 				this.__onPrinterMessage({
 					kind: "progress",
 					processedFileNumber: this.__processedFileNumber,
-					totalFileNumber: this.__currentFileCount - 1,
+					totalFileNumber: this.__currentFileCount,
 					processedFileName: resolve(workerThreadMessage.path),
 				});
 			}

--- a/apps/studio/src/pageComponents/main/DownloadZip.tsx
+++ b/apps/studio/src/pageComponents/main/DownloadZip.tsx
@@ -45,15 +45,13 @@ export const DownloadZip = () => {
 
 		const token = await getToken();
 
-		const humanCodemodName =
-			token !== null
-				? await getHumanCodemodName(modStore.internalContent, token)
-				: null;
+		const humanCodemodName = await getHumanCodemodName(
+			modStore.internalContent,
+			token,
+		);
 
 		await downloadProject({
-			name: humanCodemodName?.name ?? "codemod",
-			framework: humanCodemodName?.framework,
-			version: humanCodemodName?.version,
+			name: humanCodemodName,
 			codemodBody: modStore.internalContent,
 			cases: [
 				{
@@ -62,7 +60,7 @@ export const DownloadZip = () => {
 				},
 			],
 			engine,
-			user: session?.user,
+			username: session?.user.username ?? null,
 		});
 
 		setIsDownloading(false);
@@ -167,12 +165,12 @@ export function CopyTerminalCommands({ text }: { text: string }) {
 
 async function getHumanCodemodName(
 	codemod: string,
-	token: string,
-): Promise<{
-	name: string;
-	framework?: string;
-	version?: string;
-}> {
+	token: string | null,
+): Promise<string> {
+	if (token === null) {
+		return "codemod";
+	}
+
 	try {
 		if (!codemod) {
 			throw new Error("codemod content not found");
@@ -193,30 +191,10 @@ async function getHumanCodemodName(
 			}
 		}
 
-		const splitResult = codemodName.split("/");
-
-		if (splitResult.length === 1) {
-			return {
-				name: splitResult[0]!,
-			};
-		}
-
-		if (splitResult.length === 3) {
-			return {
-				framework: splitResult[0]!,
-				version: splitResult[1]!,
-				name: splitResult[2]!,
-			};
-		}
-
-		return {
-			name: "",
-		};
+		return codemodName;
 	} catch (error) {
 		console.error(error);
 
-		return {
-			name: "",
-		};
+		return "codemod";
 	}
 }

--- a/apps/studio/src/utils/download.ts
+++ b/apps/studio/src/utils/download.ts
@@ -2,7 +2,7 @@ import {
 	type ProjectDownloadInput,
 	getCodemodProjectFiles,
 	// Because webpack literally does not support tree-shaking
-} from "@codemod-com/utilities/dist/package-boilerplate";
+} from "@codemod-com/utilities/src/package-boilerplate";
 import initSwc, { transform } from "@swc/wasm-web";
 import JSZip from "jszip";
 

--- a/apps/studio/src/utils/download.ts
+++ b/apps/studio/src/utils/download.ts
@@ -1,7 +1,8 @@
 import {
 	type ProjectDownloadInput,
 	getCodemodProjectFiles,
-} from "@codemod-com/utilities";
+	// Because webpack literally does not support tree-shaking
+} from "@codemod-com/utilities/dist/package-boilerplate";
 import initSwc, { transform } from "@swc/wasm-web";
 import JSZip from "jszip";
 

--- a/apps/studio/src/utils/download.ts
+++ b/apps/studio/src/utils/download.ts
@@ -1,34 +1,35 @@
-// Tsconfig issue, requires to set to NodeNext, but this breaks other imports. TODO:
 import {
 	type ProjectDownloadInput,
 	getCodemodProjectFiles,
-	// @ts-ignore
-} from "@codemod-com/utilities/package-boilerplate";
+} from "@codemod-com/utilities";
 import initSwc, { transform } from "@swc/wasm-web";
 import JSZip from "jszip";
 
 export const downloadProject = async (input: ProjectDownloadInput) => {
 	const zip = new JSZip();
 
-	const files: Record<string, string> = getCodemodProjectFiles(input);
+	const files = getCodemodProjectFiles(input);
 	for (const [name, content] of Object.entries(files)) {
 		zip.file(name, content);
 	}
 
 	// Pre-built file
-	await initSwc();
-	// biome-ignore lint: typescript is broken
-	const { code: compiled } = await transform(files["src/index.ts"]!, {
-		minify: true,
-		module: { type: "commonjs" },
-		jsc: {
-			target: "es5",
-			loose: false,
-			parser: { syntax: "typescript", tsx: true },
-		},
-	});
-	zip.file("dist/index.cjs", `/*! @license\n${files.LICENSE}\n*/\n${compiled}`);
-
+	if ("src/index.ts" in files) {
+		await initSwc();
+		const { code: compiled } = await transform(files["src/index.ts"], {
+			minify: true,
+			module: { type: "commonjs" },
+			jsc: {
+				target: "es5",
+				loose: false,
+				parser: { syntax: "typescript", tsx: true },
+			},
+		});
+		zip.file(
+			"dist/index.cjs",
+			`/*! @license\n${files.LICENSE}\n*/\n${compiled}`,
+		);
+	}
 	const blob = await zip.generateAsync({ type: "blob" });
 
 	// download hack

--- a/packages/codemods/eslint/biome/migrate-rules/src/functions.ts
+++ b/packages/codemods/eslint/biome/migrate-rules/src/functions.ts
@@ -1,5 +1,5 @@
 import type { DataAPI } from "@codemod-com/filemod";
-import { isNeitherNullNorUndefined } from "@codemod-com/utilities/functions/validationMethods";
+import { isNeitherNullNorUndefined } from "@codemod-com/utilities";
 import type { Input } from "valibot";
 import type {
 	Configuration as BiomeConfig,

--- a/packages/codemods/eslint/biome/migrate-rules/src/index.ts
+++ b/packages/codemods/eslint/biome/migrate-rules/src/index.ts
@@ -1,6 +1,6 @@
 import { sep } from "node:path";
 import type { Filemod } from "@codemod-com/filemod";
-import { isNeitherNullNorUndefined } from "@codemod-com/utilities/functions/validationMethods";
+import { isNeitherNullNorUndefined } from "@codemod-com/utilities";
 import { type Input, is } from "valibot";
 import type { Configuration as BiomeConfig } from "../types/biome.js";
 import type { JSONSchemaForESLintConfigurationFiles as EslintConfig } from "../types/eslint.js";

--- a/packages/filemod/package.json
+++ b/packages/filemod/package.json
@@ -4,8 +4,8 @@
 	"version": "2.0.2",
 	"description": "The filemod by Codemod.com",
 	"type": "module",
-	"main": "./src/index.ts",
-	"exports": "./src/index.ts",
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"files": [
 		"./dist",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -5,12 +5,9 @@
 	"description": "The utilities used across Codemod.com packages",
 	"type": "module",
 	"main": "./dist/index.js",
-	"exports": {
-		".": "./src/index.ts",
-		"./package-boilerplate": "./src/package-boilerplate.ts",
-		"./functions/validationMethods": "./src/functions/validationMethods.ts"
-	},
+	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
+	"sideEffects": false,
 	"files": [
 		"./dist",
 		"!**/*.test.js",

--- a/packages/utilities/src/functions/validationMethods.ts
+++ b/packages/utilities/src/functions/validationMethods.ts
@@ -2,11 +2,11 @@ export const isNeitherNullNorUndefined = <T>(
 	t: NonNullable<T> | null | undefined,
 ): t is NonNullable<T> => t !== null && t !== undefined;
 
-export function assertsNeitherNullOrUndefined<T>(
+export const assertsNeitherNullOrUndefined = <T>(
 	value: T,
 	// eslint-disable-next-line @typescript-eslint/ban-types
-): asserts value is T & {} {
+): asserts value is T & {} => {
 	if (value === null || value === undefined) {
 		throw new Error("The value cannot be null or undefined");
 	}
-}
+};

--- a/packages/utilities/src/package-boilerplate.ts
+++ b/packages/utilities/src/package-boilerplate.ts
@@ -13,8 +13,9 @@ export interface ProjectDownloadInput {
 	tags?: string[];
 }
 
-export interface CodemodProjectOutput {
-	"src/index.ts": string;
+type FixtureInputFile = `__testfixtures__/fixture${number}.input.ts`;
+type FixtureOutputFile = `__testfixtures__/fixture${number}.output.ts`;
+export type CodemodProjectOutput = {
 	"test/test.ts": string;
 	LICENSE: string;
 	"README.md": string;
@@ -24,8 +25,9 @@ export interface CodemodProjectOutput {
 	".codemodrc.json": string;
 	".gitignore": string;
 
-	[key: string]: string;
-}
+	[key: FixtureInputFile]: string;
+	[key: FixtureOutputFile]: string;
+} & ({ "src/index.ts": string } | { "src/rule.yaml": string });
 
 const beautify = (input: string, options?: Parameters<typeof js>[1]) =>
 	js(input, { brace_style: "preserve-inline", indent_size: 2, ...options });
@@ -518,12 +520,30 @@ const testBody = ({
 };
 
 export const getCodemodProjectFiles = (input: ProjectDownloadInput) => {
+	let mainFileBoilerplate: string;
+	let filename: "src/index.ts" | "src/rule.yaml";
+	if (input.engine === "jscodeshift") {
+		mainFileBoilerplate = emptyJsCodeShiftBoilerplate;
+		filename = "src/index.ts";
+	} else if (input.engine === "tsmorph" || input.engine === "ts-morph") {
+		mainFileBoilerplate = emptyTsMorphBoilerplate;
+		filename = "src/index.ts";
+	} else if (input.engine === "filemod") {
+		mainFileBoilerplate = emptyFilemodBoilerplate;
+		filename = "src/index.ts";
+	} else if (input.engine === "ast-grep") {
+		mainFileBoilerplate = emptyAstGrepBoilerplate;
+		filename = "src/rule.yaml";
+	} else {
+		throw new Error(`Unknown engine: ${input.engine}`);
+	}
+
+	const mainFileContent = input.codemodBody
+		? beautify(input.codemodBody)
+		: mainFileBoilerplate;
+
 	const files: CodemodProjectOutput = {
-		"src/index.ts": input.codemodBody
-			? beautify(input.codemodBody)
-			: input.engine === "jscodeshift"
-			  ? emptyJsCodeShiftBoilerplate
-			  : emptyTsMorphBoilerplate,
+		[filename]: mainFileContent,
 		"test/test.ts": testBody(input),
 		LICENSE: license(input),
 		"README.md": readme(input),
@@ -532,7 +552,9 @@ export const getCodemodProjectFiles = (input: ProjectDownloadInput) => {
 		"tsconfig.json": tsconfigJson(),
 		".codemodrc.json": codemodRc(input),
 		".gitignore": "node_modules\ndist",
-	};
+		// Cast is needed because typescript apparently does not understand that filename is one of the required
+		// keys in the original type and throws error.
+	} as CodemodProjectOutput;
 
 	if (input.cases) {
 		for (let i = 0; i < input.cases.length; i++) {
@@ -570,7 +592,41 @@ export default function transformer(
 }
 `);
 
-export const emptyTsMorphBoilerplate = beautify(`
+export const emptyFilemodBoilerplate = beautify(`
+export const repomod: Filemod<Dependencies, Options> = {
+	includePatterns: ["**/*.ts"],
+	excludePatterns: ["**/node_modules/**"],
+	handleFile: async (api, path, options) => {
+		return [{ kind: "upsertFile", path }];
+	},
+	handleData: async (
+		api,
+		path,
+		data,
+	) => {
+    if (fileName.includes("change-me.ts")) {
+      return {
+        kind: "upsertData",
+        data: "hello world",
+        path,
+      };
+    }
+
+    return { kind: "noop" };
+  }
+}
+`);
+
+export const emptyAstGrepBoilerplate = beautify(`
+# To see how to write a rule, check out the documentation at: https://ast-grep.github.io/guide/rule-config.html
+id: test-ast-grep
+language: bash-exp
+rule:
+  pattern: DATA_DIR=$A
+fix: DATA_DIR="/new/path/to/resources"
+`);
+
+export const emptyTsMorphBoilerplate = beautify(`;
 import { type SourceFile, SyntaxKind } from "ts-morph";
 
 function shouldProcessFile(sourceFile: SourceFile): boolean {

--- a/packages/utilities/src/package-boilerplate.ts
+++ b/packages/utilities/src/package-boilerplate.ts
@@ -522,20 +522,27 @@ const testBody = ({
 export const getCodemodProjectFiles = (input: ProjectDownloadInput) => {
 	let mainFileBoilerplate: string;
 	let filename: "src/index.ts" | "src/rule.yaml";
-	if (input.engine === "jscodeshift") {
-		mainFileBoilerplate = emptyJsCodeShiftBoilerplate;
-		filename = "src/index.ts";
-	} else if (input.engine === "tsmorph" || input.engine === "ts-morph") {
-		mainFileBoilerplate = emptyTsMorphBoilerplate;
-		filename = "src/index.ts";
-	} else if (input.engine === "filemod") {
-		mainFileBoilerplate = emptyFilemodBoilerplate;
-		filename = "src/index.ts";
-	} else if (input.engine === "ast-grep") {
-		mainFileBoilerplate = emptyAstGrepBoilerplate;
-		filename = "src/rule.yaml";
-	} else {
-		throw new Error(`Unknown engine: ${input.engine}`);
+
+	switch (input.engine) {
+		case "jscodeshift":
+			mainFileBoilerplate = emptyJsCodeShiftBoilerplate;
+			filename = "src/index.ts";
+			break;
+		case "tsmorph":
+		case "ts-morph":
+			mainFileBoilerplate = emptyTsMorphBoilerplate;
+			filename = "src/index.ts";
+			break;
+		case "filemod":
+			mainFileBoilerplate = emptyFilemodBoilerplate;
+			filename = "src/index.ts";
+			break;
+		case "ast-grep":
+			mainFileBoilerplate = emptyAstGrepBoilerplate;
+			filename = "src/rule.yaml";
+			break;
+		default:
+			throw new Error(`Unknown engine: ${input.engine}`);
 	}
 
 	const mainFileContent = input.codemodBody

--- a/packages/utilities/src/package-boilerplate.ts
+++ b/packages/utilities/src/package-boilerplate.ts
@@ -1,6 +1,6 @@
 import * as changeCase from "change-case";
 import { js } from "js-beautify";
-import { KnownEngines } from "./index.js";
+import { KnownEngines } from "./schemata/codemodConfigSchema.js";
 
 export interface ProjectDownloadInput {
 	codemodBody?: string;


### PR DESCRIPTION
- proper `codemod init` boilerplate for filemod and ast-grep
- fix tree-shaking issue with utilities package
- fix types in studio
- only tell the user in the info after `codemod init` that he has to build it if it's a js codemod
- only pre-build the executable in studio downloaded bundle, if it's actually buildable (for future support of other engines in studio)
- improves shutdown time upon successful codemod run
- minor logic improvements (cleanup)