### PR TITLE
[codemods] fix prop-types-typescript git meta

### DIFF
--- a/packages/codemods/react/prop-types-typescript/.codemodrc.json
+++ b/packages/codemods/react/prop-types-typescript/.codemodrc.json
@@ -18,7 +18,8 @@
     }
   ],
   "meta": {
-    "tags": ["react", "migration"]
+    "tags": ["react", "migration"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/react/prop-types-typescript"
   },
   "include": ["**/*.js", "**/*.ts"]
 }


### PR DESCRIPTION
Fixes missing git meta for the React prop-types-typescript codemod