### PR TITLE
[CLI, Backend, Utils] feat: keychain implementation, post-install script (CDMD-2464)

### DIFF
--- a/apps/backend/esbuild.config.js
+++ b/apps/backend/esbuild.config.js
@@ -7,7 +7,7 @@ esbuild
 		minify: true,
 		platform: "node",
 		outfile: "build/index.js",
-		external: ["@prisma/client", "pg-hstore"],
+		external: ["@prisma/client", "pg-hstore", "@codemod-com/utilities"],
 		banner: {
 			js: `import { createRequire } from 'module';\nconst require = createRequire(import.meta.url);`,
 		},

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemod-com/backend",
-	"version": "0.0.59",
+	"version": "0.0.60",
 	"scripts": {
 		"build": "node esbuild.config.js",
 		"start": "prisma -v && pnpm run db:migrate:apply && node build/index.js",

--- a/apps/backend/src/publishHandler.ts
+++ b/apps/backend/src/publishHandler.ts
@@ -283,6 +283,7 @@ export const publishHandler =
 						tags: codemodRc.meta?.tags,
 						engine: codemodRc.engine,
 						applicability: codemodRc.applicability,
+						private: isPrivate,
 						arguments: codemodRc.arguments,
 						versions: {
 							create: codemodVersionEntry,

--- a/apps/cli/build.js
+++ b/apps/cli/build.js
@@ -11,6 +11,7 @@ build({
 	outfile: "./dist/index.cjs",
 	external: [
 		"esbuild",
+		"keytar",
 		// Workaround for @vue/compiler-sfc dynamic require
 		"mustache",
 		"templayed",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "codemod",
 	"author": "Codemod, Inc.",
-	"version": "0.10.2",
+	"version": "0.10.3",
 	"description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
 	"type": "module",
 	"exports": null,
@@ -83,7 +83,8 @@
 		"package": "pkg --compress GZip .",
 		"test": "TEST=1 vitest run",
 		"coverage": "TEST=1 vitest run --coverage",
-		"prepublishOnly": "pnpm run build"
+		"prepublishOnly": "pnpm run build",
+		"postinstall": "node ./scripts/postinstall.js"
 	},
 	"engines": {
 		"node": ">=18.5.0"
@@ -95,7 +96,8 @@
 	"files": [
 		"./dist/index.cjs",
 		"LICENSE",
-		"README.md"
+		"README.md",
+		"scripts/postinstall.js"
 	],
 	"publishConfig": {
 		"access": "public"
@@ -105,6 +107,7 @@
 		"exponential-backoff": "^3.1.1",
 		"inquirer": "^9.2.16",
 		"js-yaml": "4.1.0",
+		"keytar": "^7.9.0",
 		"ms": "^2.1.3",
 		"prettier": "^3.2.5",
 		"vue-sfc-descriptor-to-string": "^2.0.0"

--- a/apps/cli/scripts/postinstall.js
+++ b/apps/cli/scripts/postinstall.js
@@ -1,0 +1,11 @@
+const { exec } = require("child_process");
+
+exec("npm install -g esbuild --no-audit", (error, stdout, stderr) => {
+	if (error) {
+		console.error(`Codemod CLI postinstall error: ${error}`);
+		return;
+	}
+
+	console.log(`stdout: ${stdout}`);
+	console.error(`stderr: ${stderr}`);
+});

--- a/apps/cli/scripts/postinstall.js
+++ b/apps/cli/scripts/postinstall.js
@@ -1,11 +1,10 @@
-const { exec } = require("child_process");
+import { exec } from "child_process";
 
 exec("npm install -g esbuild --no-audit", (error, stdout, stderr) => {
 	if (error) {
-		console.error(`Codemod CLI postinstall error: ${error}`);
+		console.error(`codemod (postinstall error) - ${error}`);
 		return;
 	}
 
-	console.log(`stdout: ${stdout}`);
-	console.error(`stderr: ${stderr}`);
+	console.log("codemod - esbuild installed globally");
 });

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -9,7 +9,7 @@ import { FileDownloadServiceBlueprint } from "./fileDownloadService.js";
 import { handleListNamesCommand } from "./handleListCliCommand.js";
 import { PrinterBlueprint } from "./printer.js";
 import { TarService } from "./services/tarService.js";
-import { boldText, colorizeText, getTokenData } from "./utils.js";
+import { boldText, colorizeText, getCurrentUserData } from "./utils.js";
 
 export type CodemodDownloaderBlueprint = Readonly<{
 	download(name: string): Promise<Codemod & { source: "package" }>;
@@ -47,11 +47,8 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 
 		// download codemod
 		try {
-			const tokenData = await getTokenData();
-			const s3DownloadLink = await getCodemodDownloadURI(
-				name,
-				tokenData?.value,
-			);
+			const userData = await getCurrentUserData();
+			const s3DownloadLink = await getCodemodDownloadURI(name, userData?.token);
 			const localCodemodPath = join(directoryPath, "codemod.tar.gz");
 
 			const buffer = await this._fileDownloadService.download(

--- a/apps/cli/src/handleLoginCliCommand.ts
+++ b/apps/cli/src/handleLoginCliCommand.ts
@@ -1,7 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { backOff } from "exponential-backoff";
+import keytar from "keytar";
 import { confirmUserLoggedIn, generateUserLoginIntent } from "./apis.js";
 import type { PrinterBlueprint } from "./printer.js";
 import {
@@ -58,12 +56,7 @@ export const handleLoginCliCommand = async (printer: PrinterBlueprint) => {
 			},
 		);
 
-		const codemodDirectoryPath = join(homedir(), ".codemod");
-		const tokenTxtPath = join(codemodDirectoryPath, "token.txt");
-		// Ensure that `/.codemod.` folder exists
-		await mkdir(codemodDirectoryPath, { recursive: true });
-
-		await writeFile(tokenTxtPath, token, "utf-8");
+		await keytar.setPassword("codemod.com", "user-account", token);
 
 		stopLoading();
 		printer.printConsoleMessage(

--- a/apps/cli/src/handleLogoutCliCommand.ts
+++ b/apps/cli/src/handleLogoutCliCommand.ts
@@ -1,28 +1,20 @@
-import { readFile, unlink } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { revokeCLIToken } from "./apis.js";
 import type { PrinterBlueprint } from "./printer.js";
+import { getCurrentUserData } from "./utils.js";
 
 export const handleLogoutCliCommand = async (printer: PrinterBlueprint) => {
-	const tokenTxtPath = join(homedir(), ".codemod", "token.txt");
+	const userData = await getCurrentUserData();
 
-	let token: string;
-
-	try {
-		token = await readFile(tokenTxtPath, "utf-8");
-	} catch (err) {
+	if (userData === null) {
 		printer.printConsoleMessage("info", "You are already logged out.");
 		return;
 	}
 
 	try {
-		await revokeCLIToken(token.trim());
+		await revokeCLIToken(userData.token);
 	} catch (err) {
-		// Don't inform user if something went wrong, just delete the token file.
+		//
 	}
 
-	await unlink(tokenTxtPath);
-
-	printer.printConsoleMessage("info", "You have successfully logged out.");
+	printer.printConsoleMessage("info", "You have been successfully logged out.");
 };

--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -27,7 +27,7 @@ export const handlePublishCliCommand = async (
 
 	const {
 		user: { username },
-		token: { value: token },
+		token,
 	} = userData;
 	printer.printConsoleMessage(
 		"info",

--- a/apps/docs/codemod-registry/publishing-codemods.mdx
+++ b/apps/docs/codemod-registry/publishing-codemods.mdx
@@ -225,7 +225,7 @@ Once your codemod package is [compatible with Codemod platform](#required-codemo
   codemod login
   ```
   
-  When logging in, you will be redirected to your generated auth token on the web platform. Simply copy your token and enter it into your terminal to login with Codemod CLI.
+  You will be redirected to the Codemod platform login page. Upon successful login, our CLI will automatically authenticate you.
   </Step>
 
   <Step title="Build your local project">
@@ -239,6 +239,8 @@ Once your codemod package is [compatible with Codemod platform](#required-codemo
   ```bash
   npm install -g esbuild
   ```
+
+  <Note>We install `esbuild` globally for you upon installation of Codemod CLI, so you might not need to install it again.</Note>
   
   2. Build codemod:
   ```bash

--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,8 @@
 			".eslint*",
 			".next",
 			".vscode",
-			"build-ncc"
+			"build-ncc",
+			"generated"
 		],
 		"rules": {
 			"suspicious": {
@@ -110,7 +111,8 @@
 			"node_modules",
 			"build-ncc",
 			".next",
-			".vscode"
+			".vscode",
+			"generated"
 		]
 	},
 	"organizeImports": {

--- a/packages/filemod/src/unifiedFileSystem.test.ts
+++ b/packages/filemod/src/unifiedFileSystem.test.ts
@@ -1,7 +1,7 @@
 import { createHash } from "crypto";
 import { deepStrictEqual } from "node:assert";
 import { join } from "node:path";
-import { FileSystemAdapter, glob } from "fast-glob";
+import glob, { type FileSystemAdapter } from "fast-glob";
 import { Volume, createFsFromVolume } from "memfs";
 import { describe, it } from "vitest";
 import type {

--- a/packages/utilities/src/package-boilerplate.ts
+++ b/packages/utilities/src/package-boilerplate.ts
@@ -1,7 +1,8 @@
 import * as changeCase from "change-case";
-import { js } from "js-beautify";
+import jsBeautify from "js-beautify";
 import { KnownEngines } from "./schemata/codemodConfigSchema.js";
 
+const { js } = jsBeautify;
 export interface ProjectDownloadInput {
 	codemodBody?: string;
 	name: string;

--- a/packages/utilities/src/registry.ts
+++ b/packages/utilities/src/registry.ts
@@ -7,7 +7,7 @@ import type {
 	UnifiedEntry,
 } from "@codemod-com/filemod";
 import { UnifiedFileSystem } from "@codemod-com/filemod";
-import { FileSystemAdapter, glob } from "fast-glob";
+import glob, { type FileSystemAdapter } from "fast-glob";
 import type { API } from "jscodeshift";
 import jscodeshift from "jscodeshift";
 import { type IFs } from "memfs";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
+      keytar:
+        specifier: ^7.9.0
+        version: 7.9.0
       ms:
         specifier: ^2.1.3
         version: 2.1.3
@@ -17502,7 +17505,6 @@ packages:
       node-addon-api: 4.3.0
       prebuild-install: 7.1.1
     dev: false
-    optional: true
 
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -19318,7 +19320,6 @@ packages:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
     requiresBuild: true
     dev: false
-    optional: true
 
   /node-addon-api@7.1.0:
     resolution: {integrity: sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==}


### PR DESCRIPTION
- Adds keychain impl to support writing token to system encrypted storage
- adds post-install script to install esbuild globally for `codemod build` command to work
- fixes esm/cjs issues in utils package
- fixes backend build issue (hopefully)
- adjusts documentation just a bit
- allows changing privacy of the codemod