### PR TITLE
Feat/telemetry improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,8 @@
 	"editor.defaultFormatter": "biomejs.biome",
 	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
-    "source.fixAll": "explicit",
-    "quickfix.biome": "explicit",
-    "source.organizeImports.biome": "explicit"
-  }
+		"source.fixAll": "explicit",
+		"quickfix.biome": "explicit",
+		"source.organizeImports.biome": "explicit"
+	}
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@codemod-com/backend",
-	"version": "0.0.87",
+	"version": "0.0.88",
 	"scripts": {
 		"build": "node esbuild.config.js",
 		"start": "prisma -v && pnpm run db:migrate:apply && node build/index.js",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "codemod",
 	"author": "Codemod, Inc.",
-	"version": "0.10.9",
+	"version": "0.10.10",
 	"description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
 	"type": "module",
 	"exports": null,

--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -5,6 +5,7 @@ import {
 	type TelemetrySender,
 } from "@codemod-com/telemetry";
 import { doubleQuotify, execPromise } from "@codemod-com/utilities";
+import { Axios } from "axios";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { version } from "../package.json";
@@ -29,13 +30,26 @@ export const executeMainThread = async () => {
 
 	const argv = await Promise.resolve(argvObject.argv);
 
+	// client identifier is required to prevent duplicated tracking of events
+	// we can specify that request is coming from the VSCE or other client
+	const clientIdentifier =
+		typeof argv.clientIdentifier === "string" ? argv.clientIdentifier : "CLI";
+
+	Axios.interceptors.request.use((config) => {
+		config.headers["X-Client-Identifier"] = clientIdentifier;
+
+		return config;
+	});
+
+
+
 	const printer = new Printer(argv.json);
 
 	const telemetryService: TelemetrySender<TelemetryEvent> =
 		argv.telemetryDisable
 			? new NullSender()
 			: new PostHogSender({
-					cloudRole: "CLI",
+					cloudRole: clientIdentifier,
 					distinctId: await getUserDistinctId(),
 				});
 

--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -5,7 +5,7 @@ import {
 	type TelemetrySender,
 } from "@codemod-com/telemetry";
 import { doubleQuotify, execPromise } from "@codemod-com/utilities";
-import { Axios } from "axios";
+import Axios from "axios";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import { version } from "../package.json";
@@ -40,8 +40,6 @@ export const executeMainThread = async () => {
 
 		return config;
 	});
-
-
 
 	const printer = new Printer(argv.json);
 

--- a/apps/vsce/package.json
+++ b/apps/vsce/package.json
@@ -3,7 +3,7 @@
 	"author": "Codemod, Inc.",
 	"displayName": "Codemod.com",
 	"description": " Discover, run & manage codemods faster & easier.",
-	"version": "0.38.22",
+	"version": "0.38.23",
 	"publisher": "codemod",
 	"icon": "img/codemod_square128.png",
 	"repository": {

--- a/apps/vsce/src/telemetry/reporter.ts
+++ b/apps/vsce/src/telemetry/reporter.ts
@@ -14,10 +14,6 @@ export class VscodeTelemetryReporter implements Telemetry {
 		private readonly __telemetryLogger: TelemetryLogger,
 		private readonly __messageBus: MessageBus,
 	) {
-		this.__messageBus.subscribe(MessageKind.codemodSetExecuted, (message) => {
-			this.__onCodemodSetExecuted(message);
-		});
-
 		this.__messageBus.subscribe(MessageKind.jobsAccepted, (message) =>
 			this.__onJobsAcceptedMessage(message),
 		);
@@ -77,17 +73,6 @@ export class VscodeTelemetryReporter implements Telemetry {
 				executionId: caseHashDigest as CaseHash,
 			});
 		}
-	}
-
-	__onCodemodSetExecuted(
-		message: Message & { kind: MessageKind.codemodSetExecuted },
-	): void {
-		this.sendEvent({
-			kind: message.halted ? "codemodHalted" : "codemodExecuted",
-			executionId: message.case.hash,
-			fileCount: message.jobs.length,
-			codemodName: this.__transformPathLikeName(message.case.codemodName),
-		});
 	}
 
 	// transform path-like strings to bypass vscode logger filter

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -17,6 +17,7 @@
 	"scripts": {
 		"build": "tsc",
 		"test": "vitest run",
+		"test:watch": "vitest watch",
 		"coverage": "vitest run --coverage"
 	},
 	"keywords": [],

