### PR TITLE
[CLI] feat: support enum args and multiple arg types

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.10.19",
+  "version": "0.10.20",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/buildOptions.ts
+++ b/apps/cli/src/buildOptions.ts
@@ -15,6 +15,10 @@ export const buildGlobalOptions = <T>(y: Argv<T>) =>
       type: "boolean",
       description: "Disable telemetry",
     })
+    .option("clientIdentifier", {
+      type: "string",
+      description: "Telemetry client ID",
+    })
     .option("json", {
       alias: "j",
       type: "boolean",

--- a/apps/cli/src/safeArgumentRecord.ts
+++ b/apps/cli/src/safeArgumentRecord.ts
@@ -1,6 +1,9 @@
 import type { Codemod } from "@codemod-com/runner";
-import { type ArgumentRecord, doubleQuotify } from "@codemod-com/utilities";
-import { safeParseArgument } from "@codemod-com/utilities/dist/schemata/argumentRecordSchema";
+import {
+  type ArgumentRecord,
+  doubleQuotify,
+  safeParseArgument,
+} from "@codemod-com/utilities";
 
 export const buildSafeArgumentRecord = (
   codemod: Codemod,
@@ -26,6 +29,7 @@ export const buildSafeArgumentRecord = (
   const safeArgumentRecord: ArgumentRecord = {};
 
   const missing: typeof codemod.arguments = [];
+  const invalid: typeof codemod.arguments = [];
   codemod.arguments.forEach((descriptor) => {
     const maybeArgument = safeParseArgument(rawArgumentRecord[descriptor.name]);
 
@@ -38,6 +42,14 @@ export const buildSafeArgumentRecord = (
     }
 
     if (
+      descriptor.kind === "enum" &&
+      maybeArgument.success &&
+      !descriptor.options.includes(maybeArgument.output)
+    ) {
+      invalid.push(descriptor);
+    }
+
+    if (
       maybeArgument.success &&
       typeof maybeArgument.output === descriptor.kind
     ) {
@@ -47,13 +59,26 @@ export const buildSafeArgumentRecord = (
     }
   });
 
+  let errMsg = "";
   if (missing.length > 0) {
     const missingString = `- ${missing
       .map(({ kind, name }) => `${doubleQuotify(name)} (${kind})`)
       .join("\n- ")}`;
-    throw new Error(
-      `Missing required arguments:\n\n${missingString}\n\nPlease provide them as "--<arg-name> <value>".`,
-    );
+    errMsg += `Missing required arguments:\n${missingString}\nPlease provide them as "--<arg-name> <value>".`;
+  }
+
+  if (invalid.length > 0) {
+    const invalidString = `- ${invalid
+      .map(({ kind, name }) => `${doubleQuotify(name)} (${kind})`)
+      .join("\n- ")}`;
+    if (errMsg.length > 0) {
+      errMsg += "\n\n";
+    }
+    errMsg += `Invalid arguments:\n${invalidString}\nPlease use one of the predefined values.`;
+  }
+
+  if (errMsg.length > 0) {
+    throw new Error(errMsg);
   }
 
   return safeArgumentRecord;

--- a/apps/cli/src/safeArgumentRecord.ts
+++ b/apps/cli/src/safeArgumentRecord.ts
@@ -1,5 +1,6 @@
 import type { Codemod } from "@codemod-com/runner";
 import {
+  type Argument,
   type ArgumentRecord,
   doubleQuotify,
   safeParseArgument,
@@ -28,57 +29,84 @@ export const buildSafeArgumentRecord = (
 
   const safeArgumentRecord: ArgumentRecord = {};
 
-  const missing: typeof codemod.arguments = [];
-  const invalid: typeof codemod.arguments = [];
-  codemod.arguments.forEach((descriptor) => {
-    const maybeArgument = safeParseArgument(rawArgumentRecord[descriptor.name]);
+  const invalid: ((typeof codemod.arguments)[number] & { err: string })[] = [];
+
+  const validateArg = (
+    descriptor: (typeof codemod.arguments)[number],
+    arg: unknown,
+  ) => {
+    const maybeArgument = safeParseArgument(arg);
 
     if (
       !maybeArgument.success &&
       descriptor.required &&
       descriptor.default === undefined
     ) {
-      missing.push(descriptor);
+      invalid.push({ ...descriptor, err: "required but missing" });
+      return false;
+    }
+
+    if (!maybeArgument.success) {
+      return false;
+    }
+
+    if (descriptor.kind === "enum") {
+      if (!descriptor.options.includes(maybeArgument.output)) {
+        invalid.push({
+          ...descriptor,
+          err: `incorrect value. Valid options: ${descriptor.options.join(
+            ",",
+          )}`,
+        });
+      } else {
+        safeArgumentRecord[descriptor.name] = maybeArgument.output;
+      }
+
+      return true;
     }
 
     if (
-      descriptor.kind === "enum" &&
-      maybeArgument.success &&
-      !descriptor.options.includes(maybeArgument.output)
-    ) {
-      invalid.push(descriptor);
-    }
-
-    if (
-      maybeArgument.success &&
+      // biome-ignore lint: incorrect warning
       typeof maybeArgument.output === descriptor.kind
     ) {
       safeArgumentRecord[descriptor.name] = maybeArgument.output;
     } else if (descriptor.default !== undefined) {
       safeArgumentRecord[descriptor.name] = descriptor.default;
     }
+
+    return true;
+  };
+
+  codemod.arguments.forEach((descriptor) => {
+    if (Array.isArray(descriptor.kind)) {
+      let isValid = false;
+
+      for (const kind of descriptor.kind) {
+        const valid = validateArg(
+          { ...descriptor, kind } as any,
+          rawArgumentRecord[descriptor.name],
+        );
+
+        if (valid) {
+          isValid = true;
+          break;
+        }
+      }
+
+      return;
+    }
+
+    return validateArg(descriptor, rawArgumentRecord[descriptor.name]);
   });
 
-  let errMsg = "";
-  if (missing.length > 0) {
-    const missingString = `- ${missing
-      .map(({ kind, name }) => `${doubleQuotify(name)} (${kind})`)
-      .join("\n- ")}`;
-    errMsg += `Missing required arguments:\n${missingString}\nPlease provide them as "--<arg-name> <value>".`;
-  }
-
   if (invalid.length > 0) {
-    const invalidString = `- ${invalid
-      .map(({ kind, name }) => `${doubleQuotify(name)} (${kind})`)
+    const missingString = `- ${invalid
+      .map(({ kind, name, err }) => `${doubleQuotify(name)} (${kind}) - ${err}`)
       .join("\n- ")}`;
-    if (errMsg.length > 0) {
-      errMsg += "\n\n";
-    }
-    errMsg += `Invalid arguments:\n${invalidString}\nPlease use one of the predefined values.`;
-  }
 
-  if (errMsg.length > 0) {
-    throw new Error(errMsg);
+    throw new Error(
+      `Invalid arguments:\n${missingString}\n\nPlease provide missing values as "--<arg-name> <value>" or make sure the provided values are valid.`,
+    );
   }
 
   return safeArgumentRecord;

--- a/packages/codemods/react/19/remove-forward-ref/.codemodrc.json
+++ b/packages/codemods/react/19/remove-forward-ref/.codemodrc.json
@@ -10,5 +10,19 @@
   },
   "applicability": {
     "from": [["react", "<=", "18"]]
-  }
+  },
+  "arguments": [
+    {
+      "name": "one",
+      "kind": "enum",
+      "options": ["a", "b", 1],
+      "required": true
+    },
+    {
+      "name": "two",
+      "kind": ["enum", "boolean"],
+      "options": ["a", "c"],
+      "required": true
+    }
+  ]
 }

--- a/packages/codemods/react/19/remove-forward-ref/.codemodrc.json
+++ b/packages/codemods/react/19/remove-forward-ref/.codemodrc.json
@@ -10,19 +10,5 @@
   },
   "applicability": {
     "from": [["react", "<=", "18"]]
-  },
-  "arguments": [
-    {
-      "name": "one",
-      "kind": "enum",
-      "options": ["a", "b", 1],
-      "required": true
-    },
-    {
-      "name": "two",
-      "kind": ["enum", "boolean"],
-      "options": ["a", "c"],
-      "required": true
-    }
-  ]
+  }
 }

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -43,8 +43,10 @@ export {
 } from "./registry.js";
 export {
   argumentRecordSchema,
-  safeParseArgument,
+  argumentSchema,
   parseArgumentRecordSchema,
+  safeParseArgument,
+  type Argument,
   type ArgumentRecord,
 } from "./schemata/argumentRecordSchema.js";
 export {

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -43,6 +43,7 @@ export {
 } from "./registry.js";
 export {
   argumentRecordSchema,
+  safeParseArgument,
   parseArgumentRecordSchema,
   type ArgumentRecord,
 } from "./schemata/argumentRecordSchema.js";

--- a/packages/utilities/src/schemata/argumentRecordSchema.ts
+++ b/packages/utilities/src/schemata/argumentRecordSchema.ts
@@ -19,6 +19,8 @@ export const argumentSchema = union([
 
 export const argumentRecordSchema = record(string(), argumentSchema);
 
+export type Argument = Output<typeof argumentSchema>;
+
 export type ArgumentRecord = Output<typeof argumentRecordSchema>;
 
 export const safeParseArgument = (input: unknown) =>

--- a/packages/utilities/src/schemata/codemodConfigSchema.ts
+++ b/packages/utilities/src/schemata/codemodConfigSchema.ts
@@ -18,6 +18,7 @@ import {
   union,
 } from "valibot";
 import { isNeitherNullNorUndefined } from "../functions/validationMethods.js";
+import { argumentSchema } from "./argumentRecordSchema.js";
 
 const getFirstValibotIssue = (issues: Issues) => {
   let reasonableError: string | undefined;
@@ -80,6 +81,13 @@ export const argumentsSchema = array(
       object({
         name: string(),
         kind: literal("boolean"),
+        required: optional(boolean(), false),
+        default: optional(boolean()),
+      }),
+      object({
+        name: string(),
+        kind: literal("enum"),
+        options: array(argumentSchema),
         required: optional(boolean(), false),
         default: optional(boolean()),
       }),

--- a/packages/utilities/src/schemata/codemodConfigSchema.ts
+++ b/packages/utilities/src/schemata/codemodConfigSchema.ts
@@ -89,7 +89,21 @@ export const argumentsSchema = array(
         kind: literal("enum"),
         options: array(argumentSchema),
         required: optional(boolean(), false),
-        default: optional(boolean()),
+        default: optional(argumentSchema),
+      }),
+      object({
+        name: string(),
+        kind: array(
+          union([
+            literal("string"),
+            literal("number"),
+            literal("boolean"),
+            literal("enum"),
+          ]),
+        ),
+        options: array(argumentSchema),
+        required: optional(boolean(), false),
+        default: optional(argumentSchema),
       }),
     ],
     "Invalid arguments definition.",


### PR DESCRIPTION
Provided the following args are used:
<img width="238" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/d8076dc1-3a73-4461-a4bc-29a4634c362d">

This is the console output when they are missing:
<img width="843" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/e9499b9f-5ed9-4f76-bab0-78b51899a58a">

Stacked on top of #544 
