### PR TITLE
[Frontend] fix: build warnings and env validation

### DIFF
--- a/apps/cli/src/buildCodemodOptions.ts
+++ b/apps/cli/src/buildCodemodOptions.ts
@@ -68,13 +68,13 @@ const extractMainScriptPath = async (
     onlyFiles: true,
   });
 
-  if (mainFiles.length === 0) {
+  if (!mainFiles[0]) {
     throw new Error(
       `Could not find the main file of the codemod with name ${actualMainFileName}. ${errorOnMissing}`,
     );
   }
 
-  return mainFiles.at(0)!;
+  return mainFiles[0];
 };
 
 export const buildSourcedCodemodOptions = async (
@@ -88,13 +88,13 @@ export const buildSourcedCodemodOptions = async (
     .then((pathStat) => pathStat.isDirectory());
 
   if (!isDirectorySource) {
-    if (codemodOptions.codemodEngine === null) {
+    if (codemodOptions.engine === null) {
       throw new Error("--engine has to be defined when running local codemod");
     }
 
     return {
       source: "standalone",
-      engine: codemodOptions.codemodEngine,
+      engine: codemodOptions.engine,
       indexPath: codemodOptions.source,
     };
   }

--- a/apps/frontend/app/(website)/registry/[codemod]/page.tsx
+++ b/apps/frontend/app/(website)/registry/[codemod]/page.tsx
@@ -4,6 +4,7 @@ import { transformAutomation } from "@/components/templates/Registry/helpers";
 import { fetchWithTimeout, loadCodemod } from "@/data/codemod/loaders";
 import { loadAutomationPage } from "@/data/sanity/loadQuery";
 import { resolveSanityRouteMetadata } from "@/data/sanity/resolveSanityRouteMetadata";
+import { env } from "@/env";
 import type { RouteProps } from "@/types";
 import { vercelStegaCleanAll } from "@sanity/client/stega";
 import { cx } from "cva";
@@ -14,7 +15,7 @@ import { notFound } from "next/navigation";
 export const dynamicParams = true;
 
 export async function generateStaticParams() {
-  const baseUrl = process.env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
+  const baseUrl = env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
   const res = await fetchWithTimeout(`${baseUrl}/list`);
   const allAutomations = res.status === 200 ? await res.json() : [];
   return allAutomations.map((automation) => ({ codemod: automation.slug }));

--- a/apps/frontend/app/(website)/studio/src/store/zustand/CFS/index.ts
+++ b/apps/frontend/app/(website)/studio/src/store/zustand/CFS/index.ts
@@ -1,6 +1,6 @@
 import type { SendMessageResponse } from "@studio/api/sendMessage";
 import { autoGenerateCodemodPrompt } from "@studio/store/zustand/CFS/prompts";
-import create from "zustand";
+import { create } from "zustand";
 import type { PromptPreset } from "./prompts";
 
 export const LLM_ENGINES = [

--- a/apps/frontend/app/(website)/studio/src/store/zustand/codemodOutput.ts
+++ b/apps/frontend/app/(website)/studio/src/store/zustand/codemodOutput.ts
@@ -5,7 +5,7 @@ import { parseSnippet } from "@studio/utils/babelParser";
 import mapBabelASTToRenderableTree from "@studio/utils/mappers";
 import type { RangeCommand } from "@studio/utils/tree";
 import { buildRanges } from "@studio/utils/tree";
-import create from "zustand";
+import { create } from "zustand";
 
 type CodemodOutputState = {
   content: string | null;

--- a/apps/frontend/app/(website)/studio/src/store/zustand/log.ts
+++ b/apps/frontend/app/(website)/studio/src/store/zustand/log.ts
@@ -1,5 +1,5 @@
 import type { Event } from "@studio/schemata/eventSchemata";
-import create from "zustand";
+import { create } from "zustand";
 import { TabNames, useViewStore } from "./view";
 
 type LogState = {

--- a/apps/frontend/app/(website)/studio/src/store/zustand/mod.ts
+++ b/apps/frontend/app/(website)/studio/src/store/zustand/mod.ts
@@ -1,7 +1,7 @@
 import { isFile } from "@babel/types";
 import type { OffsetRange } from "@studio/schemata/offsetRangeSchemata";
 import type { TreeNode } from "@studio/types/tree";
-import create from "zustand";
+import { create } from "zustand";
 import { parseSnippet } from "../../utils/babelParser";
 import mapBabelASTToRenderableTree from "../../utils/mappers";
 import { type RangeCommand, buildRanges } from "../../utils/tree";

--- a/apps/frontend/app/(website)/studio/src/store/zustand/snippets.ts
+++ b/apps/frontend/app/(website)/studio/src/store/zustand/snippets.ts
@@ -1,6 +1,6 @@
 import { isFile } from "@babel/types";
 import { INITIAL_STATE } from "@studio/store/getInitialState";
-import create from "zustand";
+import { create } from "zustand";
 
 import type { KnownEngines } from "@codemod-com/utilities";
 import type { SnippetType } from "@studio/main/PageBottomPane";

--- a/apps/frontend/app/(website)/studio/src/store/zustand/view.ts
+++ b/apps/frontend/app/(website)/studio/src/store/zustand/view.ts
@@ -1,4 +1,4 @@
-import create from "zustand";
+import { create } from "zustand";
 
 export enum TabNames {
   MODGPT = "MODGPT",

--- a/apps/frontend/app/api/apply-to-job/route.ts
+++ b/apps/frontend/app/api/apply-to-job/route.ts
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import { headers } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -17,7 +18,7 @@ export async function POST(req: NextRequest) {
   const job_title =
     formData.get("job_title")?.toString() || "no job title provided";
   try {
-    const endpoint = `https://api.hsforms.com/submissions/v3/integration/submit/${process.env.HUBSPOT_PORTAL_ID}`;
+    const endpoint = `https://api.hsforms.com/submissions/v3/integration/submit/${env.HUBSPOT_PORTAL_ID}`;
 
     const fields = [
       {
@@ -59,9 +60,7 @@ export async function POST(req: NextRequest) {
       });
     };
 
-    const hubspotRes = await (
-      await submitForm(process.env.HUBSPOT_JOB_FORM_ID!)
-    ).json();
+    const hubspotRes = await (await submitForm(env.HUBSPOT_JOB_FORM_ID)).json();
 
     if (!hubspotRes?.inlineMessage) {
       throw new Error(JSON.stringify(hubspotRes));

--- a/apps/frontend/app/api/contact-form/route.ts
+++ b/apps/frontend/app/api/contact-form/route.ts
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import { headers } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
 
@@ -16,7 +17,7 @@ export async function POST(req: NextRequest) {
   const company = formData.get("company")?.toString() || "no company provided";
   const message = formData.get("message")?.toString() || "no message provided";
   try {
-    const endpoint = `https://api.hsforms.com/submissions/v3/integration/submit/${process.env.HUBSPOT_PORTAL_ID}`;
+    const endpoint = `https://api.hsforms.com/submissions/v3/integration/submit/${env.HUBSPOT_PORTAL_ID}`;
 
     const fields = [
       {
@@ -59,7 +60,7 @@ export async function POST(req: NextRequest) {
     };
 
     const hubspotRes = await (
-      await submitForm(process.env.HUBSPOT_CONTACT_FORM_ID!)
+      await submitForm(env.HUBSPOT_CONTACT_FORM_ID)
     ).json();
 
     if (!hubspotRes?.inlineMessage) {

--- a/apps/frontend/app/api/newsletter-form/route.ts
+++ b/apps/frontend/app/api/newsletter-form/route.ts
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import { headers } from "next/headers";
 import { type NextRequest, NextResponse } from "next/server";
 /**
@@ -12,7 +13,7 @@ export async function POST(req: NextRequest) {
   const email = formData.get("email")?.toString() || "no email provided";
 
   try {
-    const endpoint = `https://api.hsforms.com/submissions/v3/integration/submit/${process.env.HUBSPOT_PORTAL_ID}`;
+    const endpoint = `https://api.hsforms.com/submissions/v3/integration/submit/${env.HUBSPOT_PORTAL_ID}`;
 
     const fields = [
       {
@@ -43,7 +44,7 @@ export async function POST(req: NextRequest) {
     };
 
     const hubspotRes = await (
-      await submitForm(process.env.HUBSPOT_NEWSLETTER_FORM_ID!)
+      await submitForm(env.HUBSPOT_NEWSLETTER_FORM_ID)
     ).json();
 
     if (!hubspotRes?.inlineMessage) {

--- a/apps/frontend/app/api/og/route.tsx
+++ b/apps/frontend/app/api/og/route.tsx
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import { capitalize } from "@/utils/strings";
 import { ImageResponse } from "next/og";
 import Automation from "./templates/Automation";
@@ -65,7 +66,7 @@ const RegistryTemplate = ({ title }) => {
   return (
     <Registry
       title={title}
-      imageUrl={`${process.env.NEXT_PUBLIC_BASE_URL}/registry.png`}
+      imageUrl={`${env.NEXT_PUBLIC_BASE_URL}/registry.png`}
     />
   );
 };

--- a/apps/frontend/app/sitemap.ts
+++ b/apps/frontend/app/sitemap.ts
@@ -4,6 +4,7 @@ import { groq } from "next-sanity";
 
 import { fetchWithTimeout } from "@/data/codemod/loaders";
 import { client } from "@/data/sanity/client";
+import { env } from "@/env";
 import { PublishStatus } from "@/types";
 import type { AutomationAPIListResponse } from "@/types/object.types";
 import { pathToAbsUrl } from "@/utils/urls";
@@ -39,7 +40,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       },
     },
   );
-  const baseUrl = process.env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
+  const baseUrl = env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
 
   const res = await fetchWithTimeout(`${baseUrl}/list`);
   const allAutomations: AutomationAPIListResponse[] =

--- a/apps/frontend/config.ts
+++ b/apps/frontend/config.ts
@@ -1,16 +1,18 @@
+import { env } from "./env";
+
 const config = {
   sanity: {
-    projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "",
-    dataset: process.env.NEXT_PUBLIC_SANITY_DATASET || "",
+    projectId: env.NEXT_PUBLIC_SANITY_PROJECT_ID || "",
+    dataset: env.NEXT_PUBLIC_SANITY_DATASET || "",
     // Not exposed to the front-end, used solely by the server
-    token: process.env.SANITY_API_TOKEN || "",
-    apiVersion: process.env.NEXT_PUBLIC_SANITY_API_VERSION || "2023-06-21",
-    revalidateSecret: process.env.SANITY_REVALIDATE_SECRET || "",
+    token: env.SANITY_API_TOKEN || "",
+    apiVersion: env.NEXT_PUBLIC_SANITY_API_VERSION || "2023-06-21",
+    revalidateSecret: env.SANITY_REVALIDATE_SECRET || "",
     studioUrl: "/manage",
   },
   siteName: "Codemod",
-  siteDomain: process.env.NEXT_PUBLIC_SITE_DOMAIN || "",
-  baseUrl: process.env.NEXT_PUBLIC_BASE_URL || "",
+  siteDomain: env.NEXT_PUBLIC_SITE_DOMAIN || "",
+  baseUrl: env.NEXT_PUBLIC_BASE_URL || "",
 };
 
 export default config;

--- a/apps/frontend/data/codemod/loaders.ts
+++ b/apps/frontend/data/codemod/loaders.ts
@@ -1,3 +1,4 @@
+import { env } from "@/env";
 import type {
   AutomationAPISearchResponse,
   AutomationResponse,
@@ -21,7 +22,7 @@ export async function fetchWithTimeout(resource, options = {}) {
 }
 
 export async function loadCodemod(pathname: string) {
-  const baseUrl = process.env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
+  const baseUrl = env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
   const { cleaned: url } = vercelStegaSplit(`${baseUrl}/${pathname}`);
   try {
     // API is regularly unstable, handle timeout errors
@@ -51,7 +52,7 @@ export async function loadRegistryAPIData({
   searchParams: URLSearchParams;
   entriesPerPage: number;
 }): Promise<AutomationAPISearchResponse | null> {
-  const baseUrl = process.env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
+  const baseUrl = env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT;
   const registryIndexQuery = buildRegistryIndexDataQuery({
     pageNumber,
     entriesPerPage,

--- a/apps/frontend/data/sanity/resolveSanityRouteMetadata.tsx
+++ b/apps/frontend/data/sanity/resolveSanityRouteMetadata.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/components/templates/Registry/helpers";
 import config from "@/config";
 import { REGISTRY_FILTER_TYPES } from "@/constants";
+import { env } from "@/env";
 import {
   type BasicPageDocumentPayload,
   type BlogArticlePayload,
@@ -173,7 +174,7 @@ export async function resolveSanityRouteMetadata(
     : // Then default to generated image
       ogQueryString
       ? {
-          url: `${process.env.NEXT_PUBLIC_BASE_URL}/api/og?${ogQueryString}`,
+          url: `${env.NEXT_PUBLIC_BASE_URL}/api/og?${ogQueryString}`,
           width: 1200,
         }
       : parent.openGraph?.images;

--- a/apps/frontend/data/sanity/token.ts
+++ b/apps/frontend/data/sanity/token.ts
@@ -1,6 +1,8 @@
 import "server-only";
 
-export const token = process.env.SANITY_API_TOKEN;
+import { env } from "@/env";
+
+export const token = env.SANITY_API_TOKEN;
 
 if (!token) {
   throw new Error("Missing SANITY_API_TOKEN");

--- a/apps/frontend/env.ts
+++ b/apps/frontend/env.ts
@@ -14,10 +14,22 @@ export const env = createEnv({
       .default("development"),
     DUBCO_WORKSPACE_ID: z.string().optional(),
     DUBCO_API_TOKEN: z.string().optional(),
+    SANITY_API_TOKEN: z.string(),
+    SANITY_REVALIDATE_SECRET: z.string().optional(),
+    HUBSPOT_PORTAL_ID: z.string(),
+    HUBSPOT_JOB_FORM_ID: z.string(),
+    HUBSPOT_CONTACT_FORM_ID: z.string(),
+    HUBSPOT_NEWSLETTER_FORM_ID: z.string(),
   },
   client: {
     NEXT_PUBLIC_API_URL: z.string(),
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string(),
+    NEXT_PUBLIC_SANITY_PROJECT_ID: z.string(),
+    NEXT_PUBLIC_SANITY_DATASET: z.string(),
+    NEXT_PUBLIC_SANITY_API_VERSION: z.string().optional(),
+    NEXT_PUBLIC_SITE_DOMAIN: z.string().optional(),
+    NEXT_PUBLIC_BASE_URL: z.string().optional(),
+    NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT: z.string(),
   },
 
   /**
@@ -31,5 +43,18 @@ export const env = createEnv({
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
     NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
       process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    SANITY_API_TOKEN: process.env.SANITY_API_TOKEN,
+    SANITY_REVALIDATE_SECRET: process.env.SANITY_REVALIDATE_SECRET,
+    NEXT_PUBLIC_SANITY_PROJECT_ID: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+    NEXT_PUBLIC_SANITY_DATASET: process.env.NEXT_PUBLIC_SANITY_DATASET,
+    NEXT_PUBLIC_SANITY_API_VERSION: process.env.NEXT_PUBLIC_SANITY_API_VERSION,
+    NEXT_PUBLIC_SITE_DOMAIN: process.env.NEXT_PUBLIC_SITE_DOMAIN,
+    NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
+    NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT:
+      process.env.NEXT_PUBLIC_CODEMOD_AUTOMATIONS_LIST_ENDPOINT,
+    HUBSPOT_PORTAL_ID: process.env.HUBSPOT_PORTAL_ID,
+    HUBSPOT_JOB_FORM_ID: process.env.HUBSPOT_JOB_FORM_ID,
+    HUBSPOT_CONTACT_FORM_ID: process.env.HUBSPOT_CONTACT_FORM_ID,
+    HUBSPOT_NEWSLETTER_FORM_ID: process.env.HUBSPOT_NEWSLETTER_FORM_ID,
   },
 });

--- a/apps/frontend/sanity.cli.ts
+++ b/apps/frontend/sanity.cli.ts
@@ -1,5 +1,6 @@
 import { loadEnvConfig } from "@next/env";
 import { defineCliConfig } from "sanity/cli";
+import { env } from "./env";
 
 const dev = process.env.NODE_ENV !== "production";
 loadEnvConfig(__dirname, dev, { info: () => null, error: console.error });
@@ -7,7 +8,7 @@ loadEnvConfig(__dirname, dev, { info: () => null, error: console.error });
 // @TODO report top-level await bug
 // Using a dynamic import here as `loadEnvConfig` needs to run before this file is loaded
 // const { projectId, dataset } = await import('@/lib/sanity.api')
-const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
-const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const projectId = env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = env.NEXT_PUBLIC_SANITY_DATASET;
 
 export default defineCliConfig({ api: { projectId, dataset } });

--- a/packages/runner/src/schemata/codemodSettingsSchema.ts
+++ b/packages/runner/src/schemata/codemodSettingsSchema.ts
@@ -19,7 +19,7 @@ const codemodEngineSchema = union([
 export const codemodSettingsSchema = object({
   _: array(string()),
   source: optional(string()),
-  codemodEngine: optional(codemodEngineSchema),
+  engine: optional(codemodEngineSchema),
 });
 
 export type CodemodSettings =
@@ -33,7 +33,7 @@ export type CodemodSettings =
   | Readonly<{
       kind: "runSourced";
       source: string;
-      codemodEngine: Output<typeof codemodEngineSchema> | null;
+      engine: Output<typeof codemodEngineSchema> | null;
     }>;
 
 export const parseCodemodSettings = (input: unknown): CodemodSettings => {
@@ -51,7 +51,7 @@ export const parseCodemodSettings = (input: unknown): CodemodSettings => {
     return {
       kind: "runSourced",
       source,
-      codemodEngine: codemodSettings.codemodEngine ?? null,
+      engine: codemodSettings.engine ?? null,
     };
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(@types/node@20.10.5)
 
+  apps/backend/prisma/client: {}
+
   apps/cli:
     dependencies:
       keytar:


### PR DESCRIPTION
- fix warning telling to `import { create } from 'zustand'` instead of using default export
- fix using env variables from `process.env` instead of using validation library