### PR TITLE
[CLI] feat: check file tree before running (CDMD-3333, CDMD-3322)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -52,8 +52,16 @@ const checkFileTreeVersioning = async (target: string) => {
 
       force = res.force;
     }
+  } catch (err) {
+    if (!(err instanceof Error)) {
+      return;
+    }
 
-    if (status.stderr.trim()) {
+    if (
+      "stderr" in err &&
+      typeof err.stderr === "string" &&
+      err.stderr.trim().startsWith("fatal: not a git repository")
+    ) {
       const res = await inquirer.prompt<{ force: boolean }>({
         type: "confirm",
         name: "force",
@@ -63,8 +71,10 @@ const checkFileTreeVersioning = async (target: string) => {
       });
 
       force = res.force;
+
+      return;
     }
-  } catch (err) {
+
     const res = await inquirer.prompt<{ force: boolean }>({
       type: "confirm",
       name: "force",

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -16,9 +16,11 @@ import type { TelemetrySender } from "@codemod-com/telemetry";
 import {
   TarService,
   doubleQuotify,
+  execPromise,
   parseCodemodConfig,
 } from "@codemod-com/utilities";
 import { AxiosError } from "axios";
+import inquirer from "inquirer";
 import terminalLink from "terminal-link";
 import type { TelemetryEvent } from "../analytics/telemetry.js";
 import { buildSourcedCodemodOptions } from "../buildCodemodOptions.js";
@@ -30,6 +32,53 @@ import { handleInstallDependencies } from "../handleInstallDependencies.js";
 import { loadRepositoryConfiguration } from "../repositoryConfiguration.js";
 import { buildSafeArgumentRecord } from "../safeArgumentRecord.js";
 import { getConfigurationDirectoryPath } from "../utils.js";
+
+const checkFileTreeVersioning = async (target: string) => {
+  let force = true;
+
+  try {
+    const status = await execPromise("git status --porcelain", {
+      cwd: target,
+    });
+
+    if (status.stdout.trim()) {
+      const res = await inquirer.prompt<{ force: boolean }>({
+        type: "confirm",
+        name: "force",
+        message:
+          "Current git state contains uncommitted changes. Proceed anyway?",
+        default: false,
+      });
+
+      force = res.force;
+    }
+
+    if (status.stderr.trim()) {
+      const res = await inquirer.prompt<{ force: boolean }>({
+        type: "confirm",
+        name: "force",
+        message:
+          "Target folder is not tracked by git. Codemod changes might be irreversible. Proceed anyway?",
+        default: false,
+      });
+
+      force = res.force;
+    }
+  } catch (err) {
+    const res = await inquirer.prompt<{ force: boolean }>({
+      type: "confirm",
+      name: "force",
+      message: "Could not run git working tree check. Proceed anyway?",
+      default: false,
+    });
+
+    force = res.force;
+  }
+
+  if (!force) {
+    process.exit(0);
+  }
+};
 
 export const handleRunCliCommand = async (
   printer: PrinterBlueprint,
@@ -45,6 +94,8 @@ export const handleRunCliCommand = async (
   const codemodSettings = parseCodemodSettings(args);
   const flowSettings = parseFlowSettings(args);
   const runSettings = parseRunSettings(homedir(), args);
+
+  await checkFileTreeVersioning(flowSettings.target);
 
   const fileDownloadService = new FileDownloadService(
     args.noCache,


### PR DESCRIPTION
Examples:

<img width="768" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/0824dc48-4eba-4ba2-827c-e88dbcd0219f">

<img width="587" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/95e61709-f765-4fd7-9e97-49cc397b3541">

<img width="570" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/af3646a3-7ea1-4627-98b4-81e0704c60bb">


If `git status --porcelain` yields no diff, then no prompt is printed.