### PR TITLE
[runner] Using codemod name from user on github branch name can throw errors

### DIFF
--- a/apps/task-manager/package.json
+++ b/apps/task-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-com/task-manager",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "scripts": {
     "build": "node esbuild.config.js",
     "start": "node build/worker.js"

--- a/apps/task-manager/src/services/GithubProvider.ts
+++ b/apps/task-manager/src/services/GithubProvider.ts
@@ -22,11 +22,9 @@ export class GithubProviderService {
   private __git: SimpleGit | null;
 
   constructor(codemodMetadata: CodemodMetadata) {
-    const { codemodName } = codemodMetadata;
-
     this.__git = null;
     this.__base = "main";
-    this.__currentBranch = `codemod-${codemodName.toLowerCase()}-${Date.now()}`;
+    this.__currentBranch = `codemod-${Date.now()}`;
     this.__codemodMetadata = codemodMetadata;
   }
 


### PR DESCRIPTION
<img width="310" alt="Screenshot 2024-05-16 at 13 15 28" src="https://github.com/codemod-com/codemod/assets/32841130/5a246bcb-a050-4fc0-84ee-ce602ae35061">
