### PR TITLE
[Backend]: replaced `framework` field with `frameworks` (CDMD-3235)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-com/backend",
-  "version": "0.0.91",
+  "version": "0.0.92",
   "scripts": {
     "build": "node esbuild.config.js",
     "start": "prisma -v && pnpm run db:migrate:apply && node build/index.js",

--- a/apps/backend/src/services/codemodService.ts
+++ b/apps/backend/src/services/codemodService.ts
@@ -21,7 +21,7 @@ const parseAndFilterQueryParams = (query: string | string[] | undefined) => {
 };
 
 type LongCodemodIndoDetails = {
-  framework: string | null | undefined;
+  frameworks: string[];
   useCaseCategory: string | null | undefined;
 };
 
@@ -155,13 +155,14 @@ export class CodemodService {
         const useCaseCategory = useCaseCategoryTags.find((tag) =>
           tag.aliases.some((t) => codemod.tags.includes(t)),
         )?.title;
-        const framework = frameworkTags.find((tag) =>
-          tag.aliases.some((t) => codemod.tags.includes(t)),
-        )?.title;
+
+        const frameworks = frameworkTags
+          .filter((tag) => tag.aliases.some((t) => codemod.tags.includes(t)))
+          .map((tag) => tag.title);
 
         return {
           ...codemod,
-          framework: framework ?? "",
+          frameworks,
           useCaseCategory: useCaseCategory ?? "",
         };
       }),
@@ -253,13 +254,13 @@ export class CodemodService {
       tag.aliases.some((t) => codemod.tags.includes(t)),
     )?.title;
 
-    const framework = frameworkTags.find((tag) =>
-      tag.aliases.some((t) => codemod.tags.includes(t)),
-    )?.title;
+    const frameworks = frameworkTags
+      .filter((tag) => tag.aliases.some((t) => codemod.tags.includes(t)))
+      .map((tag) => tag.title);
 
     return {
       ...codemod,
-      framework: framework ?? "",
+      frameworks,
       useCaseCategory: useCaseCategory ?? "",
     };
   }


### PR DESCRIPTION
- replaced `framework` field with `frameworks` so we have all frameworks related to this `codemod` in this field
- bumped version to 0.0.92