### PR TITLE
[CLI, Backend] fix: empty prints, wrong total files, dedicated loader library, fix codemod list sorting

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemod-com/backend",
-	"version": "0.0.76",
+	"version": "0.0.77",
 	"scripts": {
 		"build": "node esbuild.config.js",
 		"start": "prisma -v && pnpm run db:migrate:apply && node build/index.js",

--- a/apps/backend/src/handlers/getCodemodsListHandler.ts
+++ b/apps/backend/src/handlers/getCodemodsListHandler.ts
@@ -1,9 +1,9 @@
+import type { CodemodListResponse } from "@codemod-com/utilities";
 import type { CustomHandler } from "../customHandler.js";
 import { parseListCodemodsQuery } from "../schemata/schema.js";
-import type { ShortCodemodInfo } from "../services/codemodService.js";
 import { ALL_CLAIMS } from "../services/tokenService.js";
 
-export const getCodemodsListHandler: CustomHandler<ShortCodemodInfo[]> =
+export const getCodemodsListHandler: CustomHandler<CodemodListResponse> =
 	async ({
 		getAccessToken,
 		tokenService,

--- a/apps/backend/src/services/codemodService.ts
+++ b/apps/backend/src/services/codemodService.ts
@@ -1,10 +1,8 @@
-import { isNeitherNullNorUndefined } from "@codemod-com/utilities";
-import type {
-	Codemod,
-	CodemodVersion,
-	Prisma,
-	PrismaClient,
-} from "@prisma/client";
+import {
+	type CodemodListResponse,
+	isNeitherNullNorUndefined,
+} from "@codemod-com/utilities";
+import type { Codemod, Prisma, PrismaClient } from "@prisma/client";
 import Fuse from "fuse.js";
 
 const parseAndFilterQueryParams = (query: string | string[] | undefined) => {
@@ -27,9 +25,6 @@ type LongCodemodIndoDetails = {
 };
 
 export type LongCodemodInfo = Codemod & LongCodemodIndoDetails;
-
-export type ShortCodemodInfo = Pick<Codemod, "name" | "author" | "slug"> &
-	Pick<CodemodVersion, "engine">;
 
 export type Filter = {
 	id: string;
@@ -299,8 +294,8 @@ export class CodemodService {
 		userId: string | null,
 		search: string | undefined,
 		allowedNamespaces?: string[],
-	): Promise<ShortCodemodInfo[]> {
-		let codemodData: ShortCodemodInfo[];
+	): Promise<CodemodListResponse> {
+		let codemodData: CodemodListResponse;
 
 		if (isNeitherNullNorUndefined(userId)) {
 			const dbCodemods = await this.prisma.codemod.findMany({
@@ -378,6 +373,10 @@ export class CodemodService {
 			});
 
 			codemodData = fuse.search(search).map((res) => res.item);
+		} else {
+			codemodData = codemodData.sort((a, b) =>
+				a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+			);
 		}
 
 		return codemodData;

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -109,6 +109,7 @@
 		"js-yaml": "4.1.0",
 		"keytar": "^7.9.0",
 		"ms": "^2.1.3",
+		"ora": "^8.0.1",
 		"prettier": "^3.2.5",
 		"vue-sfc-descriptor-to-string": "^2.0.0"
 	}

--- a/apps/cli/src/buildCodemodOptions.ts
+++ b/apps/cli/src/buildCodemodOptions.ts
@@ -15,7 +15,7 @@ import type { Codemod } from "./codemod.js";
 import type { CodemodDownloaderBlueprint } from "./downloadCodemod.js";
 import type { PrinterBlueprint } from "./printer.js";
 import type { CodemodSettings } from "./schemata/codemodSettingsSchema.js";
-import { boldText, colorizeText } from "./utils.js";
+import { boldText } from "./utils.js";
 
 const extractEngine = async (
 	fs: IFs,
@@ -130,15 +130,6 @@ export const buildSourcedCodemodOptions = async (
 			codemodConfig as CodemodConfig & { engine: "recipe" }
 		).names;
 
-		const stopLoading = printer.withLoaderMessage((loader) =>
-			colorizeText(
-				`${loader.get("vertical-dots")}  Downloading ${
-					subCodemodsNames.length
-				} recipe codemods...`,
-				"cyan",
-			),
-		);
-
 		const codemods = await Promise.all(
 			subCodemodsNames.map(async (subCodemodName) => {
 				const localMachinePath = resolve(codemodOptions.source, subCodemodName);
@@ -153,9 +144,8 @@ export const buildSourcedCodemodOptions = async (
 				}
 
 				try {
-					return await codemodDownloader.download(subCodemodName, true);
+					return await codemodDownloader.download(subCodemodName);
 				} catch (error) {
-					stopLoading();
 					if (error instanceof AxiosError) {
 						if (
 							error.response?.status === 400 &&
@@ -173,8 +163,6 @@ export const buildSourcedCodemodOptions = async (
 				}
 			}),
 		);
-
-		stopLoading();
 
 		return {
 			source: "package",

--- a/apps/cli/src/executeWorkerThread.ts
+++ b/apps/cli/src/executeWorkerThread.ts
@@ -40,7 +40,6 @@ const messageHandler = async (m: unknown) => {
 		try {
 			message = decodeMainThreadMessage(m);
 		} catch (err) {
-			console.dir(err, { depth: 10 });
 			throw new Error(`Failed to decode message: ${String(err)}`);
 		}
 

--- a/apps/cli/src/handleInstallDependencies.ts
+++ b/apps/cli/src/handleInstallDependencies.ts
@@ -278,11 +278,8 @@ export const handleInstallDependencies = async (options: {
 		}
 
 		if (install === "root") {
-			const stopRemovalMessageLoading = printer.withLoaderMessage((loader) =>
-				colorizeText(
-					`${loader.get("vertical-dots")}  Removing: ${toDelete.join(", ")}...`,
-					"cyan",
-				),
+			const stopRemovalSpinner = printer.withLoaderMessage(
+				colorizeText(`Removing: ${toDelete.join(", ")}...`, "cyan"),
 			);
 			try {
 				await execPromise(
@@ -292,34 +289,24 @@ export const handleInstallDependencies = async (options: {
 			} catch (err) {
 				// Fails when no dep
 			}
-			stopRemovalMessageLoading();
+			stopRemovalSpinner.succeed();
 
-			const stopInstallationMessageLoading = printer.withLoaderMessage(
-				(loader) =>
-					colorizeText(
-						`${loader.get("vertical-dots")}  Installing: ${toInstall.join(
-							", ",
-						)}...`,
-						"cyan",
-					),
+			const stopInstallationSpinner = printer.withLoaderMessage(
+				colorizeText(`Installing: ${toInstall.join(", ")}...`, "cyan"),
 			);
 			try {
 				await execPromise(
 					`${detectedPackageManager} ${addRootCmd} ${toInstall.join(" ")}`,
 					{ cwd: rootPath },
 				);
-				stopInstallationMessageLoading();
+				stopInstallationSpinner.succeed();
 			} catch (err) {
-				stopInstallationMessageLoading();
+				stopInstallationSpinner.fail();
 				throw err;
-				//
 			}
 		} else {
-			const stopRemovalMessageLoading = printer.withLoaderMessage((loader) =>
-				colorizeText(
-					`${loader.get("vertical-dots")}  Removing: ${toDelete.join(", ")}...`,
-					"cyan",
-				),
+			const stopRemovalSpinner = printer.withLoaderMessage(
+				colorizeText(`Removing: ${toDelete.join(", ")}...`, "cyan"),
 			);
 			for (const packageJsonPath of affectedProjectsPackageJsons) {
 				const packageJsonContent = await readFile(packageJsonPath, {
@@ -359,17 +346,11 @@ export const handleInstallDependencies = async (options: {
 					// Fails when no dep
 				}
 
-				stopRemovalMessageLoading();
+				stopRemovalSpinner.succeed();
 			}
 
-			const stopInstallationMessageLoading = printer.withLoaderMessage(
-				(loader) =>
-					colorizeText(
-						`${loader.get("vertical-dots")}  Installing: ${toInstall.join(
-							", ",
-						)}...`,
-						"cyan",
-					),
+			const stopInstallationSpinner = printer.withLoaderMessage(
+				colorizeText(`Installing: ${toInstall.join(", ")}...`, "cyan"),
 			);
 			for (const packageJsonPath of affectedProjectsPackageJsons) {
 				if (packageJsonPath === rootPackageJsonPath) {
@@ -390,9 +371,9 @@ export const handleInstallDependencies = async (options: {
 						`${detectedPackageManager} ${addCmd} ${toInstall.join(" ")}`,
 						{ cwd: dirname(packageJsonPath) },
 					);
-					stopInstallationMessageLoading();
+					stopInstallationSpinner.succeed();
 				} catch (err) {
-					stopInstallationMessageLoading();
+					stopInstallationSpinner.fail();
 					throw err;
 					//
 				}

--- a/apps/cli/src/handleListCliCommand.ts
+++ b/apps/cli/src/handleListCliCommand.ts
@@ -7,20 +7,15 @@ export const handleListNamesCommand = async (
 	printer: PrinterBlueprint,
 	search: string | null,
 ) => {
-	let stopSearchingMessage = () => {};
+	let spinner: ReturnType<typeof printer.withLoaderMessage> | null = null;
 	if (search && !printer.__jsonOutput) {
-		stopSearchingMessage = printer.withLoaderMessage((loader) =>
-			colorizeText(
-				`${loader.get("vertical-dots")}  Searching for ${boldText(
-					`"${search}"`,
-				)}`,
-				"cyan",
-			),
+		spinner = printer.withLoaderMessage(
+			colorizeText(`Searching for ${boldText(`"${search}"`)}`, "cyan"),
 		);
 	}
 
 	const configObjects = await getCodemodList({ search });
-	stopSearchingMessage();
+	spinner?.stop();
 
 	if (printer.__jsonOutput) {
 		printer.printOperationMessage({
@@ -30,11 +25,11 @@ export const handleListNamesCommand = async (
 		return;
 	}
 
-	let prettified = configObjects
-		.map(({ name, verified: _, tags: tagsArray, engine, author }) => {
+	let prettified = configObjects.map(
+		({ name, verified: _, tags: tagsArray, engine, author }) => {
 			const tags = tagsArray.join(", ");
 
-			if (search && (name === search || tags.includes(search))) {
+			if (search && (name === search || tagsArray.includes(search))) {
 				return {
 					name: boldText(colorizeText(name, "cyan")),
 					tags: boldText(colorizeText(tags, "cyan")),
@@ -49,8 +44,8 @@ export const handleListNamesCommand = async (
 				engine,
 				author,
 			};
-		})
-		.sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+		},
+	);
 
 	if (search) {
 		prettified = prettified.slice(0, 10);

--- a/apps/cli/src/handleLoginCliCommand.ts
+++ b/apps/cli/src/handleLoginCliCommand.ts
@@ -40,11 +40,8 @@ export const handleLoginCliCommand = async (printer: PrinterBlueprint) => {
 	const { id: sessionId, iv: initVector } = await generateUserLoginIntent();
 
 	routeUserToStudioForLogin(printer, sessionId, initVector);
-	const stopLoading = printer.withLoaderMessage((loader) =>
-		colorizeText(
-			`${loader.get("vertical-dots")} Redirecting to Codemod sign-in page`,
-			"cyan",
-		),
+	const spinner = printer.withLoaderMessage(
+		colorizeText("Redirecting to Codemod sign-in page", "cyan"),
 	);
 	try {
 		const token = await backOff(
@@ -58,13 +55,13 @@ export const handleLoginCliCommand = async (printer: PrinterBlueprint) => {
 
 		await keytar.setPassword("codemod.com", "user-account", token);
 
-		stopLoading();
+		spinner.succeed();
 		printer.printConsoleMessage(
 			"info",
 			colorizeText(boldText("You are successfully logged in."), "cyan"),
 		);
 	} catch (e) {
-		stopLoading();
+		spinner.fail();
 		throw new Error("Could not validate access token. Please try again.");
 	}
 };

--- a/apps/cli/src/handlePublishCliCommand.ts
+++ b/apps/cli/src/handlePublishCliCommand.ts
@@ -130,11 +130,9 @@ export const handlePublishCliCommand = async (
 
 		let mainFilePath = await locateMainFile();
 		if (mainFilePath === undefined) {
-			const stopLoading = printer.withLoaderMessage((loader) =>
+			const spinner = printer.withLoaderMessage(
 				colorizeText(
-					`${loader.get(
-						"vertical-dots",
-					)} Could not find the main file of the codemod. Trying to build...`,
+					"Could not find the main file of the codemod. Trying to build...",
 					"cyan",
 				),
 			);
@@ -145,13 +143,13 @@ export const handlePublishCliCommand = async (
 				await execPromise("codemod build", { cwd: source });
 
 				mainFilePath = await locateMainFile();
-				stopLoading();
+				spinner.succeed();
 				// Likely meaning that the "codemod build" command succeeded, but the file was still not found in output
 				if (mainFilePath === undefined) {
 					throw new Error();
 				}
 			} catch (error) {
-				stopLoading();
+				spinner.fail();
 				throw new Error(
 					`Could not find the main file of the codemod. ${errorOnMissing}`,
 				);
@@ -172,11 +170,9 @@ export const handlePublishCliCommand = async (
 		//
 	}
 
-	const stopLoading = printer.withLoaderMessage((loader) =>
+	const publishSpinner = printer.withLoaderMessage(
 		colorizeText(
-			`${loader.get(
-				"vertical-dots",
-			)} Publishing the codemod using name from ${boldText(
+			`Publishing the codemod using name from ${boldText(
 				".codemodrc.json",
 			)} file: "${boldText(codemodRc.name)}"`,
 			"cyan",
@@ -185,9 +181,9 @@ export const handlePublishCliCommand = async (
 
 	try {
 		await publish(token, formData);
-		stopLoading();
+		publishSpinner.succeed();
 	} catch (error) {
-		stopLoading();
+		publishSpinner.fail();
 		const message =
 			error instanceof AxiosError ? error.response?.data.error : String(error);
 		const errorMessage = `${boldText(

--- a/apps/cli/src/handleUnpublishCliCommand.ts
+++ b/apps/cli/src/handleUnpublishCliCommand.ts
@@ -40,18 +40,15 @@ export const handleUnpublishCliCommand = async (
 		token,
 	} = userData;
 
-	const stopLoading = printer.withLoaderMessage((loader) =>
-		colorizeText(
-			`${loader.get("vertical-dots")} Unpublishing ${boldText(`"${name}"`)}`,
-			"cyan",
-		),
+	const spinner = printer.withLoaderMessage(
+		colorizeText(`Unpublishing ${boldText(`"${name}"`)}`, "cyan"),
 	);
 
 	try {
 		await unpublish(token, name);
-		stopLoading();
+		spinner.succeed();
 	} catch (error) {
-		stopLoading();
+		spinner.fail();
 		const message =
 			error instanceof AxiosError ? error.response?.data.error : String(error);
 		const errorMessage = `${boldText(

--- a/apps/cli/src/messages.ts
+++ b/apps/cli/src/messages.ts
@@ -1,4 +1,4 @@
-import type { CodemodListReturn } from "@codemod-com/utilities";
+import type { CodemodListResponse } from "@codemod-com/utilities";
 
 export type RewriteMessage = Readonly<{
 	kind: "rewrite";
@@ -14,7 +14,7 @@ export type ProgressMessage = Readonly<{
 	kind: "progress";
 	recipeCodemodName?: string;
 	processedFileNumber: number;
-	processedFileName: string;
+	processedFileName: string | null;
 	totalFileNumber: number;
 }>;
 
@@ -59,7 +59,7 @@ export type StatusUpdateMessage = Readonly<{
 
 export type NamesMessage = Readonly<{
 	kind: "codemodList";
-	codemods: CodemodListReturn;
+	codemods: CodemodListResponse;
 }>;
 
 export type OperationMessage =

--- a/apps/cli/src/printer.ts
+++ b/apps/cli/src/printer.ts
@@ -67,13 +67,15 @@ export class Printer implements PrinterBlueprint {
 
 		if (message.kind === "progress") {
 			console.log(
-				`%sProcessed %d files out of %d: ${boldText("%s")}`,
+				"%sProcessed %d files out of %d%s",
 				message.recipeCodemodName
 					? boldText(`(${message.recipeCodemodName})  `)
 					: "",
 				message.processedFileNumber,
 				message.totalFileNumber,
-				message.processedFileName,
+				message.processedFileName
+					? `: ${boldText(message.processedFileName)}`
+					: "",
 			);
 		}
 	}

--- a/apps/cli/src/printer.ts
+++ b/apps/cli/src/printer.ts
@@ -1,3 +1,4 @@
+import ora, { type Ora } from "ora";
 import type { OperationMessage } from "./messages.js";
 import type { ConsoleKind } from "./schemata/consoleKindSchema.js";
 import { boldText, colorizeText } from "./utils.js";
@@ -11,11 +12,7 @@ export type PrinterBlueprint = Readonly<{
 	printOperationMessage(message: OperationMessage): void;
 	printConsoleMessage(kind: ConsoleKind, message: string): void;
 
-	withLoaderMessage(
-		cb: (loader: {
-			get: (type: "dots" | "whirl" | "vertical-dots") => string;
-		}) => string,
-	): () => void;
+	withLoaderMessage(text: string): Ora;
 }>;
 
 export class Printer implements PrinterBlueprint {
@@ -97,44 +94,7 @@ export class Printer implements PrinterBlueprint {
 		console[kind](message);
 	}
 
-	public withLoaderMessage(
-		cb: (loader: {
-			get: (type: "dots" | "whirl" | "vertical-dots") => string;
-		}) => string,
-	): () => void {
-		let messageUpdateFunction: () => void;
-
-		const loader = {
-			get: (type: "dots" | "whirl" | "vertical-dots"): string => {
-				const id = `loader_${Object.keys(this.loaderStates).length}`;
-				this.loaderStates[id] = { type, index: 0 };
-				return id; // Placeholder for the loader, to be replaced in the message
-			},
-		};
-
-		(async () => {
-			const messageTemplate = cb(loader); // Get the message template with loader placeholders
-			messageUpdateFunction = () => {
-				let message = messageTemplate;
-				for (const [id, loaderState] of Object.entries(this.loaderStates)) {
-					const symbols = this.loaderSymbols[loaderState.type];
-					message = message.replace(id, symbols[loaderState.index]!);
-					loaderState.index = (loaderState.index + 1) % symbols.length; // Update for next tick
-				}
-				// Example output handling; replace with actual output logic
-				process.stdout.write(`\r${message}`); // Output the updated message
-			};
-
-			this.loadingTimer = setInterval(messageUpdateFunction, 250);
-		})();
-
-		return () => {
-			if (this.loadingTimer) {
-				clearInterval(this.loadingTimer);
-				this.loadingTimer = null;
-			}
-			this.loaderStates = {}; // Reset loader states
-			process.stdout.write("\n");
-		};
+	public withLoaderMessage(text: string): Ora {
+		return ora({ text, color: "cyan" }).start();
 	}
 }

--- a/apps/cli/src/runCodemod.ts
+++ b/apps/cli/src/runCodemod.ts
@@ -380,10 +380,9 @@ export const runCodemod = async (
 						kind: "progress",
 						processedFileNumber: message.processedFileNumber,
 						totalFileNumber: message.totalFileNumber,
-						processedFileName: relative(
-							flowSettings.target,
-							message.processedFileName,
-						),
+						processedFileName: message.processedFileName
+							? relative(flowSettings.target, message.processedFileName)
+							: null,
 					});
 				} else {
 					onPrinterMessage(message);

--- a/apps/cli/src/workerThreadManager.ts
+++ b/apps/cli/src/workerThreadManager.ts
@@ -129,14 +129,10 @@ export class WorkerThreadManager {
 		const filePath = this.__filePaths.shift();
 
 		if (filePath === undefined) {
-			// console.log("this.__totalFileCount", this.__totalFileCount);
-			// console.log("this.__idleWorkerIds.length", this.__idleWorkerIds.length);
-			// console.log("this.__workerCount", this.__workerCount);
 			if (
 				this.__totalFileCount !== null &&
 				this.__idleWorkerIds.length === this.__workerCount
 			) {
-				console.log("there");
 				this.__finished = true;
 
 				this.__finish();
@@ -187,32 +183,29 @@ export class WorkerThreadManager {
 				return;
 			}
 
+			++this.__processedFileNumber;
 			if (workerThreadMessage.kind === "commands") {
 				const commands = workerThreadMessage.commands as FormattedFileCommand[];
 
 				for (const command of commands) {
 					await this.__onCommand(command);
 				}
-				return;
-			}
-
-			if (workerThreadMessage.kind === "error") {
+			} else if (workerThreadMessage.kind === "error") {
 				this.__onPrinterMessage({
 					kind: "error",
 					message: workerThreadMessage.message,
 					path: workerThreadMessage.path,
 				});
-				return;
 			}
 
-			if (workerThreadMessage.path) {
-				this.__onPrinterMessage({
-					kind: "progress",
-					processedFileNumber: this.__processedFileNumber,
-					totalFileNumber: this.__currentFileCount,
-					processedFileName: resolve(workerThreadMessage.path),
-				});
-			}
+			this.__onPrinterMessage({
+				kind: "progress",
+				processedFileNumber: this.__processedFileNumber,
+				totalFileNumber: this.__currentFileCount,
+				processedFileName: workerThreadMessage.path
+					? resolve(workerThreadMessage.path)
+					: null,
+			});
 
 			this.__idleWorkerIds.push(i);
 			await this.__work();

--- a/apps/cli/src/workerThreadManager.ts
+++ b/apps/cli/src/workerThreadManager.ts
@@ -109,7 +109,6 @@ export class WorkerThreadManager {
 		if (iteratorResult.done) {
 			this.__totalFileCount = this.__currentFileCount;
 
-			await this.__work();
 			return;
 		}
 
@@ -127,13 +126,17 @@ export class WorkerThreadManager {
 			return;
 		}
 
-		const filePath = this.__filePaths.pop();
+		const filePath = this.__filePaths.shift();
 
 		if (filePath === undefined) {
+			// console.log("this.__totalFileCount", this.__totalFileCount);
+			// console.log("this.__idleWorkerIds.length", this.__idleWorkerIds.length);
+			// console.log("this.__workerCount", this.__workerCount);
 			if (
 				this.__totalFileCount !== null &&
 				this.__idleWorkerIds.length === this.__workerCount
 			) {
+				console.log("there");
 				this.__finished = true;
 
 				this.__finish();
@@ -190,15 +193,17 @@ export class WorkerThreadManager {
 				for (const command of commands) {
 					await this.__onCommand(command);
 				}
-			} else if (workerThreadMessage.kind === "error") {
+				return;
+			}
+
+			if (workerThreadMessage.kind === "error") {
 				this.__onPrinterMessage({
 					kind: "error",
 					message: workerThreadMessage.message,
 					path: workerThreadMessage.path,
 				});
+				return;
 			}
-
-			++this.__processedFileNumber;
 
 			if (workerThreadMessage.path) {
 				this.__onPrinterMessage({

--- a/apps/cli/src/workerThreadManager.ts
+++ b/apps/cli/src/workerThreadManager.ts
@@ -9,18 +9,14 @@ import {
 	decodeWorkerThreadMessage,
 } from "./workerThreadMessages.js";
 
-const WORKER_THREAD_TIME_LIMIT = 20_000;
-
 export class WorkerThreadManager {
 	private __finished = false;
 	private __idleWorkerIds: number[] = [];
 	private __workers: Worker[] = [];
 	private __workerTimestamps: number[] = [];
 	private __filePaths: string[] = [];
-	private __currentFileCount = 0;
-	private __totalFileCount: number | null = null;
+	private __totalFileCount = 0;
 	private __processedFileNumber = 0;
-	private readonly __interval: NodeJS.Timeout;
 
 	public constructor(
 		private readonly __workerCount: number,
@@ -62,32 +58,6 @@ export class WorkerThreadManager {
 			this.__workers.push(worker);
 		}
 
-		this.__interval = setInterval(() => {
-			const now = Date.now();
-
-			for (let i = 0; i < __workerCount; ++i) {
-				const timestamp = this.__workerTimestamps[i] ?? Date.now();
-
-				if (now > timestamp + WORKER_THREAD_TIME_LIMIT) {
-					// hanging promise on purpose
-					this.__workers[i]?.terminate();
-
-					const filename = process.env.TEST
-						? join(dirname(__filename), "../dist/index.cjs")
-						: __filename;
-
-					const worker = new Worker(filename);
-					worker.on("message", this.__buildOnWorkerMessage(i));
-
-					this.__workers[i] = worker;
-
-					this.__idleWorkerIds.push(i);
-
-					this.__workerTimestamps[i] = Date.now();
-				}
-			}
-		}, 1000);
-
 		this.__pullNewPath();
 	}
 
@@ -95,8 +65,6 @@ export class WorkerThreadManager {
 		if (this.__finished) {
 			return;
 		}
-
-		clearInterval(this.__interval);
 
 		for (const worker of this.__workers) {
 			await worker.terminate();
@@ -107,12 +75,10 @@ export class WorkerThreadManager {
 		const iteratorResult = await this.__pathGenerator.next();
 
 		if (iteratorResult.done) {
-			this.__totalFileCount = this.__currentFileCount;
-
 			return;
 		}
 
-		++this.__currentFileCount;
+		++this.__totalFileCount;
 
 		this.__filePaths.push(iteratorResult.value);
 
@@ -163,8 +129,6 @@ export class WorkerThreadManager {
 	}
 
 	private __finish(): void {
-		clearInterval(this.__interval);
-
 		for (const worker of this.__workers) {
 			worker.postMessage({ kind: "exit" } satisfies MainThreadMessage);
 		}
@@ -183,7 +147,6 @@ export class WorkerThreadManager {
 				return;
 			}
 
-			++this.__processedFileNumber;
 			if (workerThreadMessage.kind === "commands") {
 				const commands = workerThreadMessage.commands as FormattedFileCommand[];
 
@@ -200,8 +163,8 @@ export class WorkerThreadManager {
 
 			this.__onPrinterMessage({
 				kind: "progress",
-				processedFileNumber: this.__processedFileNumber,
-				totalFileNumber: this.__currentFileCount,
+				processedFileNumber: ++this.__processedFileNumber,
+				totalFileNumber: this.__totalFileCount,
 				processedFileName: workerThreadMessage.path
 					? resolve(workerThreadMessage.path)
 					: null,

--- a/apps/cli/src/workerThreadMessages.ts
+++ b/apps/cli/src/workerThreadMessages.ts
@@ -26,11 +26,6 @@ const workerThreadMessageSchema = union([
 		consoleKind: consoleKindSchema,
 		message: string(),
 	}),
-	object({
-		kind: literal("runCodemod"),
-		path: string(),
-		data: string(),
-	}),
 ]);
 
 export type WorkerThreadMessage = Output<typeof workerThreadMessageSchema>;

--- a/apps/cli/src/workerThreadMessages.ts
+++ b/apps/cli/src/workerThreadMessages.ts
@@ -26,6 +26,11 @@ const workerThreadMessageSchema = union([
 		consoleKind: consoleKindSchema,
 		message: string(),
 	}),
+	object({
+		kind: literal("runCodemod"),
+		path: string(),
+		data: string(),
+	}),
 ]);
 
 export type WorkerThreadMessage = Output<typeof workerThreadMessageSchema>;

--- a/packages/utilities/src/schemata/codemodListResponse.ts
+++ b/packages/utilities/src/schemata/codemodListResponse.ts
@@ -2,6 +2,7 @@ import type { AllEngines, Arguments } from "./codemodConfigSchema.js";
 
 export type CodemodListResponse = {
 	name: string;
+	slug: string;
 	author: string;
 	engine: AllEngines;
 	tags: string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       ms:
         specifier: ^2.1.3
         version: 2.1.3
+      ora:
+        specifier: ^8.0.1
+        version: 8.0.1
       prettier:
         specifier: ^3.2.5
         version: 3.2.5
@@ -14726,7 +14729,6 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     dependencies:
       restore-cursor: 4.0.0
-    dev: true
 
   /cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
@@ -15598,7 +15600,6 @@ packages:
 
   /emoji-regex@10.3.0:
     resolution: {integrity: sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==}
-    dev: true
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -16416,7 +16417,6 @@ packages:
   /get-east-asian-width@1.2.0:
     resolution: {integrity: sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==}
     engines: {node: '>=18'}
-    dev: true
 
   /get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -17077,6 +17077,11 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /is-interactive@2.0.0:
+    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
+    engines: {node: '>=12'}
+    dev: false
+
   /is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
     requiresBuild: true
@@ -17184,6 +17189,16 @@ packages:
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+    dev: false
+
+  /is-unicode-supported@1.3.0:
+    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /is-unicode-supported@2.0.0:
+    resolution: {integrity: sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==}
+    engines: {node: '>=18'}
     dev: false
 
   /is-weakmap@2.0.1:
@@ -18011,6 +18026,14 @@ packages:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+    dev: false
+
+  /log-symbols@6.0.0:
+    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+    dependencies:
+      chalk: 5.3.0
+      is-unicode-supported: 1.3.0
     dev: false
 
   /log-update@6.0.0:
@@ -19664,6 +19687,21 @@ packages:
       wcwidth: 1.0.1
     dev: false
 
+  /ora@8.0.1:
+    resolution: {integrity: sha512-ANIvzobt1rls2BDny5fWZ3ZVKyD6nscLvfFRpQgfWsythlcsVUC9kL0zq6j2Z5z9wwp1kd7wpsD/T9qNPVLCaQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      chalk: 5.3.0
+      cli-cursor: 4.0.0
+      cli-spinners: 2.9.2
+      is-interactive: 2.0.0
+      is-unicode-supported: 2.0.0
+      log-symbols: 6.0.0
+      stdin-discarder: 0.2.2
+      string-width: 7.1.0
+      strip-ansi: 7.1.0
+    dev: false
+
   /orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
     dev: false
@@ -21250,7 +21288,6 @@ packages:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
-    dev: true
 
   /ret@0.2.2:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
@@ -21853,6 +21890,11 @@ packages:
     resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: true
 
+  /stdin-discarder@0.2.2:
+    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+    engines: {node: '>=18'}
+    dev: false
+
   /stop-iteration-iterator@1.0.0:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
     engines: {node: '>= 0.4'}
@@ -21907,7 +21949,6 @@ packages:
       emoji-regex: 10.3.0
       get-east-asian-width: 1.2.0
       strip-ansi: 7.1.0
-    dev: true
 
   /string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}


### PR DESCRIPTION
- Fixes empty prints
- Fixes wrong total files
- Introduces dedicated loader library instead of from-scratch solution
- Fix codemod list sorting (perform it on backend, perform it via fuzzy-find library by score if search is provided, otherwise alphabetically)
- Minor fixes, such as using types from utilities shared package and dead code removal