### PR TITLE
[CLI] feat: ask user to provide missing args and perform re-validation (CDMD-3343)

### DIFF
--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -79,7 +79,7 @@ export const handleRunCliCommand = async (
       hashDigest: createHash("ripemd160")
         .update(codemodSettings.source)
         .digest(),
-      safeArgumentRecord: buildSafeArgumentRecord(codemod, args),
+      safeArgumentRecord: await buildSafeArgumentRecord(codemod, args),
     });
   } else if (codemodSettings.kind === "runNamed") {
     let codemod: Awaited<ReturnType<typeof codemodDownloader.download>>;
@@ -115,7 +115,7 @@ export const handleRunCliCommand = async (
     codemods.push({
       ...codemod,
       hashDigest: createHash("ripemd160").update(codemod.name).digest(),
-      safeArgumentRecord: buildSafeArgumentRecord(codemod, args),
+      safeArgumentRecord: await buildSafeArgumentRecord(codemod, args),
     });
   } else {
     const { preCommitCodemods } = await loadRepositoryConfiguration();
@@ -125,7 +125,7 @@ export const handleRunCliCommand = async (
         const codemod = await codemodDownloader.download(preCommitCodemod.name);
         codemods.push({
           ...codemod,
-          safeArgumentRecord: buildSafeArgumentRecord(
+          safeArgumentRecord: await buildSafeArgumentRecord(
             codemod,
             preCommitCodemod.arguments,
           ),

--- a/apps/cli/src/safeArgumentRecord.ts
+++ b/apps/cli/src/safeArgumentRecord.ts
@@ -5,11 +5,12 @@ import {
   doubleQuotify,
   safeParseArgument,
 } from "@codemod-com/utilities";
+import inquirer from "inquirer";
 
-export const buildSafeArgumentRecord = (
+export const buildSafeArgumentRecord = async (
   codemod: Codemod,
   rawArgumentRecord: Record<string, unknown>,
-): ArgumentRecord => {
+): Promise<ArgumentRecord> => {
   if (codemod.source === "standalone") {
     // no checks performed for local codemods
     // b/c no source of truth for the arguments
@@ -29,83 +30,204 @@ export const buildSafeArgumentRecord = (
 
   const safeArgumentRecord: ArgumentRecord = {};
 
-  const invalid: ((typeof codemod.arguments)[number] & { err: string })[] = [];
+  let invalid: ((typeof codemod.arguments)[number] & { err: string })[] = [];
 
   const validateArg = (
     descriptor: (typeof codemod.arguments)[number],
-    arg: unknown,
+    value: unknown,
   ) => {
-    const maybeArgument = safeParseArgument(arg);
+    const validator = (
+      descriptor: (typeof codemod.arguments)[number],
+      arg: unknown,
+      skipInvalidFlagging = false,
+    ) => {
+      const maybeArgument = safeParseArgument(arg);
 
-    if (
-      !maybeArgument.success &&
-      descriptor.required &&
-      descriptor.default === undefined
-    ) {
-      invalid.push({ ...descriptor, err: "required but missing" });
-      return false;
-    }
+      if (
+        !maybeArgument.success &&
+        descriptor.required &&
+        descriptor.default === undefined
+      ) {
+        if (!skipInvalidFlagging) {
+          invalid.push({ ...descriptor, err: "required but missing" });
+        }
+        return false;
+      }
 
-    if (!maybeArgument.success) {
-      return false;
-    }
+      if (!maybeArgument.success) {
+        return false;
+      }
 
-    if (descriptor.kind === "enum") {
-      if (!descriptor.options.includes(maybeArgument.output)) {
-        invalid.push({
-          ...descriptor,
-          err: `incorrect value. Valid options: ${descriptor.options.join(
-            ",",
-          )}`,
-        });
-      } else {
+      if (descriptor.kind === "enum") {
+        if (!descriptor.options.includes(maybeArgument.output)) {
+          if (!skipInvalidFlagging) {
+            invalid.push({
+              ...descriptor,
+              err: `incorrect value. Valid options: ${descriptor.options.join(
+                ",",
+              )}`,
+            });
+          }
+
+          return false;
+        }
+
         safeArgumentRecord[descriptor.name] = maybeArgument.output;
+        return true;
+      }
+
+      if (descriptor.kind === "boolean") {
+        if (
+          maybeArgument.output === "true" ||
+          maybeArgument.output === "false"
+        ) {
+          if (!skipInvalidFlagging) {
+            invalid.push({
+              ...descriptor,
+              err: "incorrect value. Valid options: true, false",
+            });
+          }
+
+          return false;
+        }
+
+        safeArgumentRecord[descriptor.name] = maybeArgument.output === "true";
+        return true;
+      }
+
+      if (descriptor.kind === "number") {
+        const numArg = Number(maybeArgument.output);
+        if (Number.isNaN(numArg) || !Number.isFinite(numArg)) {
+          if (!skipInvalidFlagging) {
+            invalid.push({ ...descriptor, err: "invalid number" });
+          }
+
+          return false;
+        }
+
+        safeArgumentRecord[descriptor.name] = numArg;
+        return true;
+      }
+
+      if (
+        descriptor.kind === "string" &&
+        typeof maybeArgument.output === "string"
+      ) {
+        if (maybeArgument.output.length === 0) {
+          if (!skipInvalidFlagging) {
+            invalid.push({ ...descriptor, err: "empty string" });
+          }
+
+          return false;
+        }
+
+        safeArgumentRecord[descriptor.name] = maybeArgument.output;
+        return true;
+      }
+
+      if (
+        // biome-ignore lint: incorrect warning
+        typeof maybeArgument.output === descriptor.kind
+      ) {
+        safeArgumentRecord[descriptor.name] = maybeArgument.output;
+      } else if (descriptor.default !== undefined) {
+        safeArgumentRecord[descriptor.name] = descriptor.default;
       }
 
       return true;
-    }
+    };
 
-    if (
-      // biome-ignore lint: incorrect warning
-      typeof maybeArgument.output === descriptor.kind
-    ) {
-      safeArgumentRecord[descriptor.name] = maybeArgument.output;
-    } else if (descriptor.default !== undefined) {
-      safeArgumentRecord[descriptor.name] = descriptor.default;
-    }
-
-    return true;
-  };
-
-  codemod.arguments.forEach((descriptor) => {
     if (Array.isArray(descriptor.kind)) {
-      let isValid = false;
-
       for (const kind of descriptor.kind) {
-        const valid = validateArg(
-          { ...descriptor, kind } as any,
-          rawArgumentRecord[descriptor.name],
-        );
+        const valid = validator({ ...descriptor, kind } as any, value, true);
 
         if (valid) {
-          isValid = true;
-          break;
+          return true;
         }
       }
 
-      return;
+      invalid.push({
+        ...descriptor,
+        err: `incorrect type or enum value`,
+      });
+      return false;
     }
 
-    return validateArg(descriptor, rawArgumentRecord[descriptor.name]);
-  });
+    return validator(descriptor, value);
+  };
+
+  codemod.arguments.forEach((descriptor) =>
+    validateArg(descriptor, rawArgumentRecord[descriptor.name]),
+  );
 
   if (invalid.length > 0) {
-    const missingString = `- ${invalid
+    const answers = await inquirer.prompt<ArgumentRecord>(
+      invalid.map((arg) => {
+        const isEnum = arg.kind === "enum";
+
+        if (isEnum) {
+          return {
+            type: "list",
+            name: arg.name,
+            choices: arg.options,
+            default: arg.options[0],
+            pageSize: arg.options.length,
+            message: `Please select a missing value for ${arg.name} argument`,
+          };
+        }
+
+        if (Array.isArray(arg.kind)) {
+          const kinds = [...arg.kind];
+
+          const enumElIdx = kinds.indexOf("enum");
+          if (enumElIdx !== -1) {
+            kinds.splice(enumElIdx, 1);
+          }
+
+          let message = `Please enter a missing value for ${
+            arg.name
+          } argument (${kinds.join(", ")}`;
+
+          if ("options" in arg) {
+            message += ` or one of the following: ${arg.options.join(", ")}`;
+          }
+          message += ")";
+
+          return {
+            type: "input",
+            name: arg.name,
+            message,
+          };
+        }
+
+        return {
+          type: "input",
+          name: arg.name,
+          message: `Please enter a missing value for ${arg.name} argument (${arg.kind})`,
+        };
+      }),
+    );
+
+    invalid = [];
+
+    for (const [name, value] of Object.entries(answers)) {
+      const descriptor = codemod.arguments.find((arg) => arg.name === name);
+
+      if (!descriptor) {
+        continue;
+      }
+
+      validateArg(descriptor, value);
+    }
+  }
+
+  if (invalid.length > 0) {
+    const invalidString = `- ${invalid
       .map(({ kind, name, err }) => `${doubleQuotify(name)} (${kind}) - ${err}`)
       .join("\n- ")}`;
 
     throw new Error(
-      `Invalid arguments:\n${missingString}\n\nPlease provide missing values as "--<arg-name> <value>" or make sure the provided values are valid.`,
+      `Invalid arguments:\n${invalidString}\n\nMake sure provided values are correct.`,
     );
   }
 


### PR DESCRIPTION
- fixed array of kinds validation
- added logic that allows user to provide missing args manually

Example:

giving the following arguments configuration:

<img width="401" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/265c34d4-5101-4d75-847c-4cf219642a37">


and provided user input shown on below screenshot, revalidation will happen and print all the errors if any, otherwise continue codemod execution:

<img width="1415" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/f712b448-f484-40a5-80fe-db90e21866f0">
