### PR TITLE
[CLI] feat: add test fixtures to init output (CDMD-3334)

### DIFF
--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -288,14 +288,14 @@ export const handleInitCliCommand = async (options: {
   )} to run the codemod on current working directory (or specify a target using ${chalk.yellow(
     "--target",
   )} option).`;
-  printer.printConsoleMessage("info", chalk.cyan(howToRunText, "cyan"));
+  printer.printConsoleMessage("info", chalk.cyan(howToRunText));
 
   let publishText = `Run ${chalk.bold(
     doubleQuotify("codemod publish"),
   )} to publish the codemod to the Codemod registry.`;
   if (isJsCodemod) {
     publishText += chalk.yellow(
-      "NOTE: Your codemod has to be built using the build command",
+      " NOTE: Your codemod has to be built using the build command",
     );
   }
   printer.printConsoleMessage("info", chalk.cyan(publishText));

--- a/packages/utilities/src/package-boilerplate.ts
+++ b/packages/utilities/src/package-boilerplate.ts
@@ -440,19 +440,20 @@ const testBody = ({
   name,
   cases,
   engine,
-}: Pick<ProjectDownloadInput, "name" | "engine" | "cases">) => {
+  vanillaJs,
+}: Pick<ProjectDownloadInput, "name" | "engine" | "cases" | "vanillaJs">) => {
   let body = "";
 
   if (engine === "jscodeshift") {
     body = beautify(`
         import { describe, it } from 'vitest';
-        import jscodeshift, { API } from 'jscodeshift';
+        import jscodeshift${vanillaJs ? "" : ", { type API }"} from 'jscodeshift';
         import transform from '../src/index.js';
         import assert from 'node:assert';
         import { readFile } from 'node:fs/promises';
         import { join } from 'node:path';
 
-        const buildApi = (parser: string | undefined): API => ({
+        const buildApi = (parser: string | undefined)${vanillaJs ? "" : ": API"} => ({
           j: parser ? jscodeshift.withParser(parser) : jscodeshift,
           jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
           stats: () => {
@@ -473,10 +474,10 @@ const testBody = ({
               `it('test #${i + 1}', async () => {
                 const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture${
                   i + 1
-                }.input.ts'), 'utf-8');
+                }.input.${vanillaJs ? "js" : "ts"}'), 'utf-8');
                 const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture${
                   i + 1
-                }.output.ts'), 'utf-8');
+                }.output.${vanillaJs ? "js" : "ts"}'), 'utf-8');
 
                 const actualOutput = transform(
                   {
@@ -598,6 +599,15 @@ export function getCodemodProjectFiles(input: ProjectDownloadInput) {
       throw new Error(`Unknown engine: ${input.engine}`);
   }
 
+  if (!input.cases || input.cases.length === 0) {
+    input.cases = [
+      {
+        before: `const toReplace = "hello";`,
+        after: `const replacement = "hello";`,
+      },
+    ];
+  }
+
   const mainFileContent = input.codemodBody
     ? beautify(input.codemodBody)
     : mainFileBoilerplate;
@@ -635,26 +645,24 @@ export function getCodemodProjectFiles(input: ProjectDownloadInput) {
     };
   }
 
-  if (input.cases) {
-    for (let i = 0; i < input.cases.length; i++) {
-      // biome-ignore lint: cases[i] is defined
-      const { before, after } = input.cases[i]!;
+  for (let i = 0; i < input.cases.length; i++) {
+    // biome-ignore lint: cases[i] is defined
+    const { before, after } = input.cases[i]!;
 
-      if (input.vanillaJs) {
-        (files as JavaScriptProjectFiles)[
-          `__testfixtures__/fixture${i + 1}.input.js`
-        ] = beautify(before);
-        (files as JavaScriptProjectFiles)[
-          `__testfixtures__/fixture${i + 1}.output.js`
-        ] = beautify(after);
-      } else {
-        (files as TypeScriptProjectFiles)[
-          `__testfixtures__/fixture${i + 1}.input.ts`
-        ] = beautify(before);
-        (files as TypeScriptProjectFiles)[
-          `__testfixtures__/fixture${i + 1}.output.ts`
-        ] = beautify(after);
-      }
+    if (input.vanillaJs) {
+      (files as JavaScriptProjectFiles)[
+        `__testfixtures__/fixture${i + 1}.input.js`
+      ] = beautify(before);
+      (files as JavaScriptProjectFiles)[
+        `__testfixtures__/fixture${i + 1}.output.js`
+      ] = beautify(after);
+    } else {
+      (files as TypeScriptProjectFiles)[
+        `__testfixtures__/fixture${i + 1}.input.ts`
+      ] = beautify(before);
+      (files as TypeScriptProjectFiles)[
+        `__testfixtures__/fixture${i + 1}.output.ts`
+      ] = beautify(after);
     }
   }
 
@@ -662,25 +670,44 @@ export function getCodemodProjectFiles(input: ProjectDownloadInput) {
 }
 
 export const emptyJsCodeShiftBoilerplate = beautify(`
-import type { API, FileInfo, Options } from "jscodeshift";
+// BUILT WITH https://codemod.studio
 
-export default function transformer(
-	file: FileInfo,
-	api: API,
-	options: Options,
-) {
-	const j = api.jscodeshift;
-	const root = j(file.source);
+import type { FileInfo, API, Options } from "jscodeshift";
+export default function transform(
+  file: FileInfo,
+  api: API,
+  options?: Options
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
 
-	root
-		.find(j.CallExpression, {
-			callee: { name: "name" },
-		})
-		.forEach((path) => {
-      path.node.callee.name = "replacement";
-    });
+  // Helper function to preserve comments when replacing nodes
+  function replaceWithComments(path, newNode) {
+    // If the original node had comments, add them to the new node
+    if (path.node.comments) {
+      newNode.comments = path.node.comments;
+    }
 
-	return root.toSource(options);
+    // Replace the node
+    j(path).replaceWith(newNode);
+  }
+
+  // Find all variable declarations
+  root.find(j.VariableDeclarator).forEach((path) => {
+    // Ensure the node is an Identifier and its name is 'toReplace'
+    if (
+      path.node.id.type === "Identifier" &&
+      path.node.id.name === "toReplace"
+    ) {
+      // Create a new Identifier with the name 'replacement'
+      const newId = j.identifier("replacement");
+
+      // Replace the old Identifier with the new one, preserving comments
+      replaceWithComments(path.get("id"), newId);
+    }
+  });
+
+  return root.toSource();
 }
 `);
 


### PR DESCRIPTION
- Adds test fixtures to `codemod init` output
- Fixes text issues upon `codemod init` command finished execution