### PR TITLE
[CLI, utilities] feat: init during publish (CDMD-3283)

### DIFF
--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -231,13 +231,24 @@ export const executeMainThread = async () => {
       "init",
       "initialize a codemod package",
       (y) =>
-        buildGlobalOptions(y).option("no-prompt", {
-          alias: "y",
-          type: "boolean",
-          description: "skip all prompts and use default values",
-        }),
+        buildGlobalOptions(y)
+          .option("target", {
+            alias: "t",
+            type: "string",
+            description: "Path to init codemod in",
+          })
+          .option("no-prompt", {
+            alias: "y",
+            type: "boolean",
+            description: "skip all prompts and use default values",
+          }),
       async (args) =>
-        executeCliCommand(() => handleInitCliCommand(printer, args.noPrompt)),
+        executeCliCommand(() =>
+          handleInitCliCommand({
+            printer,
+            noPrompt: args.noPrompt,
+          }),
+        ),
     );
 
   if (slicedArgv.length === 0) {

--- a/apps/frontend/app/(website)/studio/src/utils/download.ts
+++ b/apps/frontend/app/(website)/studio/src/utils/download.ts
@@ -1,3 +1,4 @@
+import { isTypeScriptProjectFiles } from "@codemod-com/utilities";
 import {
   type ProjectDownloadInput,
   getCodemodProjectFiles,
@@ -14,7 +15,7 @@ export const downloadProject = async (input: ProjectDownloadInput) => {
   }
 
   // Pre-built file
-  if ("src/index.ts" in files) {
+  if (isTypeScriptProjectFiles(files)) {
     await initSwc();
     const { code: compiled } = await transform(files["src/index.ts"], {
       minify: true,

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./constants.js";
 export { debounce } from "./functions/debounce.js";
 export {
   backtickify,
@@ -20,8 +21,14 @@ export {
 } from "./functions/validationMethods.js";
 export {
   getCodemodProjectFiles,
+  isAstGrepProjectFiles,
+  isJavaScriptProjectFiles,
+  isTypeScriptProjectFiles,
+  type AstGrepProjectFiles,
   type CodemodProjectOutput,
+  type JavaScriptProjectFiles,
   type ProjectDownloadInput,
+  type TypeScriptProjectFiles,
 } from "./package-boilerplate.js";
 export {
   buildApi,
@@ -69,4 +76,3 @@ export { CaseReadingService } from "./services/case/caseReadingService.js";
 export { CaseWritingService } from "./services/case/caseWritingService.js";
 export { FileWatcher } from "./services/case/fileWatcher.js";
 export { TarService } from "./services/tar.js";
-export * from "./constants.js";


### PR DESCRIPTION
Upon merging this PR, #506 can be closed. (@DmytroHryshyn)

- `codemod init` questions are adjusted if main file/folder path is provided
- When user tries to run `codemod publish` on a directory, we will ask him to provide a path to the main file in that directory and use this directory as a default path to run `codemod init` on.
- When user tries to run it on a concrete file, we do the same, but get the default directory based on where this file is located.