### PR TITLE
[CLI] feat: print codemod version and always build the codemod

### DIFF
--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -300,12 +300,22 @@ export const handleRunCliCommand = async (
       },
     );
 
+    let runningCodemodVersion = "";
+    if ("version" in codemodDefinition.codemod) {
+      runningCodemodVersion += `@${codemodDefinition.codemod.version}`;
+    }
+    if (args.source) {
+      runningCodemodVersion += " (local)";
+    }
+
     printer.printConsoleMessage(
       "info",
       boxen(
         chalk.cyan(
           "Running with the following configuration:",
-          `\n\n${chalk.yellow.bold(reason ?? "")}\n${patternsColumns}\n`,
+          `\n\nCodemod:`,
+          chalk.bold(`${nameOrPath}${runningCodemodVersion}`),
+          `\n${chalk.yellow.bold(reason ?? "")}\n${patternsColumns}\n`,
           chalk.yellow(
             !flowSettings.install ? "\nDependency installation disabled" : "",
           ),

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -155,6 +155,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
         return {
           source: "package",
           name,
+          version: config.version,
           engine: config.engine,
           include: config.include,
           indexPath: yamlPath,
@@ -179,6 +180,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
       return {
         source: "package",
         name,
+        version: config.version,
         engine: config.engine,
         include: config.include,
         directoryPath,
@@ -196,6 +198,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
       return {
         source: "package",
         name,
+        version: config.version,
         engine: config.engine,
         include: config.include,
         indexPath,
@@ -236,6 +239,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
       return {
         source: "package",
         name,
+        version: config.version,
         engine: config.engine,
         include: config.include,
         codemods,

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -1,11 +1,13 @@
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { type PrinterBlueprint, chalk } from "@codemod-com/printer";
 import {
   type ValidateTokenResponse,
   execPromise,
   isNeitherNullNorUndefined,
 } from "@codemod-com/utilities";
+import { glob } from "fast-glob";
 import keytar from "keytar";
 import { validateAccessToken } from "./apis";
 
@@ -102,3 +104,44 @@ export const getConfigurationDirectoryPath = (argvUnderScore?: unknown) =>
     String(argvUnderScore) === "runOnPreCommit" ? process.cwd() : homedir(),
     ".codemod",
   );
+
+export const rebuildCodemodFallback = async (options: {
+  globPattern: string | string[];
+  source: string;
+  errorText: string;
+  onSuccess?: () => void;
+  onFail?: () => void;
+}): Promise<string> => {
+  const { globPattern, source, errorText, onSuccess, onFail } = options;
+
+  const locateMainFile = async () => {
+    const mainFiles = await glob(globPattern, {
+      absolute: true,
+      ignore: ["**/node_modules/**"],
+      cwd: source,
+      onlyFiles: true,
+    });
+
+    return mainFiles.at(0);
+  };
+
+  let mainFilePath = await locateMainFile();
+
+  try {
+    // Try to build the codemod anyways, and if after build there is still no main file
+    // or the process throws - throw an error
+    await execPromise("codemod build", { cwd: source });
+
+    mainFilePath = await locateMainFile();
+    // Likely meaning that the "codemod build" command succeeded, but the file was still not found in output
+    if (mainFilePath === undefined) {
+      throw new Error();
+    }
+    onSuccess?.();
+  } catch (error) {
+    onFail?.();
+    throw new Error(errorText);
+  }
+
+  return mainFilePath;
+};

--- a/packages/runner/src/codemod.ts
+++ b/packages/runner/src/codemod.ts
@@ -4,6 +4,7 @@ export type Codemod =
   | Readonly<{
       source: "package";
       name: string;
+      version: string;
       include?: string[];
       engine: "recipe";
       directoryPath: string;
@@ -13,6 +14,7 @@ export type Codemod =
   | Readonly<{
       source: "package";
       name: string;
+      version: string;
       include?: string[];
       engine: KnownEngines;
       directoryPath: string;
@@ -22,6 +24,7 @@ export type Codemod =
   | Readonly<{
       source: "package";
       name: string;
+      version: string;
       include?: string[];
       engine: "piranha";
       directoryPath: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,8 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(@types/node@20.10.5)(jsdom@23.2.0)(terser@5.30.4)
 
+  apps/backend/prisma/client: {}
+
   apps/cli:
     dependencies:
       '@ast-grep/napi':


### PR DESCRIPTION
- now prints version of codemod that is being run

<img width="566" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/c31d56d0-c16a-48c6-a72e-5b6a1739aaf8">

<img width="665" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/c2bd156e-05f9-4e8e-b2ce-3da4fc5b1e15">

- always build the codemod before publishing
- always build the codemod before running
- fix semver validation logic