### PR TITLE
[registry] rename time saved to total runs

### DIFF
--- a/apps/frontend/components/templates/CodemodPage/CodemodPageUI.tsx
+++ b/apps/frontend/components/templates/CodemodPage/CodemodPageUI.tsx
@@ -330,7 +330,7 @@ export default function CodemodPageUI({ data, description }: CodemodPageProps) {
             <div className="flex items-center gap-s">
               <InfoCard
                 value={String(data?.currentVersion?.totalTimeSaved)}
-                label="Total time saved"
+                label="Total runs"
               />
               <span className="h-[36px] w-[2px] bg-border-light dark:bg-border-dark" />
               <InfoCard

--- a/apps/frontend/sanity/schemas/objects/automationVersion.ts
+++ b/apps/frontend/sanity/schemas/objects/automationVersion.ts
@@ -69,7 +69,7 @@ export const automationVersion = defineType({
     },
     {
       name: "totalTimeSaved",
-      title: "Total Time Saved",
+      title: "Total runs",
       type: "number",
       readOnly: true,
     },


### PR DESCRIPTION
-   [x] The commit message follows [our code of conduct](https://github.com/codemod-com/codemod-registry/blob/main/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md)
-   [x] Tests for the changes have been added (for bug fixes/features)
-   [x] Docs have been added / updated (for bug fixes / features)

-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Renames "Total time saved" to "Total runs".