### PR TITLE
Fix CLI build

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,
@@ -81,5 +81,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "keytar": "^7.9.0",
+    "prettier": "^3.2.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,13 @@ importers:
         version: 1.1.0(@types/node@20.10.5)(jsdom@23.2.0)(terser@5.27.0)
 
   apps/cli:
+    dependencies:
+      keytar:
+        specifier: ^7.9.0
+        version: 7.9.0
+      prettier:
+        specifier: ^3.2.5
+        version: 3.2.5
     devDependencies:
       '@codemod-com/filemod':
         specifier: workspace:*
@@ -270,15 +277,9 @@ importers:
       inquirer:
         specifier: ^9.2.16
         version: 9.2.16
-      keytar:
-        specifier: ^7.9.0
-        version: 7.9.0
       memfs:
         specifier: ^4.6.0
         version: 4.8.2
-      prettier:
-        specifier: ^3.2.5
-        version: 3.2.5
       terminal-link:
         specifier: ^3.0.0
         version: 3.0.0


### PR DESCRIPTION
ensure that externalized deps are in "dependencies" not in "devDependencies" so they are included to the CLI installation via `pnpm add --global`