### PR TITLE
[Printer, CLI] fix: text formatting

### DIFF
--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -126,9 +126,10 @@ export const handleInitCliCommand = async (
 			printer.printConsoleMessage(
 				"error",
 				chalk.red(
-					`Failed to write file ${chalk.bold(path)}: ${
-						(err as Error).message
-					}. Aborting codemod creation...`,
+					"Failed to write file",
+					`${chalk.bold(path)}:`,
+					`${(err as Error).message}.`,
+					"Aborting codemod creation...",
 				),
 			);
 
@@ -146,7 +147,7 @@ export const handleInitCliCommand = async (
 
 	printer.printConsoleMessage(
 		"info",
-		chalk.cyan(`Codemod package created at ${chalk.bold(codemodBaseDir)}.`),
+		chalk.cyan("Codemod package created at", `${chalk.bold(codemodBaseDir)}.`),
 	);
 
 	const isJsCodemod =
@@ -158,15 +159,15 @@ export const handleInitCliCommand = async (
 		printer.printConsoleMessage(
 			"info",
 			chalk.cyan(
-				"\nRun ",
+				"\nRun",
 				chalk.bold(doubleQuotify("codemod build")),
-				" to build the codemod.",
+				"to build the codemod.",
 			),
 		);
 	}
 
 	const howToRunText = `Run ${chalk.bold(
-		`\`codemod --source ${codemodBaseDir}\``,
+		doubleQuotify(`codemod --source ${codemodBaseDir}`),
 	)} to run the codemod on current working directory (or specify a target using ${chalk.yellow(
 		"--target",
 	)} option).`;

--- a/apps/cli/src/commands/learn.ts
+++ b/apps/cli/src/commands/learn.ts
@@ -155,11 +155,11 @@ export const handleLearnCliCommand = async (
 	printer.printConsoleMessage(
 		"info",
 		chalk.cyan(
-			"Learning ",
+			"Learning",
 			chalk.bold(doubleQuotify("git diff")),
-			" at ",
+			"at",
 			chalk.bold(path),
-			" has begun...",
+			"has begun...",
 			"\n",
 		),
 	);

--- a/apps/cli/src/commands/list.ts
+++ b/apps/cli/src/commands/list.ts
@@ -10,7 +10,7 @@ export const handleListNamesCommand = async (
 	let spinner: ReturnType<typeof printer.withLoaderMessage> | null = null;
 	if (search && !printer.__jsonOutput) {
 		spinner = printer.withLoaderMessage(
-			chalk.cyan("Searching for ", chalk.bold(doubleQuotify(search))),
+			chalk.cyan("Searching for", chalk.bold(doubleQuotify(search))),
 		);
 	}
 

--- a/apps/cli/src/commands/publish.ts
+++ b/apps/cli/src/commands/publish.ts
@@ -171,9 +171,9 @@ export const handlePublishCliCommand = async (
 
 	const publishSpinner = printer.withLoaderMessage(
 		chalk.cyan(
-			"Publishing the codemod using name from ",
+			"Publishing the codemod using name from",
 			chalk.bold(".codemodrc.json"),
-			" file: ",
+			"file:",
 			chalk.bold(doubleQuotify(codemodRc.name)),
 		),
 	);

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -93,16 +93,16 @@ export const handleRunCliCommand = async (
 				) {
 					printer.printConsoleMessage(
 						"error",
-						// biome-ignore lint: readability reasons
-						"The specified command or codemod name could not be recognized.\n" +
-							`To view available commands, execute ${chalk.bold(
-								doubleQuotify("codemod --help"),
-							)}.\n` +
-							`To see a list of existing codemods, run ${chalk.bold(
-								doubleQuotify("codemod search"),
-							)} or ${chalk.bold(
-								doubleQuotify("codemod list"),
-							)} with a query representing the codemod you are looking for.`,
+						chalk.white(
+							"The specified command or codemod name could not be recognized.\n",
+							"To view available commands, execute",
+							`${chalk.bold(doubleQuotify("codemod --help"))}.\n`,
+							"To see a list of existing codemods, run",
+							`${chalk.bold(doubleQuotify("codemod search"))}`,
+							"or",
+							`${chalk.bold(doubleQuotify("codemod list"))}`,
+							"with a query representing the codemod you are looking for.",
+						),
 					);
 
 					process.exit(1);

--- a/apps/cli/src/commands/unpublish.ts
+++ b/apps/cli/src/commands/unpublish.ts
@@ -58,9 +58,9 @@ export const handleUnpublishCliCommand = async (
 	printer.printConsoleMessage(
 		"info",
 		chalk.cyan(
-			"Codemod ",
+			"Codemod",
 			chalk.bold(doubleQuotify(name)),
-			" was successfully unpublished.",
+			"was successfully unpublished.",
 		),
 	);
 };

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -15,14 +15,14 @@ export const handleWhoAmICommand = async (printer: PrinterBlueprint) => {
 	const { username, organizations } = userData.user;
 	printer.printConsoleMessage(
 		"info",
-		chalk.cyan("You are logged in as ", chalk.bold(username), "."),
+		chalk.cyan("You are logged in as", `${chalk.bold(username)}.`),
 	);
 
 	if (organizations.length > 0) {
 		printer.printConsoleMessage(
 			"info",
 			chalk.cyan(
-				"You have access to the following organizations: ",
+				"You have access to the following organizations:\n",
 				chalk.bold(`- ${getOrgsNames(userData).join("\n- ")}`),
 			),
 		);

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -47,9 +47,10 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 		if (!disableSpinner) {
 			spinner = this.__printer.withLoaderMessage(
 				chalk.cyan(
-					`Downloading the ${chalk.bold(doubleQuotify(name))} codemod${
-						this._cacheDisabled ? ", not using cache..." : "..."
-					}`,
+					"Downloading the",
+					chalk.bold(doubleQuotify(name)),
+					"codemod",
+					this._cacheDisabled ? "" : "(using cache)",
 				),
 			);
 		}

--- a/apps/cli/src/handleInstallDependencies.ts
+++ b/apps/cli/src/handleInstallDependencies.ts
@@ -4,6 +4,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { type PrinterBlueprint, chalk } from "@codemod-com/printer";
 import {
 	type CodemodConfig,
+	doubleQuotify,
 	execPromise,
 	extractLibNameAndVersion,
 } from "@codemod-com/utilities";
@@ -153,10 +154,10 @@ export const handleInstallDependencies = async (options: {
 		const rootPackageJsonPath = join(rootPath, "package.json");
 
 		const installedDepsString = toInstall.length
-			? chalk.green(`+ ${toInstall.join("\n+ ")}`)
+			? chalk.green("+", toInstall.join("\n+ "))
 			: "";
 		const unInstalledDepsString = toDelete.length
-			? chalk.red(`- ${toDelete.join("\n- ")}`)
+			? chalk.red("-", toDelete.join("\n- "))
 			: "";
 		const affectedString = chalk.bold(
 			affectedProjectsPackageJsons
@@ -210,9 +211,9 @@ export const handleInstallDependencies = async (options: {
 		printer.printConsoleMessage(
 			"info",
 			`\n${chalk.cyan(
-				`Codemod "${chalk.bold(
-					codemodName,
-				)}" expects the following dependency changes:`,
+				"Codemod",
+				chalk.bold(doubleQuotify(codemodName)),
+				"expects the following dependency changes:",
 			)}\n${installedDepsString}\n${unInstalledDepsString}\n`,
 		);
 
@@ -256,7 +257,9 @@ export const handleInstallDependencies = async (options: {
 		printer.printConsoleMessage(
 			"info",
 			chalk.cyan(
-				`Using package manager: ${chalk.bold(detectedPackageManager)}\n`,
+				"Using package manager:",
+				chalk.bold(detectedPackageManager),
+				"\n",
 			),
 		);
 
@@ -280,7 +283,7 @@ export const handleInstallDependencies = async (options: {
 
 		if (install === "root") {
 			const stopRemovalSpinner = printer.withLoaderMessage(
-				chalk.cyan(`Removing: ${toDelete.join(", ")}...`),
+				chalk.cyan("Removing:", `${toDelete.join(", ")}...`),
 			);
 			try {
 				await execPromise(
@@ -293,7 +296,7 @@ export const handleInstallDependencies = async (options: {
 			stopRemovalSpinner.succeed();
 
 			const stopInstallationSpinner = printer.withLoaderMessage(
-				chalk.cyan(`Installing: ${toInstall.join(", ")}...`),
+				chalk.cyan("Installing:", `${toInstall.join(", ")}...`),
 			);
 			try {
 				await execPromise(
@@ -307,7 +310,7 @@ export const handleInstallDependencies = async (options: {
 			}
 		} else {
 			const stopRemovalSpinner = printer.withLoaderMessage(
-				chalk.cyan(`Removing: ${toDelete.join(", ")}...`),
+				chalk.cyan("Removing:", `${toDelete.join(", ")}...`),
 			);
 			for (const packageJsonPath of affectedProjectsPackageJsons) {
 				const packageJsonContent = await readFile(packageJsonPath, {
@@ -351,7 +354,7 @@ export const handleInstallDependencies = async (options: {
 			}
 
 			const stopInstallationSpinner = printer.withLoaderMessage(
-				chalk.cyan(`Installing: ${toInstall.join(", ")}...`),
+				chalk.cyan("Installing:", `${toInstall.join(", ")}...`),
 			);
 			for (const packageJsonPath of affectedProjectsPackageJsons) {
 				if (packageJsonPath === rootPackageJsonPath) {
@@ -383,7 +386,10 @@ export const handleInstallDependencies = async (options: {
 
 		let installedInString: string;
 		if (install === "affected") {
-			installedInString = chalk.cyan(affectedProjectsPackageJsons.join("\n"));
+			installedInString = chalk.cyan(
+				"\n",
+				affectedProjectsPackageJsons.join("\n"),
+			);
 		} else {
 			installedInString = chalk.cyan(resolve(target, rootPackageJsonPath));
 		}
@@ -391,7 +397,12 @@ export const handleInstallDependencies = async (options: {
 		printer.printConsoleMessage(
 			"info",
 			chalk.green(
-				`Successfully installed dependencies:\n\n${installedDepsString}\n${unInstalledDepsString}\n\nin:\n${installedInString}`,
+				"Successfully installed dependencies:\n\n",
+				installedDepsString,
+				"\n",
+				unInstalledDepsString,
+				"\n\nin:",
+				installedInString,
 			),
 		);
 	} catch (error) {

--- a/packages/printer/src/printer.ts
+++ b/packages/printer/src/printer.ts
@@ -45,7 +45,7 @@ export class Printer implements PrinterBlueprint {
 			let errorText: string = text;
 
 			if (path) {
-				errorText = `${chalk.bold(`Error at ${path}:`)}\n\n${text}`;
+				errorText = `${chalk.bold("Error at", `${path}:`)}\n\n${text}`;
 			}
 
 			console.error(chalk.red(`\n${errorText}\n`));

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,5 +1,6 @@
 export { debounce } from "./functions/debounce.js";
 export {
+	backtickify,
 	buildCrossplatformArg,
 	capitalize,
 	doubleQuotify,


### PR DESCRIPTION
- Removes redundant spaces in chalk prints
- Unifies chalk usage to prefer comma notations for joined strings instead of template literals, where possible, for readability reasons.