### PR TITLE
[CLI, Backend] fix: resolve publishing/downloading issues

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-com/backend",
-  "version": "0.0.107",
+  "version": "0.0.108",
   "scripts": {
     "build": "node esbuild.config.js",
     "start": "node build/index.js",

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -287,9 +287,16 @@ const wrapRequestHandlerMethod =
       const userOrganizations =
         await clerkClient.users.getOrganizationMembershipList({ userId });
       const userAllowedNamespaces = [
-        user.username,
         ...userOrganizations.map((org) => org.organization.slug),
       ].filter(isNeitherNullNorUndefined);
+
+      if (user.username) {
+        userAllowedNamespaces.push(user.username);
+
+        if (environment.VERIFIED_PUBLISHERS.includes(user.username)) {
+          userAllowedNamespaces.push("codemod-com", "codemod.com");
+        }
+      }
 
       return {
         user,

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.10.23",
+  "version": "0.10.24",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/apis.ts
+++ b/apps/cli/src/apis.ts
@@ -77,6 +77,7 @@ export const getCodemodDownloadURI = async (
   }
 
   const res = await Axios.get<{ link: string }>(url.toString(), {
+    headers,
     timeout: 10000,
   });
 

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -160,14 +160,14 @@ export const handleRunCliCommand = async (
         ) {
           printer.printConsoleMessage(
             "error",
-            chalk.white(
-              "The specified command or codemod name could not be recognized.\n",
-              "To view available commands, execute",
-              `${chalk.bold(doubleQuotify("codemod --help"))}.\n`,
-              "To see a list of existing codemods, run",
-              `${chalk.bold(doubleQuotify("codemod search"))}`,
+            chalk.red(
+              "The specified command or codemod name could not be recognized.",
+              "\nTo view available commands, execute",
+              `${chalk.yellow.bold(doubleQuotify("codemod --help"))}.`,
+              "\nTo see a list of existing codemods, run",
+              `${chalk.yellow.bold(doubleQuotify("codemod search"))}`,
               "or",
-              `${chalk.bold(doubleQuotify("codemod list"))}`,
+              `${chalk.yellow.bold(doubleQuotify("codemod list"))}`,
               "with a query representing the codemod you are looking for.",
             ),
           );


### PR DESCRIPTION
- Fixed access token not being passed to an endpoint that retrieves codemod download URI
- Fixed wrong logic for assembling user allowed namespaces in the same endpoint
- Fixed bad indentation in download error
- Improved cache disabled/enabled messages with reasons given to the user where appropriate
- Improved execution flow in `downloadCodemod.ts` to achieve better error messages