### PR TITLE
[CLI, Backend] feat: `codemod unpublish` (CDMD-2667)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemod-com/backend",
-	"version": "0.0.75",
+	"version": "0.0.76",
 	"scripts": {
 		"build": "node esbuild.config.js",
 		"start": "prisma -v && pnpm run db:migrate:apply && node build/index.js",

--- a/apps/backend/prisma/migrations/20240411123904_cascade_delete_versions/migration.sql
+++ b/apps/backend/prisma/migrations/20240411123904_cascade_delete_versions/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "CodemodVersion" DROP CONSTRAINT "CodemodVersion_codemodId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "CodemodVersion" ADD CONSTRAINT "CodemodVersion_codemodId_fkey" FOREIGN KEY ("codemodId") REFERENCES "Codemod"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -62,7 +62,7 @@ model CodemodVersion {
   s3UploadKey              String   @db.VarChar(255)
   tags                     String[] @default([])
   codemodId                Int
-  codemod                  Codemod  @relation(fields: [codemodId], references: [id])
+  codemod                  Codemod  @relation(fields: [codemodId], references: [id], onDelete: Cascade)
   createdAt                DateTime @default(now())
   updatedAt                DateTime @default(now()) @updatedAt
 }

--- a/apps/backend/src/publishHandler.test.ts
+++ b/apps/backend/src/publishHandler.test.ts
@@ -132,7 +132,6 @@ describe("/publish route", async () => {
 
 	await fastify.ready();
 
-	const areClerkKeysSpy = vi.spyOn(utils, "areClerkKeysSet");
 	const getCustomAccessTokenSpy = vi.spyOn(utils, "getCustomAccessToken");
 
 	const tarPackSpy = vi.spyOn(codemodComUtils, "tarPack");
@@ -181,7 +180,6 @@ describe("/publish route", async () => {
 			.expect("Content-Type", "application/json; charset=utf-8")
 			.expect(expectedCode);
 
-		expect(areClerkKeysSpy).toHaveBeenCalledOnce();
 		expect(getCustomAccessTokenSpy).toHaveBeenCalledOnce();
 
 		expect(tarPackSpy).toHaveBeenCalledOnce();
@@ -250,7 +248,6 @@ describe("/publish route", async () => {
 			.expect("Content-Type", "application/json; charset=utf-8")
 			.expect(expectedCode);
 
-		expect(areClerkKeysSpy).toHaveBeenCalledOnce();
 		expect(getCustomAccessTokenSpy).toHaveBeenCalledOnce();
 
 		expect(tarPackSpy).toHaveBeenCalledOnce();
@@ -315,7 +312,6 @@ describe("/publish route", async () => {
 			.expect("Content-Type", "application/json; charset=utf-8")
 			.expect(expectedCode);
 
-		expect(areClerkKeysSpy).toHaveBeenCalledOnce();
 		expect(getCustomAccessTokenSpy).toHaveBeenCalledOnce();
 
 		expect(response.body).toEqual({

--- a/apps/backend/src/publishHandler.ts
+++ b/apps/backend/src/publishHandler.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
-import { createClerkClient } from "@clerk/fastify";
 import {
 	CodemodConfig,
 	codemodNameRegex,
@@ -8,356 +7,347 @@ import {
 	parseCodemodConfig,
 	tarPack,
 } from "@codemod-com/utilities";
-import { RouteHandlerMethod } from "fastify";
 import * as semver from "semver";
 import { z } from "zod";
 import { CodemodVersionCreateInputSchema } from "../prisma/generated/zod";
+import { CustomHandler } from "./customHandler";
 import { prisma } from "./db/prisma.js";
-import { Environment } from "./schemata/env.js";
-import { CLAIM_PUBLISHING, TokenService } from "./services/tokenService.js";
-import { areClerkKeysSet, getCustomAccessToken } from "./util.js";
+import { CLAIM_PUBLISHING } from "./services/tokenService.js";
+import { getCustomAccessToken } from "./util.js";
 
-export const publishHandler =
-	(environment: Environment, tokenService: TokenService): RouteHandlerMethod =>
-	async (request, reply) => {
-		try {
-			if (!areClerkKeysSet(environment)) {
-				throw new Error("This endpoint requires auth configuration.");
-			}
+export const publishHandler: CustomHandler<Record<string, never>> = async ({
+	environment,
+	tokenService,
+	clerkClient,
+	request,
+	reply,
+}) => {
+	try {
+		if (clerkClient === null) {
+			throw new Error("This endpoint requires auth configuration.");
+		}
 
-			const accessToken = getCustomAccessToken(environment, request.headers);
+		const accessToken = getCustomAccessToken(environment, request.headers);
 
-			if (accessToken === null) {
-				return reply
-					.code(401)
-					.send({ error: "Access token is not present", success: false });
-			}
+		if (accessToken === null) {
+			return reply
+				.code(401)
+				.send({ error: "Access token is not present", success: false });
+		}
 
-			const userId = await tokenService.findUserIdMetadataFromToken(
-				accessToken,
-				BigInt(Date.now()),
-				CLAIM_PUBLISHING,
-			);
+		const userId = await tokenService.findUserIdMetadataFromToken(
+			accessToken,
+			BigInt(Date.now()),
+			CLAIM_PUBLISHING,
+		);
 
-			if (userId === null) {
-				return reply
-					.code(401)
-					.send({ error: "User id was not found", success: false });
-			}
+		if (userId === null) {
+			return reply
+				.code(401)
+				.send({ error: "User id was not found", success: false });
+		}
 
-			const clerkClient = createClerkClient({
-				publishableKey: environment.CLERK_PUBLISH_KEY,
-				secretKey: environment.CLERK_SECRET_KEY,
-				jwtKey: environment.CLERK_JWT_KEY,
-			});
+		const { username } = await clerkClient.users.getUser(userId);
+		const orgs = await clerkClient.users.getOrganizationMembershipList({
+			userId,
+		});
 
-			const { username } = await clerkClient.users.getUser(userId);
-			const orgs = await clerkClient.users.getOrganizationMembershipList({
-				userId,
-			});
+		if (username === null) {
+			throw new Error("The username of the current user does not exist");
+		}
 
-			if (username === null) {
-				throw new Error("The username of the current user does not exist");
-			}
+		let codemodRcBuffer: Buffer | null = null;
+		let codemodRc: CodemodConfig | null = null;
+		let mainFileBuffer: Buffer | null = null;
+		let mainFileName: string | null = null;
+		let descriptionMdBuffer: Buffer | null = null;
 
-			let codemodRcBuffer: Buffer | null = null;
-			let codemodRc: CodemodConfig | null = null;
-			let mainFileBuffer: Buffer | null = null;
-			let mainFileName: string | null = null;
-			let descriptionMdBuffer: Buffer | null = null;
+		for await (const multipartFile of request.files()) {
+			const buffer = await multipartFile.toBuffer();
 
-			for await (const multipartFile of request.files()) {
-				const buffer = await multipartFile.toBuffer();
+			if (multipartFile.fieldname === ".codemodrc.json") {
+				codemodRcBuffer = buffer;
 
-				if (multipartFile.fieldname === ".codemodrc.json") {
-					codemodRcBuffer = buffer;
+				const codemodRcData = JSON.parse(codemodRcBuffer.toString("utf8"));
 
-					const codemodRcData = JSON.parse(codemodRcBuffer.toString("utf8"));
+				codemodRc = parseCodemodConfig(codemodRcData);
 
-					codemodRc = parseCodemodConfig(codemodRcData);
-
-					if (codemodRc.engine === "recipe") {
-						if (codemodRc.names.length < 2) {
-							throw new Error(
-								`The "names" field in .codemodrc.json must contain at least two names for a recipe codemod.`,
-							);
-						}
-
-						for (const name of codemodRc.names) {
-							if (!codemodNameRegex.test(name)) {
-								throw new Error(
-									`Each entry in the "names" field in .codemodrc.json must only contain allowed characters (a-z, A-Z, 0-9, _, /, @ or -)`,
-								);
-							}
-						}
-					} else if (!codemodNameRegex.test(codemodRc.name)) {
+				if (codemodRc.engine === "recipe") {
+					if (codemodRc.names.length < 2) {
 						throw new Error(
-							`The "name" field in .codemodrc.json must only contain allowed characters (a-z, A-Z, 0-9, _, /, @ or -)`,
+							`The "names" field in .codemodrc.json must contain at least two names for a recipe codemod.`,
 						);
 					}
-				}
 
-				if (
-					["index.cjs", "rules.toml", "rule.yaml"].includes(
-						multipartFile.fieldname,
-					)
-				) {
-					mainFileName = multipartFile.fieldname;
-					mainFileBuffer = buffer;
+					for (const name of codemodRc.names) {
+						if (!codemodNameRegex.test(name)) {
+							throw new Error(
+								`Each entry in the "names" field in .codemodrc.json must only contain allowed characters (a-z, A-Z, 0-9, _, /, @ or -)`,
+							);
+						}
+					}
+				} else if (!codemodNameRegex.test(codemodRc.name)) {
+					throw new Error(
+						`The "name" field in .codemodrc.json must only contain allowed characters (a-z, A-Z, 0-9, _, /, @ or -)`,
+					);
 				}
-
-				if (multipartFile.fieldname === "description.md") {
-					descriptionMdBuffer = buffer;
-				}
-			}
-
-			if (!isNeitherNullNorUndefined(codemodRcBuffer) || !codemodRc) {
-				return reply.code(400).send({
-					error: "No .codemodrc.json file was provided",
-					success: false,
-				});
 			}
 
 			if (
-				codemodRc.engine !== "recipe" &&
-				(!isNeitherNullNorUndefined(mainFileBuffer) ||
-					!isNeitherNullNorUndefined(mainFileName))
+				["index.cjs", "rules.toml", "rule.yaml"].includes(
+					multipartFile.fieldname,
+				)
 			) {
-				return reply.code(400).send({
-					error: "No main file was provided",
+				mainFileName = multipartFile.fieldname;
+				mainFileBuffer = buffer;
+			}
+
+			if (multipartFile.fieldname === "description.md") {
+				descriptionMdBuffer = buffer;
+			}
+		}
+
+		if (!isNeitherNullNorUndefined(codemodRcBuffer) || !codemodRc) {
+			return reply.code(400).send({
+				error: "No .codemodrc.json file was provided",
+				success: false,
+			});
+		}
+
+		if (
+			codemodRc.engine !== "recipe" &&
+			(!isNeitherNullNorUndefined(mainFileBuffer) ||
+				!isNeitherNullNorUndefined(mainFileName))
+		) {
+			return reply.code(400).send({
+				error: "No main file was provided",
+				success: false,
+			});
+		}
+
+		const { name, version } = codemodRc;
+
+		let namespace: string | null = null;
+		if (name.startsWith("@") && name.includes("/")) {
+			namespace = name.split("/").at(0)?.slice(1)!;
+
+			const allowedNamespaces = [
+				username,
+				...orgs.map((org) => org.organization.slug),
+			].filter(isNeitherNullNorUndefined);
+
+			if (!allowedNamespaces.includes(namespace)) {
+				return reply.code(403).send({
+					error: `You are not allowed to publish under namespace "${namespace}"`,
 					success: false,
 				});
 			}
+		}
 
-			const { name, version } = codemodRc;
+		// private flag in codemodrc as primary source of truth,
+		// fallback is to check if publishing under a namespace. if yes - set to private by default
+		const isPrivate = codemodRc.private ?? !!namespace;
 
-			let namespace: string | null = null;
-			if (name.startsWith("@") && name.includes("/")) {
-				namespace = name.split("/").at(0)?.slice(1)!;
+		if (!isNeitherNullNorUndefined(name)) {
+			return reply.code(400).send({
+				error: "Codemod name was not provided in codemodrc",
+				success: false,
+			});
+		}
 
-				const allowedNamespaces = [
-					username,
-					...orgs.map((org) => org.organization.slug),
-				].filter(isNeitherNullNorUndefined);
+		if (!isNeitherNullNorUndefined(version)) {
+			return reply.code(400).send({
+				error: "Codemod version was not provided in codemodrc",
+				success: false,
+			});
+		}
 
-				if (!allowedNamespaces.includes(namespace)) {
-					return reply.code(403).send({
-						error: `You are not allowed to publish under namespace "${namespace}"`,
-						success: false,
-					});
-				}
-			}
+		const buffers = [
+			{
+				name: ".codemodrc.json",
+				data: codemodRcBuffer,
+			},
+		];
 
-			// private flag in codemodrc as primary source of truth,
-			// fallback is to check if publishing under a namespace. if yes - set to private by default
-			const isPrivate = codemodRc.private ?? !!namespace;
+		if (mainFileBuffer && mainFileName) {
+			buffers.push({
+				name: mainFileName,
+				data: mainFileBuffer,
+			});
+		}
 
-			if (!isNeitherNullNorUndefined(name)) {
-				return reply.code(400).send({
-					error: "Codemod name was not provided in codemodrc",
-					success: false,
-				});
-			}
+		if (isNeitherNullNorUndefined(descriptionMdBuffer)) {
+			buffers.push({
+				name: "description.md",
+				data: descriptionMdBuffer,
+			});
+		}
 
-			if (!isNeitherNullNorUndefined(version)) {
-				return reply.code(400).send({
-					error: "Codemod version was not provided in codemodrc",
-					success: false,
-				});
-			}
-
-			const buffers = [
-				{
-					name: ".codemodrc.json",
-					data: codemodRcBuffer,
+		const latestVersion = await prisma.codemodVersion.findFirst({
+			where: {
+				codemod: {
+					name,
 				},
-			];
+			},
+			orderBy: {
+				version: "desc",
+			},
+			take: 1,
+		});
 
-			if (mainFileBuffer && mainFileName) {
-				buffers.push({
-					name: mainFileName,
-					data: mainFileBuffer,
-				});
+		if (latestVersion !== null && !semver.gt(version, latestVersion.version)) {
+			return reply.code(400).send({
+				error: `Codemod ${name} version ${version} is lower than the latest published or the same as the latest published version: ${latestVersion.version}`,
+				success: false,
+			});
+		}
+
+		const archive = await tarPack(buffers);
+
+		const hashDigest = createHash("ripemd160").update(name).digest("base64url");
+
+		const REQUEST_TIMEOUT = 5000;
+
+		const bucket =
+			isPrivate && namespace ? "codemod-private" : "codemod-public";
+
+		const uploadKeyParts = [hashDigest, version, "codemod.tar.gz"];
+		if (isPrivate && namespace) {
+			uploadKeyParts.unshift(namespace);
+		}
+		uploadKeyParts.unshift("codemod-registry");
+		const uploadKey = uploadKeyParts.join("/");
+
+		const codemodVersionEntry: Omit<
+			z.infer<typeof CodemodVersionCreateInputSchema>,
+			"codemod"
+		> = {
+			version,
+			s3Bucket: bucket,
+			s3UploadKey: uploadKey,
+			engine: codemodRc.engine,
+			sourceRepo: codemodRc.meta?.git,
+			shortDescription: descriptionMdBuffer?.toString("utf-8"),
+			vsCodeLink: `vscode://codemod.codemod-vscode-extension/showCodemod?chd=${hashDigest}`,
+			applicability: codemodRc.applicability,
+			tags: codemodRc.meta?.tags,
+			arguments: codemodRc.arguments,
+		};
+
+		let isVerified = namespace === "codemod.com" || namespace === "codemod-com";
+		let author = namespace;
+		if (!author) {
+			if (isVerified || environment.VERIFIED_PUBLISHERS.includes(username)) {
+				isVerified = true;
+				author = "codemod.com";
+			} else {
+				author = username;
 			}
+		}
 
-			if (isNeitherNullNorUndefined(descriptionMdBuffer)) {
-				buffers.push({
-					name: "description.md",
-					data: descriptionMdBuffer,
-				});
-			}
+		try {
+			await prisma.codemod.upsert({
+				where: {
+					name,
+				},
+				create: {
+					slug: name
+						.replaceAll("@", "")
+						.split(/[\/ ,.-]/)
+						.join("-"),
+					name,
+					shortDescription: descriptionMdBuffer?.toString("utf-8"),
+					tags: codemodRc.meta?.tags,
+					engine: codemodRc.engine,
+					applicability: codemodRc.applicability,
+					verified: isVerified,
+					private: isPrivate,
+					author,
+					arguments: codemodRc.arguments,
+					versions: {
+						create: codemodVersionEntry,
+					},
+				},
+				update: {
+					shortDescription: descriptionMdBuffer?.toString("utf-8"),
+					tags: codemodRc.meta?.tags,
+					engine: codemodRc.engine,
+					applicability: codemodRc.applicability,
+					private: isPrivate,
+					arguments: codemodRc.arguments,
+					versions: {
+						create: codemodVersionEntry,
+					},
+				},
+			});
+		} catch (err) {
+			console.error("Failed writing codemod to the database:", err);
+			return reply.code(500).send({
+				error: `Failed writing codemod to the database: ${
+					(err as Error).message
+				}`,
+				success: false,
+			});
+		}
 
-			const latestVersion = await prisma.codemodVersion.findFirst({
+		try {
+			const client = new S3Client({
+				credentials: {
+					accessKeyId: environment.AWS_ACCESS_KEY_ID ?? "",
+					secretAccessKey: environment.AWS_SECRET_ACCESS_KEY ?? "",
+				},
+				region: "us-west-1",
+			});
+
+			await client.send(
+				new PutObjectCommand({
+					Bucket: bucket,
+					Key: uploadKey,
+					Body: archive,
+				}),
+				{
+					requestTimeout: REQUEST_TIMEOUT,
+				},
+			);
+		} catch (err) {
+			console.error("Failed uploading codemod to S3:", err);
+			await prisma.codemodVersion.deleteMany({
+				where: {
+					codemod: {
+						name,
+					},
+					version,
+				},
+			});
+
+			const otherVersions = await prisma.codemodVersion.findMany({
 				where: {
 					codemod: {
 						name,
 					},
 				},
-				orderBy: {
-					version: "desc",
-				},
-				take: 1,
 			});
 
-			if (
-				latestVersion !== null &&
-				!semver.gt(version, latestVersion.version)
-			) {
-				return reply.code(400).send({
-					error: `Codemod ${name} version ${version} is lower than the latest published or the same as the latest published version: ${latestVersion.version}`,
-					success: false,
-				});
-			}
-
-			const archive = await tarPack(buffers);
-
-			const hashDigest = createHash("ripemd160")
-				.update(name)
-				.digest("base64url");
-
-			const REQUEST_TIMEOUT = 5000;
-
-			const bucket =
-				isPrivate && namespace ? "codemod-private" : "codemod-public";
-
-			const uploadKeyParts = [hashDigest, version, "codemod.tar.gz"];
-			if (isPrivate && namespace) {
-				uploadKeyParts.unshift(namespace);
-			}
-			uploadKeyParts.unshift("codemod-registry");
-			const uploadKey = uploadKeyParts.join("/");
-
-			const codemodVersionEntry: Omit<
-				z.infer<typeof CodemodVersionCreateInputSchema>,
-				"codemod"
-			> = {
-				version,
-				s3Bucket: bucket,
-				s3UploadKey: uploadKey,
-				engine: codemodRc.engine,
-				sourceRepo: codemodRc.meta?.git,
-				shortDescription: descriptionMdBuffer?.toString("utf-8"),
-				vsCodeLink: `vscode://codemod.codemod-vscode-extension/showCodemod?chd=${hashDigest}`,
-				applicability: codemodRc.applicability,
-				tags: codemodRc.meta?.tags,
-				arguments: codemodRc.arguments,
-			};
-
-			let isVerified =
-				namespace === "codemod.com" || namespace === "codemod-com";
-			let author = namespace;
-			if (!author) {
-				if (isVerified || environment.VERIFIED_PUBLISHERS.includes(username)) {
-					isVerified = true;
-					author = "codemod.com";
-				} else {
-					author = username;
-				}
-			}
-
-			try {
-				await prisma.codemod.upsert({
+			if (otherVersions.length === 0) {
+				await prisma.codemod.delete({
 					where: {
 						name,
 					},
-					create: {
-						slug: name
-							.replaceAll("@", "")
-							.split(/[\/ ,.-]/)
-							.join("-"),
-						name,
-						shortDescription: descriptionMdBuffer?.toString("utf-8"),
-						tags: codemodRc.meta?.tags,
-						engine: codemodRc.engine,
-						applicability: codemodRc.applicability,
-						verified: isVerified,
-						private: isPrivate,
-						author,
-						arguments: codemodRc.arguments,
-						versions: {
-							create: codemodVersionEntry,
-						},
-					},
-					update: {
-						shortDescription: descriptionMdBuffer?.toString("utf-8"),
-						tags: codemodRc.meta?.tags,
-						engine: codemodRc.engine,
-						applicability: codemodRc.applicability,
-						private: isPrivate,
-						arguments: codemodRc.arguments,
-						versions: {
-							create: codemodVersionEntry,
-						},
-					},
-				});
-			} catch (err) {
-				console.error("Failed writing codemod to the database:", err);
-				return reply.code(500).send({
-					error: `Failed writing codemod to the database: ${
-						(err as Error).message
-					}`,
-					success: false,
 				});
 			}
 
-			try {
-				const client = new S3Client({
-					credentials: {
-						accessKeyId: environment.AWS_ACCESS_KEY_ID ?? "",
-						secretAccessKey: environment.AWS_SECRET_ACCESS_KEY ?? "",
-					},
-					region: "us-west-1",
-				});
-
-				await client.send(
-					new PutObjectCommand({
-						Bucket: bucket,
-						Key: uploadKey,
-						Body: archive,
-					}),
-					{
-						requestTimeout: REQUEST_TIMEOUT,
-					},
-				);
-			} catch (err) {
-				console.error("Failed uploading codemod to S3:", err);
-				await prisma.codemodVersion.deleteMany({
-					where: {
-						codemod: {
-							name,
-						},
-						version,
-					},
-				});
-
-				const otherVersions = await prisma.codemodVersion.findMany({
-					where: {
-						codemod: {
-							name,
-						},
-					},
-				});
-
-				if (otherVersions.length === 0) {
-					await prisma.codemod.delete({
-						where: {
-							name,
-						},
-					});
-				}
-
-				return reply.code(500).send({
-					error: `Failed publishing to S3: ${(err as Error).message}`,
-					success: false,
-				});
-			}
-
-			return reply.code(200).send({ success: true });
-		} catch (err) {
-			console.error(err);
 			return reply.code(500).send({
-				error: `Failed calling publish endpoint: ${(err as Error).message}`,
+				error: `Failed publishing to S3: ${(err as Error).message}`,
 				success: false,
 			});
 		}
-	};
+
+		return reply.code(200).send({ success: true });
+	} catch (err) {
+		console.error(err);
+		return reply.code(500).send({
+			error: `Failed calling publish endpoint: ${(err as Error).message}`,
+			success: false,
+		});
+	}
+};

--- a/apps/backend/src/schemata/schema.ts
+++ b/apps/backend/src/schemata/schema.ts
@@ -131,3 +131,10 @@ export const getCodeDiffSchema = object({
 
 export const parseGetCodeDiffParams = (input: unknown) =>
 	parse(getCodeDiffSchema, input);
+
+export const unpublishBodySchema = object({
+	name: string(),
+});
+
+export const parseUnpublishBody = (input: unknown) =>
+	parse(unpublishBodySchema, input);

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -57,6 +57,7 @@ import {
 	TokenRevokedError,
 	TokenService,
 } from "./services/tokenService.js";
+import { unpublishHandler } from "./unpublishHandler.js";
 import { areClerkKeysSet, environment, getCustomAccessToken } from "./util.js";
 
 const getSourceControlProvider = (
@@ -695,7 +696,9 @@ const protectedRoutes: FastifyPluginCallback = (instance, _opts, done) => {
 		return;
 	});
 
-	instance.post("/publish", publishHandler(environment, tokenService));
+	instance.post("/publish", wrapRequestHandlerMethod(publishHandler));
+
+	instance.post("/unpublish", wrapRequestHandlerMethod(unpublishHandler));
 
 	instance.get(
 		"/sourceControl/:provider/user/repos",

--- a/apps/backend/src/unpublishHandler.ts
+++ b/apps/backend/src/unpublishHandler.ts
@@ -1,0 +1,175 @@
+import { DeleteObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+	extractLibNameAndVersion,
+	isNeitherNullNorUndefined,
+} from "@codemod-com/utilities";
+import { CustomHandler } from "./customHandler";
+import { prisma } from "./db/prisma.js";
+import { parseUnpublishBody } from "./schemata/schema";
+import { CLAIM_PUBLISHING } from "./services/tokenService.js";
+import { getCustomAccessToken } from "./util.js";
+
+export const unpublishHandler: CustomHandler<Record<string, never>> = async ({
+	environment,
+	tokenService,
+	clerkClient,
+	request,
+	reply,
+}) => {
+	try {
+		if (clerkClient === null) {
+			throw new Error("This endpoint requires auth configuration.");
+		}
+
+		const accessToken = getCustomAccessToken(environment, request.headers);
+
+		if (accessToken === null) {
+			return reply
+				.code(401)
+				.send({ error: "Access token is not present", success: false });
+		}
+
+		const userId = await tokenService.findUserIdMetadataFromToken(
+			accessToken,
+			BigInt(Date.now()),
+			CLAIM_PUBLISHING,
+		);
+
+		if (userId === null) {
+			return reply
+				.code(401)
+				.send({ error: "User id was not found", success: false });
+		}
+
+		const { username } = await clerkClient.users.getUser(userId);
+		const orgs = await clerkClient.users.getOrganizationMembershipList({
+			userId,
+		});
+
+		if (username === null) {
+			throw new Error("The username of the current user does not exist");
+		}
+
+		const { name } = parseUnpublishBody(request.body);
+		const { libName: codemodName, version } = extractLibNameAndVersion(name);
+
+		const codemod = await prisma.codemod.findFirst({
+			where: { name: codemodName },
+			include: {
+				versions: {
+					select: {
+						id: true,
+						version: true,
+						s3Bucket: true,
+						s3UploadKey: true,
+					},
+				},
+			},
+		});
+
+		if (codemod === null) {
+			return reply.code(400).send({
+				error: `Codemod ${codemodName} not found in the Registry`,
+				success: false,
+			});
+		}
+
+		const allowedNamespaces = [
+			username,
+			...orgs.map((org) => org.organization.slug),
+		].filter(isNeitherNullNorUndefined);
+
+		if (!allowedNamespaces.includes(codemod.author)) {
+			return reply.code(403).send({
+				error: "You are not allowed to perform this operation",
+				success: false,
+			});
+		}
+
+		let client: S3Client;
+		try {
+			client = new S3Client({
+				credentials: {
+					accessKeyId: environment.AWS_ACCESS_KEY_ID ?? "",
+					secretAccessKey: environment.AWS_SECRET_ACCESS_KEY ?? "",
+				},
+				region: "us-west-1",
+			});
+		} catch (err) {
+			console.error("Failed instantiating S3 client:", err);
+
+			return reply.code(500).send();
+		}
+
+		const REQUEST_TIMEOUT = 5000;
+
+		if (version === null) {
+			await Promise.all(
+				codemod.versions.map(async (version) => {
+					try {
+						await client.send(
+							new DeleteObjectCommand({
+								Bucket: version.s3Bucket,
+								Key: version.s3UploadKey,
+							}),
+							{ requestTimeout: REQUEST_TIMEOUT },
+						);
+					} catch (err) {
+						console.error(
+							`Failed deleting object from S3 (${version.s3UploadKey}) :`,
+							err,
+						);
+					}
+				}),
+			);
+
+			await prisma.codemod.delete({
+				where: { name: codemodName },
+			});
+
+			return reply.code(200).send({ success: true });
+		}
+
+		const versionToRemove = codemod.versions.find((v) => v.version === version);
+
+		if (!versionToRemove) {
+			return reply.code(400).send({
+				error: `Version ${version} not found in the Registry`,
+				success: false,
+			});
+		}
+
+		try {
+			await client.send(
+				new DeleteObjectCommand({
+					Bucket: versionToRemove.s3Bucket,
+					Key: versionToRemove.s3UploadKey,
+				}),
+				{ requestTimeout: REQUEST_TIMEOUT },
+			);
+		} catch (err) {
+			console.error(
+				`Failed deleting object from S3 (${versionToRemove.s3UploadKey}) :`,
+				err,
+			);
+		}
+
+		if (codemod.versions.length === 1) {
+			await prisma.codemod.delete({
+				where: { name: codemodName },
+			});
+		} else {
+			await prisma.codemodVersion.delete({
+				where: { id: versionToRemove.id },
+			});
+		}
+
+		return reply.code(200).send({ success: true });
+	} catch (err) {
+		console.error(err);
+		return reply.code(500).send({
+			error: `Failed calling unpublish endpoint: ${(err as Error).message}`,
+			success: false,
+		});
+	}
+};

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "codemod",
 	"author": "Codemod, Inc.",
-	"version": "0.10.5",
+	"version": "0.10.6",
 	"description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
 	"type": "module",
 	"exports": null,

--- a/apps/cli/src/apis.ts
+++ b/apps/cli/src/apis.ts
@@ -37,6 +37,22 @@ export const publish = async (
 	});
 };
 
+export const unpublish = async (
+	accessToken: string,
+	name: string,
+): Promise<void> => {
+	await Axios.post(
+		"https://backend.codemod.com/unpublish",
+		{ name },
+		{
+			headers: {
+				[X_CODEMOD_ACCESS_TOKEN]: accessToken,
+			},
+			timeout: 10000,
+		},
+	);
+};
+
 export const revokeCLIToken = async (accessToken: string): Promise<void> => {
 	await Axios.delete("https://backend.codemod.com/revokeToken", {
 		headers: {
@@ -69,7 +85,7 @@ export const getCodemodDownloadURI = async (
 
 export const getCodemodList = async (options?: {
 	accessToken?: string;
-	search?: string;
+	search?: string | null;
 }): Promise<CodemodListResponse> => {
 	const { accessToken, search } = options ?? {};
 

--- a/apps/cli/src/handleInstallDependencies.ts
+++ b/apps/cli/src/handleInstallDependencies.ts
@@ -135,7 +135,7 @@ export const handleInstallDependencies = async (options: {
 		const toInstall: string[] = [];
 		const toDelete: string[] = [];
 		for (const dep of deps) {
-			const { libName, version } = extractLibNameAndVersion(dep);
+			const { libName } = extractLibNameAndVersion(dep);
 
 			if (libName?.startsWith("-")) {
 				toDelete.push(libName.slice(1));

--- a/apps/cli/src/handleListCliCommand.ts
+++ b/apps/cli/src/handleListCliCommand.ts
@@ -3,12 +3,10 @@ import { getCodemodList } from "./apis.js";
 import type { PrinterBlueprint } from "./printer.js";
 import { boldText, colorizeText } from "./utils.js";
 
-export const handleListNamesCommand = async (options: {
-	printer: PrinterBlueprint;
-	search?: string;
-}) => {
-	const { printer, search } = options;
-
+export const handleListNamesCommand = async (
+	printer: PrinterBlueprint,
+	search: string | null,
+) => {
 	let stopSearchingMessage = () => {};
 	if (search && !printer.__jsonOutput) {
 		stopSearchingMessage = printer.withLoaderMessage((loader) =>
@@ -21,7 +19,7 @@ export const handleListNamesCommand = async (options: {
 		);
 	}
 
-	const configObjects = await getCodemodList(options);
+	const configObjects = await getCodemodList({ search });
 	stopSearchingMessage();
 
 	if (printer.__jsonOutput) {

--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -21,7 +21,7 @@ export const handlePublishCliCommand = async (
 
 	if (userData === null) {
 		throw new Error(
-			"The GitHub username of the current user is not known. Contact Codemod.com.",
+			"To be able to publish to Codemod Registry, please log in first.",
 		);
 	}
 
@@ -29,12 +29,6 @@ export const handlePublishCliCommand = async (
 		user: { username },
 		token,
 	} = userData;
-	printer.printConsoleMessage(
-		"info",
-		`You are logged in as '${boldText(
-			username,
-		)}' and able to publish a codemod to our public registry.`,
-	);
 
 	const formData = new FormData();
 
@@ -184,7 +178,7 @@ export const handlePublishCliCommand = async (
 				"vertical-dots",
 			)} Publishing the codemod using name from ${boldText(
 				".codemodrc.json",
-			)} file: ${boldText(`"${codemodRc.name}"`)}`,
+			)} file: "${boldText(codemodRc.name)}"`,
 			"cyan",
 		),
 	);

--- a/apps/cli/src/handleUnpublishCliCommand.ts
+++ b/apps/cli/src/handleUnpublishCliCommand.ts
@@ -1,0 +1,73 @@
+import {
+	extractLibNameAndVersion,
+	isNeitherNullNorUndefined,
+} from "@codemod-com/utilities";
+import { AxiosError } from "axios";
+import { unpublish } from "./apis.js";
+import type { PrinterBlueprint } from "./printer.js";
+import { boldText, colorizeText, getCurrentUserData } from "./utils.js";
+
+export const handleUnpublishCliCommand = async (
+	printer: PrinterBlueprint,
+	name: string,
+	force?: boolean,
+) => {
+	const userData = await getCurrentUserData();
+
+	if (userData === null) {
+		throw new Error(
+			"To be able to unpublish your codemods, please log in first.",
+		);
+	}
+
+	const { libName: codemodName, version } = extractLibNameAndVersion(name);
+
+	if (
+		isNeitherNullNorUndefined(codemodName) &&
+		!isNeitherNullNorUndefined(version) &&
+		!force
+	) {
+		throw new Error(
+			`Please provide the version of the codemod you want to unpublish. If you want to unpublish all versions, use the "${colorizeText(
+				"--force (-f)",
+				"orange",
+			)}" flag.`,
+		);
+	}
+
+	const {
+		user: { username },
+		token,
+	} = userData;
+
+	const stopLoading = printer.withLoaderMessage((loader) =>
+		colorizeText(
+			`${loader.get("vertical-dots")} Unpublishing ${boldText(`"${name}"`)}`,
+			"cyan",
+		),
+	);
+
+	try {
+		await unpublish(token, name);
+		stopLoading();
+	} catch (error) {
+		stopLoading();
+		const message =
+			error instanceof AxiosError ? error.response?.data.error : String(error);
+		const errorMessage = `${boldText(
+			`Could not unpublish the "${name}" codemod`,
+		)}:\n${message}`;
+		printer.printOperationMessage({ kind: "error", message: errorMessage });
+		return;
+	}
+
+	printer.printConsoleMessage(
+		"info",
+		boldText(
+			colorizeText(
+				`Codemod "${boldText(name)}" was successfully unpublished.`,
+				"cyan",
+			),
+		),
+	);
+};

--- a/packages/utilities/src/schemata/codemodConfigSchema.ts
+++ b/packages/utilities/src/schemata/codemodConfigSchema.ts
@@ -48,10 +48,10 @@ const getFirstValibotIssue = (issues: Issues) => {
 
 export const extractLibNameAndVersion = (val: string) => {
 	const parts = val.split("@");
-	let version: string | undefined;
+	let version: string | null = null;
 	let libName: string;
 	if (parts.length > 1) {
-		version = parts.pop();
+		version = parts.pop() ?? null;
 		libName = parts.join("@");
 	} else {
 		libName = val;
@@ -193,7 +193,7 @@ const configJsonBaseSchema = object({
 					}
 
 					// e.g. vitest. This would install the latest version
-					if (!version) {
+					if (version === null) {
 						return true;
 					}
 


### PR DESCRIPTION
- `codemod unpublish` logic CLI + backend impl
- eliminate code repetition in `executeMainThread` file
- Delete codemod versions with cascade behaviour, create migration for that
- Bump versions
- Minor refactoring to correspond to our development practices