--- a/packages/telemetry/src/sender/PostHogSender.ts
+++ b/packages/telemetry/src/sender/PostHogSender.ts
@@ -24,8 +24,16 @@ export class PostHogSender<Event extends BaseEvent>
 		return this.__telemetryClient.shutdown();
 	}
 
-	public async sendEvent(event: Event): Promise<void> {
+	public async sendEvent(
+		event: Event,
+		// allow to override distinctId and cloudRole in the sendEvent method directly
+		optionsOverrides?: Partial<TelemetrySenderOptions>,
+	): Promise<void> {
 		const { kind, ...properties } = event;
+
+		const distinctId =
+			optionsOverrides?.distinctId ?? this.__options.distinctId;
+		const cloudRole = optionsOverrides?.cloudRole ?? this.__options.cloudRole;
 
 		const redactedProperties = Object.entries(properties).reduce<
 			Record<string, string>
@@ -36,10 +44,10 @@ export class PostHogSender<Event extends BaseEvent>
 		}, {});
 
 		this.__telemetryClient?.capture({
-			distinctId: this.__options.distinctId,
-			event: `codemod.${this.__options.cloudRole}.${kind}`,
+			distinctId,
+			event: `codemod.${cloudRole}.${kind}`,
 			properties: {
-				cloudRole: this.__options.cloudRole,
+				cloudRole: cloudRole,
 				...redactedProperties,
 			},
 		});

--- a/packages/telemetry/src/sender/PostHogSender.ts
+++ b/packages/telemetry/src/sender/PostHogSender.ts
@@ -38,7 +38,7 @@ export class PostHogSender<Event extends BaseEvent>
 		const redactedProperties = Object.entries(properties).reduce<
 			Record<string, string>
 		>((properties, [key, value]) => {
-			properties[key] = redactFilePaths(value);
+			properties[key] = redactFilePaths(String(value));
 
 			return properties;
 		}, {});

--- a/packages/telemetry/src/types.ts
+++ b/packages/telemetry/src/types.ts
@@ -7,6 +7,9 @@ export type TelemetrySenderOptions = {
 };
 
 export type TelemetrySender<Event extends BaseEvent> = {
-	sendEvent(event: Event): void;
+	sendEvent(
+		event: Event,
+		optionOverrides?: Partial<TelemetrySenderOptions>,
+	): void;
 	dispose(): Promise<unknown>;
 };

--- a/packages/telemetry/test/test.ts
+++ b/packages/telemetry/test/test.ts
@@ -12,7 +12,7 @@ vi.mock("posthog-node", async () => {
 	};
 });
 
-describe.skip("Should send telemetry", () => {
+describe("Should send telemetry", () => {
 	it("Should build correct role, properties and event name", () => {
 		const sender = new PostHogSender({
 			cloudRole: "ROLE",

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["./src", "test"],
+	"include": ["./src"],
 	"exclude": ["./dist", "./build", "./node_modules"],
 	"compilerOptions": {
 		"module": "NodeNext",

--- a/packages/telemetry/tsconfig.json
+++ b/packages/telemetry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["./src"],
+	"include": ["./src", "test"],
 	"exclude": ["./dist", "./build", "./node_modules"],
 	"compilerOptions": {
 		"module": "NodeNext",


### PR DESCRIPTION
 - adds ability to specify `clientIdentifier` for identifying events that are triggered by different clients - CLI, VSCE, etc; Fixes issue where codemod execution event is triggered twice  - by VSCE and by CLI
 - add util that allows to redact event properties - removing path-like strings
 - add tests for PostHogSender
 - add new event for tracking `codemod/list`  endpoint
