### PR TITLE
 Feat/support engine native options CDMD-3350

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.10.21",
+  "version": "0.10.22",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/buildEngineOptions.ts
+++ b/apps/cli/src/buildEngineOptions.ts
@@ -1,0 +1,15 @@
+import type { Codemod } from "@codemod-com/runner";
+import { type EngineOptions, parseEngineOptions } from "@codemod-com/utilities";
+
+export const buildCodemodEngineOptions = (
+  engine: Codemod["engine"],
+  rawArgumentRecord: Record<string, unknown>,
+): EngineOptions | null => {
+  const options = parseEngineOptions({ engine, ...rawArgumentRecord });
+
+  if (!options.success) {
+    return null;
+  }
+
+  return options.output;
+};

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -85,9 +85,7 @@ export const handleRunCliCommand = async (
       safeArgumentRecord: await buildSafeArgumentRecord(codemod, args),
       engineOptions,
     });
-  }
-  else
-  if (codemodSettings.kind === "runNamed") {
+  } else if (codemodSettings.kind === "runNamed") {
     let codemod: Awaited<ReturnType<typeof codemodDownloader.download>>;
     try {
       codemod = await codemodDownloader.download(nameOrPath);

--- a/apps/cli/src/executeWorkerThread.ts
+++ b/apps/cli/src/executeWorkerThread.ts
@@ -67,6 +67,7 @@ const messageHandler = async (m: unknown) => {
             message.data,
             initializationMessage.disablePrettier,
             initializationMessage.safeArgumentRecord,
+            initializationMessage.engineOptions,
             consoleCallback,
           );
           break;

--- a/packages/printer/package.json
+++ b/packages/printer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codemod-com/printer",
   "author": "Codemod, Inc.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Printer abstraction used in Codemod.com ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/printer/src/schemata/mainThreadMessages.ts
+++ b/packages/printer/src/schemata/mainThreadMessages.ts
@@ -1,8 +1,12 @@
-import { argumentRecordSchema } from "@codemod-com/utilities";
+import {
+  argumentRecordSchema,
+  engineOptionsSchema,
+} from "@codemod-com/utilities";
 import {
   type Output,
   boolean,
   literal,
+  nullable,
   object,
   parse,
   string,
@@ -21,6 +25,7 @@ const mainThreadMessageSchema = union([
     ]),
     disablePrettier: boolean(),
     safeArgumentRecord: argumentRecordSchema,
+    engineOptions: nullable(engineOptionsSchema),
   }),
   object({
     kind: literal("exit"),

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codemod-com/runner",
   "author": "Codemod, Inc.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The codemod runner used in Codemod.com ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runner/src/runCodemod.ts
+++ b/packages/runner/src/runCodemod.ts
@@ -4,6 +4,7 @@ import type { Filemod } from "@codemod-com/filemod";
 import { chalk } from "@codemod-com/printer";
 import {
   type ArgumentRecord,
+  type EngineOptions,
   type FileSystem,
   isGeneratorEmpty,
 } from "@codemod-com/utilities";
@@ -165,6 +166,7 @@ export const runCodemod = async (
   onCommand: (command: FormattedFileCommand) => Promise<void>,
   onPrinterMessage: PrinterMessageCallback,
   safeArgumentRecord: ArgumentRecord,
+  engineOptions: EngineOptions | null,
   onCodemodError: CodemodExecutionErrorCallback,
 ): Promise<void> => {
   if (codemod.engine === "piranha") {
@@ -221,6 +223,7 @@ export const runCodemod = async (
             // if we are within a recipe
           },
           safeArgumentRecord,
+          engineOptions,
           onCodemodError,
         );
 
@@ -284,6 +287,7 @@ export const runCodemod = async (
           // if we are within a recipe
         },
         safeArgumentRecord,
+        engineOptions,
         onCodemodError,
       );
 
@@ -454,6 +458,7 @@ export const runCodemod = async (
       transpiledSource,
       flowSettings.raw,
       safeArgumentRecord,
+      engineOptions,
       (error) => {
         onCodemodError({
           codemodName:

--- a/packages/runner/src/runJscodeshiftCodemod.ts
+++ b/packages/runner/src/runJscodeshiftCodemod.ts
@@ -1,7 +1,7 @@
 import { extname } from "node:path";
 import vm from "node:vm";
 import type { ConsoleKind } from "@codemod-com/printer";
-import type { ArgumentRecord } from "@codemod-com/utilities";
+import type { ArgumentRecord, EngineOptions } from "@codemod-com/utilities";
 import jscodeshift, { type API } from "jscodeshift";
 import { nullish, parse, string } from "valibot";
 import { getAdapterByExtname } from "./adapters/index.js";
@@ -75,6 +75,7 @@ export const runJscodeshiftCodemod = (
   oldData: string,
   disablePrettier: boolean,
   safeArgumentRecord: ArgumentRecord,
+  engineOptions: Extract<EngineOptions, { engine: "jscodeshift" }> | null,
   consoleCallback: (kind: ConsoleKind, message: string) => void,
 ): readonly FileCommand[] => {
   const commands: FileCommand[] = [];
@@ -90,7 +91,7 @@ export const runJscodeshiftCodemod = (
     });
   };
 
-  const api = buildApi("tsx");
+  const api = buildApi(engineOptions?.parser ?? "tsx");
 
   const transformFn = adapter !== null ? adapter(transform) : transform;
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1,4 +1,8 @@
-import type { ArgumentRecord, FileSystem } from "@codemod-com/utilities";
+import type {
+  ArgumentRecord,
+  EngineOptions,
+  FileSystem,
+} from "@codemod-com/utilities";
 import type { Codemod } from "./codemod.js";
 import {
   type FormattedFileCommand,
@@ -16,6 +20,7 @@ import { SurfaceAgnosticCaseService } from "./services/surfaceAgnosticCaseServic
 export type CodemodToRun = Codemod & {
   safeArgumentRecord: ArgumentRecord;
   hashDigest?: Buffer;
+  engineOptions: EngineOptions | null;
 };
 
 export class Runner {
@@ -75,6 +80,7 @@ export class Runner {
           },
           onPrinterMessage ?? (() => {}),
           codemod.safeArgumentRecord,
+          codemod.engineOptions,
           (error) => executionErrors.push(error),
         );
 

--- a/packages/runner/src/workerThreadManager.ts
+++ b/packages/runner/src/workerThreadManager.ts
@@ -6,7 +6,11 @@ import {
   type WorkerThreadMessage,
   decodeWorkerThreadMessage,
 } from "@codemod-com/printer";
-import { type ArgumentRecord, sleep } from "@codemod-com/utilities";
+import {
+  type ArgumentRecord,
+  type EngineOptions,
+  sleep,
+} from "@codemod-com/utilities";
 import type { FormattedFileCommand } from "./fileCommands.js";
 import type { CodemodExecutionErrorCallback } from "./schemata/callbacks.js";
 
@@ -34,6 +38,7 @@ export class WorkerThreadManager {
     codemodSource: string,
     disablePrettier: boolean,
     safeArgumentRecord: ArgumentRecord,
+    engineOptions: EngineOptions | null,
     private readonly onCodemodError: CodemodExecutionErrorCallback,
   ) {
     for (let i = 0; i < __workerCount; ++i) {
@@ -55,6 +60,7 @@ export class WorkerThreadManager {
         codemodSource,
         disablePrettier,
         safeArgumentRecord,
+        engineOptions,
       } satisfies MainThreadMessage);
 
       this.__workers.push(worker);

--- a/packages/runner/test/runJscodeshiftCodemod.test.ts
+++ b/packages/runner/test/runJscodeshiftCodemod.test.ts
@@ -68,6 +68,7 @@ describe("runJscodeshiftCodemod", () => {
       oldData,
       false,
       {},
+      null,
       (consoleKind, message) => {
         messages.push([consoleKind, message]);
       },

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -81,6 +81,11 @@ export {
 } from "./schemata/surfaceAgnosticJobSchema.js";
 export { type FileSystem } from "./schemata/types.js";
 export { type ValidateTokenResponse } from "./schemata/validateTokenResponse.js";
+export {
+  type EngineOptions,
+  engineOptionsSchema,
+  parseEngineOptions,
+} from "./schemata/engineOptionsSchema.js";
 export { CaseReadingService } from "./services/case/caseReadingService.js";
 export { CaseWritingService } from "./services/case/caseWritingService.js";
 export { FileWatcher } from "./services/case/fileWatcher.js";

--- a/packages/utilities/src/schemata/engineOptionsSchema.ts
+++ b/packages/utilities/src/schemata/engineOptionsSchema.ts
@@ -1,0 +1,19 @@
+import { type Output, literal, object, safeParse, union } from "valibot";
+
+export const engineOptionsSchema = union([
+  object({
+    engine: literal("jscodeshift"),
+    parser: union([
+      literal("babel"),
+      literal("babylon"),
+      literal("flow"),
+      literal("ts"),
+      literal("tsx"),
+    ]),
+  }),
+]);
+
+export type EngineOptions = Output<typeof engineOptionsSchema>;
+
+export const parseEngineOptions = (input: unknown) =>
+  safeParse(engineOptionsSchema, input);


### PR DESCRIPTION
 - adds ability to pass jscodeshift options. for now only `parser` option, as other options like `--dry` or `--verbose` are controlled by the runner, not the engine itself. 