### PR TITLE
Fixed codemod injection of imports before 'use client'

### DIFF
--- a/packages/codemods/next/13/replace-next-router/src/index.ts
+++ b/packages/codemods/next/13/replace-next-router/src/index.ts
@@ -1155,16 +1155,23 @@ export const handleSourceFile = (
 		.filter((x): x is string => x !== null)
 		.sort();
 
+	const hasUseClient = sourceFile
+		.getStatements()[0]
+		?.getText()
+		.includes("use client");
+
+	const insertImportAfterStatement = hasUseClient ? 1 : 0;
+
 	if (namedImports.length > 0) {
 		sourceFile.insertStatements(
-			0,
+			insertImportAfterStatement,
 			`import { ${namedImports.join(", ")} } from "next/navigation";`,
 		);
 	}
 
 	if (fileLevelUsageManager.shouldImportAppRouterInstance()) {
 		sourceFile.insertStatements(
-			0,
+			insertImportAfterStatement,
 			'import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context";',
 		);
 	}

--- a/packages/codemods/next/13/replace-next-router/test/test.ts
+++ b/packages/codemods/next/13/replace-next-router/test/test.ts
@@ -496,6 +496,31 @@ describe("next 13 replace-next-router", () => {
 		deepStrictEqual(actual, expected);
 	});
 
+	it("should insert import after 'use client' directive", async () => {
+		const beforeText = `
+			  "use client";
+	          import { useRouter } from 'next/router';
+
+	          function Component() {
+	              const { pathname } = useRouter();
+	          }
+	      `;
+
+		const afterText = `
+			"use client";
+			import { usePathname } from "next/navigation";
+
+	        function Component() {
+				/** TODO "pathname" no longer contains square-bracket expressions. Rewrite the code relying on them if required. **/
+	            const pathname = usePathname();
+	        }
+	    `;
+
+		const { actual, expected } = transform(beforeText, afterText, "index.tsx");
+
+		deepStrictEqual(actual, expected);
+	});
+
 	it("should replace { pathname } destructed from router with usePathname()", async () => {
 		const beforeText = `
 	          import { useRouter } from 'next/router';
@@ -1605,12 +1630,12 @@ describe("next 13 replace-next-router", () => {
 	it("should replace NextRouter with AppRouterInstance", () => {
 		const beforeText = `
 			import type { NextRouter } from "next/router"; 
-			function(router: NextRouter) {}
+			function Component(router: NextRouter) {}
 		`;
 
 		const afterText = `
 			import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context";
-			function(router: AppRouterInstance) {}
+			function Component(router: AppRouterInstance) {}
 		`;
 
 		const { actual, expected } = transform(beforeText, afterText, "index.tsx");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**:

-   [x] The commit message follows [our code of conduct](https://github.com/codemod-com/codemod-registry/blob/main/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md)
-   [x] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added / updated (for bug fixes / features)

**Please include the following information in your pull request**:

-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix
-   **What is the current behavior?** (You can also link to an open issue here)
inject of imports before 'use client'
-   **What is the new behavior (if this is a feature change)?**
inject of imports after 'use client'
-   **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
nope
-   **Any other information (if needed)**:
