### PR TITLE
[CLI] feat: smarter include/exclude options (CDMD-3450, CDMD-3451, CDMD-3462, CDMD-3470, CDMD-3448)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,36 @@
-.idea
 .DS_Store
 
-node_modules
+node_modules/
+dist/
+build/
+out/
 
-dist
-build
-out
-
-.turbo
+.turbo/
 
 **.env
 
 # Extension
 .vscode-test/
 *.vsix
-.idea
+.idea/
 yarn-error.log
 .trunk
 
-apps/engine/package
-
 # Studio
-/.pnp
+.pnp
 .pnp.js
-/coverage
+coverage/
 npm-debug.log*
 yarn-debug.log*
-.eslintcache
-.next
-.vercel
+.eslintcache/
+.next/
+.vercel/
 
 # Backend
-build
+build/
 
 # Workflow
 .cache
+
+# CLI package
+apps/cli/package/

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.10.27",
+  "version": "0.11.0",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/buildOptions.ts
+++ b/apps/cli/src/buildOptions.ts
@@ -4,20 +4,39 @@ import {
   DEFAULT_ENABLE_PRETTIER,
   DEFAULT_EXCLUDE_PATTERNS,
   DEFAULT_INSTALL,
+  DEFAULT_TELEMETRY,
   DEFAULT_THREAD_COUNT,
   DEFAULT_USE_JSON,
 } from "@codemod-com/runner";
 import type { Argv } from "yargs";
 
+export type GlobalArgvOptions = Awaited<
+  ReturnType<ReturnType<typeof buildGlobalOptions>>["argv"]
+>;
+
+export type RunArgvOptions = Awaited<
+  ReturnType<ReturnType<typeof buildRunOptions>>["argv"]
+>;
+
 export const buildGlobalOptions = <T>(y: Argv<T>) =>
   y
-    .option("telemetryDisable", {
+    .option("telemetry", {
+      type: "boolean",
+      default: DEFAULT_TELEMETRY,
+      hidden: true,
+    })
+    .option("no-telemetry", {
       type: "boolean",
       description: "Disable telemetry",
     })
     .option("clientIdentifier", {
       type: "string",
       description: "Telemetry client ID",
+      hidden: true,
+    })
+    .option("version", {
+      alias: "v",
+      description: "Show version number",
     })
     .option("json", {
       alias: "j",
@@ -27,69 +46,75 @@ export const buildGlobalOptions = <T>(y: Argv<T>) =>
     })
     .option("cache", {
       type: "boolean",
-      description:
-        "Enable cache for HTTP(S) requests. Disable it using --no-cache",
       default: DEFAULT_CACHE,
+      hidden: true,
+    })
+    .option("no-cache", {
+      type: "boolean",
+      description: "Disable cache for HTTP(S) requests",
     });
 
-type RunArgvOptions = Awaited<
-  ReturnType<ReturnType<typeof buildRunOptions>>["argv"]
->;
-
 export const buildRunOptions = <T>(y: Argv<T>) => {
-  return buildGlobalOptions(
-    y
-      .option("include", {
-        alias: "i",
-        type: "string",
-        array: true,
-        description: "Glob pattern(s) for files to include",
-      })
-      .option("exclude", {
-        alias: "e",
-        type: "string",
-        array: true,
-        description: "Glob pattern(s) for files to exclude",
-        default: DEFAULT_EXCLUDE_PATTERNS,
-      })
-      .option("target", {
-        alias: "t",
-        type: "string",
-        description: "Input directory path",
-      })
-      .option("source", {
-        alias: "s",
-        type: "string",
-        description: "Source path of the local codemod to run",
-      })
-      .option("engine", {
-        type: "string",
-        description:
-          'The engine to use with the local codemod: "jscodeshift", "ts-morph", "filemod", "ast-grep"',
-      })
-      .option("format", {
-        type: "boolean",
-        description:
-          "Enable formatting output with Prettier. Disable it using --no-format",
-        default: DEFAULT_ENABLE_PRETTIER,
-      })
-      .option("threads", {
-        alias: "n",
-        type: "number",
-        description: "Number of worker threads",
-        default: DEFAULT_THREAD_COUNT,
-      })
-      .option("dry", {
-        alias: "d",
-        type: "boolean",
-        description: "Perform a dry run",
-        default: DEFAULT_DRY_RUN,
-      })
-      .option("install", {
-        type: "boolean",
-        description:
-          "Enable packages installation for the codemod run if there is `deps` field declared in its configuration. Disable it using --no-install",
-        default: DEFAULT_INSTALL,
-      }),
-  );
+  return y
+    .option("include", {
+      alias: "i",
+      type: "string",
+      array: true,
+      description: "Glob pattern(s) for files to include",
+    })
+    .option("exclude", {
+      alias: "e",
+      type: "string",
+      array: true,
+      description: "Glob pattern(s) for files to exclude",
+      default: DEFAULT_EXCLUDE_PATTERNS,
+      defaultDescription: "node_modules, .next, dist, build",
+    })
+    .option("target", {
+      alias: "t",
+      type: "string",
+      description: "Input directory path",
+    })
+    .option("source", {
+      alias: "s",
+      type: "string",
+      description: "Source path of the local codemod to run",
+    })
+    .option("engine", {
+      type: "string",
+      description:
+        'The engine to use with the local codemod: "jscodeshift", "ts-morph", "filemod", "ast-grep"',
+    })
+    .option("format", {
+      type: "boolean",
+      default: DEFAULT_ENABLE_PRETTIER,
+      hidden: true,
+    })
+    .option("no-format", {
+      type: "boolean",
+      description: "Disable formatting output with Prettier",
+      hidden: true,
+    })
+    .option("threads", {
+      alias: "n",
+      type: "number",
+      description: "Number of worker threads",
+      default: DEFAULT_THREAD_COUNT,
+    })
+    .option("dry", {
+      alias: "d",
+      type: "boolean",
+      description: "Perform a dry run",
+      default: DEFAULT_DRY_RUN,
+    })
+    .option("install", {
+      type: "boolean",
+      default: DEFAULT_INSTALL,
+      hidden: true,
+    })
+    .option("no-install", {
+      type: "boolean",
+      description:
+        "Disable packages installation for the codemod run if there is `deps` field declared in its configuration",
+    });
 };

--- a/apps/cli/src/buildOptions.ts
+++ b/apps/cli/src/buildOptions.ts
@@ -84,6 +84,7 @@ export const buildRunOptions = <T>(y: Argv<T>) => {
       type: "string",
       description:
         'The engine to use with the local codemod: "jscodeshift", "ts-morph", "filemod", "ast-grep"',
+      hidden: true,
     })
     .option("format", {
       type: "boolean",

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -85,7 +85,8 @@ const checkFileTreeVersioning = async (target: string) => {
     const res = await inquirer.prompt<{ force: boolean }>({
       type: "confirm",
       name: "force",
-      message: "Could not run git working tree check. Proceed anyway?",
+      message:
+        "Could not run git working tree check. Codemod changes might be irreversible. Proceed anyway?",
       default: false,
     });
 
@@ -297,16 +298,20 @@ export const handleRunCliCommand = async (
       "info",
       boxen(
         chalk.cyan(
-          "Running with the following configuration:",
-          `\n\nCodemod:`,
+          `Codemod:`,
           chalk.bold(`${runningCodemodName}${runningCodemodVersion}`),
           isRunningFromLocal
             ? chalk.bold("\nRunning from local filesystem")
             : "",
-          chalk.bold(`\nTarget: ${flowSettings.target}`),
-          chalk.yellow.bold(`\n${reason ?? ""}`),
-          chalk.bold.green(`\nIncluded patterns: ${include.join(", ") ?? ""}`),
-          chalk.bold.red(`\nExcluded patterns: ${exclude.join(", ") ?? ""}`),
+          "\nTarget:",
+          chalk.bold(flowSettings.target),
+          "\n",
+          chalk.yellow(reason ? `\n${reason}` : ""),
+          chalk.green("\nIncluded patterns:"),
+          chalk.green.bold(include.join(", ") ?? ""),
+          chalk.red("\nExcluded patterns:"),
+          chalk.red.bold(exclude.join(", ") ?? ""),
+          "\n",
           chalk.yellow(
             !flowSettings.install ? "\nDependency installation disabled" : "",
           ),

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -101,7 +101,7 @@ export const handleRunCliCommand = async (
   telemetry: TelemetrySender<TelemetryEvent>,
 ) => {
   const codemodSettings = parseCodemodSettings(args);
-  const flowSettings = await parseFlowSettings(args, printer);
+  const flowSettings = parseFlowSettings(args, printer);
   const runSettings = parseRunSettings(homedir(), args);
 
   if (!runSettings.dryRun) {

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import * as fs from "node:fs";
-import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -19,24 +18,17 @@ import {
 import type { TelemetrySender } from "@codemod-com/telemetry";
 import {
   TarService,
-  capitalize,
   doubleQuotify,
   execPromise,
   parseCodemodConfig,
 } from "@codemod-com/utilities";
 import { AxiosError } from "axios";
-import columnify from "columnify";
 import inquirer from "inquirer";
 import terminalLink from "terminal-link";
 import type { TelemetryEvent } from "../analytics/telemetry.js";
 import { buildSourcedCodemodOptions } from "../buildCodemodOptions.js";
 import { buildCodemodEngineOptions } from "../buildEngineOptions.js";
-import type {
-  GlobalArgvOptions,
-  RunArgvOptions,
-  buildGlobalOptions,
-  buildRunOptions,
-} from "../buildOptions.js";
+import type { GlobalArgvOptions, RunArgvOptions } from "../buildOptions.js";
 import { CodemodDownloader } from "../downloadCodemod.js";
 import { buildPrinterMessageUponCommand } from "../fileCommands.js";
 import { FileDownloadService } from "../fileDownloadService.js";

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -109,7 +109,7 @@ export const handleRunCliCommand = async (
   telemetry: TelemetrySender<TelemetryEvent>,
 ) => {
   const codemodSettings = parseCodemodSettings(args);
-  const flowSettings = parseFlowSettings(args, printer);
+  const flowSettings = await parseFlowSettings(args, printer);
   const runSettings = parseRunSettings(homedir(), args);
 
   if (!runSettings.dryRun) {

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -31,7 +31,12 @@ import terminalLink from "terminal-link";
 import type { TelemetryEvent } from "../analytics/telemetry.js";
 import { buildSourcedCodemodOptions } from "../buildCodemodOptions.js";
 import { buildCodemodEngineOptions } from "../buildEngineOptions.js";
-import type { buildRunOptions } from "../buildOptions.js";
+import type {
+  GlobalArgvOptions,
+  RunArgvOptions,
+  buildGlobalOptions,
+  buildRunOptions,
+} from "../buildOptions.js";
 import { CodemodDownloader } from "../downloadCodemod.js";
 import { buildPrinterMessageUponCommand } from "../fileCommands.js";
 import { FileDownloadService } from "../fileDownloadService.js";
@@ -100,7 +105,7 @@ const checkFileTreeVersioning = async (target: string) => {
 
 export const handleRunCliCommand = async (
   printer: PrinterBlueprint,
-  args: Awaited<ReturnType<ReturnType<typeof buildRunOptions>>["argv"]>,
+  args: GlobalArgvOptions & RunArgvOptions,
   telemetry: TelemetrySender<TelemetryEvent>,
 ) => {
   const codemodSettings = parseCodemodSettings(args);

--- a/apps/cli/src/utils.ts
+++ b/apps/cli/src/utils.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { type PrinterBlueprint, chalk } from "@codemod-com/printer";
 import {
   type ValidateTokenResponse,
   execPromise,

--- a/apps/docs/deploying-codemods/cli.mdx
+++ b/apps/docs/deploying-codemods/cli.mdx
@@ -82,17 +82,21 @@ The following options can be used to change the default behavior of the Codemod 
   Can be used to specify the files to be targeted by the codemod.
 
 ```bash
-codemod [codemod name] -i "[glob pattern]"
+codemod [codemod name] -i "certain_file" -i "entire_folder/" -i "*.js"
 ```
+
+<Warning>Folders should be defined with a trailing slash, for example `node_modules/`. Every other entry will be treated as a file. We don't check whether the paths under a certain glob pattern are directories or not for performance reasons.</Warning>
 
 </ResponseField>
 
-<ResponseField name="--exclude (-e)" type="glob pattern" default="**/node_modules/**/*.*">
+<ResponseField name="--exclude (-e)" type="glob pattern" default="'node_modules/', 'dist/', 'build/', '.next/'">
   While running a codemod, you may want to prevent changes from occurring to specific parts of your project. The `--exclude` option can be used to specify a glob pattern of the files to be ignored by the codemod.
 
 ```bash
-codemod [codemod name] -e "[glob pattern]"
+codemod [codemod name] -e "certain_file" -e "entire_folder/" -e "*.py"
 ```
+  
+<Note>By default, Codemod CLI would also look for your project's root `.gitignore` file and exclude the patterns defined in it. The trailing slash rule mentioned in `--include` command description also applies to the `--exclude` option.</Note>
 
 </ResponseField>
 
@@ -125,7 +129,16 @@ codemod [codemod name] -t [path]
 
 </ResponseField>
 
-<ResponseField name="--no-format" type="boolean" default="false">
+<ResponseField name="--dry (-d)" type="boolean">
+  Can be used to switch to dry run mode. Dry running codemods helps you see the changes the codemod will make without affecting the project files.
+
+```bash
+codemod [codemod name] --dry
+```
+
+</ResponseField>
+
+<ResponseField name="--no-format" type="boolean">
   Can be used to disable prettier formatting to the files affected by the codemod.
 
 ```bash
@@ -134,7 +147,7 @@ codemod [codemod name] --no-format
 
 </ResponseField>
 
-<ResponseField name="--no-cache" type="boolean" default="false">
+<ResponseField name="--no-cache" type="boolean">
   Can be used to disable caching downloaded codemod files.
 
 ```bash
@@ -144,7 +157,7 @@ codemod [codemod name] --no-cache
   <Tip>Disabling cache can ensure you are getting the freshest results. While keeping the cache enabled can help you save bandwidth and time for repetitive use of the same codemods.</Tip>
 </ResponseField>
 
-<ResponseField name="--no-install" type="boolean" default="false">
+<ResponseField name="--no-install" type="boolean">
   Can be used to disable dependencies installation after codemod run.
 
 ```bash
@@ -155,7 +168,16 @@ codemod [codemod name] --no-install
   This option allows you to disable that behavior and handle dependency upgrades manually.</Warning>
 </ResponseField>
 
-<ResponseField name="--json (-j)" type="boolean" default="false">
+<ResponseField name="--no-telemetry" type="boolean">
+  Can be used to disable CLI telemetry data collection.
+
+```bash
+codemod [codemod name] --no-telemetry
+```
+
+</ResponseField>
+
+<ResponseField name="--json (-j)" type="boolean">
   Can be used to switch the CLI responses to JSON format.
 
 ```bash
@@ -169,24 +191,6 @@ codemod [codemod name] --json
 
 ```bash
 codemod [codemod name] -n [number of threads]
-```
-
-</ResponseField>
-
-<ResponseField name="--dry (-d)" type="boolean" default="false">
-  Can be used to switch to dry run mode. Dry running codemods helps you see the changes the codemod will make without affecting the project files.
-
-```bash
-codemod [codemod name] --dry
-```
-
-</ResponseField>
-
-<ResponseField name="--telemetryDisable" type="boolean" default="false">
-  Can be used to disable CLI telemetry data collection.
-
-```bash
-codemod [codemod name] --telemetryDisable [true/false]
 ```
 
 </ResponseField>
@@ -260,9 +264,15 @@ codemod publish
 codemod --help
 ```
 
+You can also use this flag in combination with a particular CLI command to display usage information relevant to that command.
+
+```bash
+codemod login --help
+```
+
 </ResponseField>
 
-<ResponseField name="--version">
+<ResponseField name="--version (-v)">
   Can be used to show the currently active version of Codemod CLI.
 
 ```bash

--- a/packages/runner/src/runCodemod.ts
+++ b/packages/runner/src/runCodemod.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { relative } from "node:path";
+import { join, relative } from "node:path";
 import type { Filemod } from "@codemod-com/filemod";
 import { chalk } from "@codemod-com/printer";
 import {
@@ -55,15 +55,15 @@ export const buildPatterns = async (
       formattedPattern = `**/${pattern}`;
     }
 
-    if (!formattedPattern.includes(".")) {
-      formattedPattern = `${formattedPattern}/**/*.*`;
+    if (!formattedPattern.endsWith("**/*.*")) {
+      return [formattedPattern, join(formattedPattern, "**/*.*`")];
     }
 
     return formattedPattern;
   };
 
   const excludePatterns = flowSettings.exclude ?? [];
-  const formattedExclude = excludePatterns.map(formatFunc);
+  const formattedExclude = excludePatterns.flatMap(formatFunc);
 
   const { files } = flowSettings;
 
@@ -129,7 +129,7 @@ export const buildPatterns = async (
 
   // Prepend the pattern with "**/" if user didn't specify it, so that we cover more files that user wants us to
   const formattedInclude = patterns
-    .map(formatFunc)
+    .flatMap(formatFunc)
     .concat(engineDefaultPatterns);
 
   const exclude = formattedExclude.filter((p) => {
@@ -361,6 +361,7 @@ export const runCodemod = async (
       absolute: true,
       cwd: flowSettings.target,
       ignore: paths.exclude,
+      dot: true,
       // @ts-expect-error type inconsistency
       fs: mfs,
       onlyFiles: true,

--- a/packages/runner/src/runCodemod.ts
+++ b/packages/runner/src/runCodemod.ts
@@ -142,10 +142,12 @@ export const buildPatterns = async (
   let reason: string | undefined;
   let patterns: string[] | undefined = undefined;
   if (flowSettings.include) {
-    reason = "Using paths provided by user via options";
+    reason =
+      "Using paths provided by user via options (combined with engine defaults)";
     patterns = flowSettings.include;
   } else if (codemod.include) {
-    reason = "Using paths provided by codemod settings";
+    reason =
+      "Using paths provided by codemod settings (combined with engine defaults)";
     patterns = codemod.include;
   }
 

--- a/packages/runner/src/runCodemod.ts
+++ b/packages/runner/src/runCodemod.ts
@@ -49,10 +49,8 @@ export const buildPatterns = async (
   const formatFunc = (pattern: string) => {
     let formattedPattern = pattern;
 
-    if (pattern.startsWith("**")) {
+    if (pattern.startsWith("**") || pattern.startsWith("/")) {
       formattedPattern = pattern;
-    } else if (pattern.startsWith("/")) {
-      formattedPattern = `**${pattern}`;
     } else {
       formattedPattern = `**/${pattern}`;
     }

--- a/packages/runner/src/schemata/codemodSettingsSchema.ts
+++ b/packages/runner/src/schemata/codemodSettingsSchema.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import {
   type Output,
   array,
@@ -46,24 +47,22 @@ export const parseCodemodSettings = (input: unknown): CodemodSettings => {
     };
   }
 
-  const source = codemodSettings.source;
+  const nameOrPath = codemodSettings._.at(0);
 
-  if (source) {
+  if (!nameOrPath) {
+    throw new Error("Codemod to run was not specified!");
+  }
+
+  if (existsSync(nameOrPath) || codemodSettings.source) {
     return {
       kind: "runSourced",
-      source,
+      source: codemodSettings.source ?? nameOrPath,
       engine: codemodSettings.engine ?? null,
     };
   }
 
-  const codemodName = codemodSettings._.at(-1);
-
-  if (!codemodName) {
-    throw new Error("Codemod to run was not specified!");
-  }
-
   return {
     kind: "runNamed",
-    name: codemodName,
+    name: nameOrPath,
   };
 };

--- a/packages/runner/src/schemata/flowSettingsSchema.ts
+++ b/packages/runner/src/schemata/flowSettingsSchema.ts
@@ -14,6 +14,7 @@ import {
 
 export const DEFAULT_EXCLUDE_PATTERNS = [
   "**/node_modules/**/*.*",
+  "**/*.d.ts",
   "**/.next/**/*.*",
   "**/dist/**/*.*",
   "**/build/**/*.*",

--- a/packages/runner/src/schemata/flowSettingsSchema.ts
+++ b/packages/runner/src/schemata/flowSettingsSchema.ts
@@ -1,7 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { resolve } from "node:path";
 import { type PrinterBlueprint, chalk } from "@codemod-com/printer";
-import { glob } from "fast-glob";
 import {
   type Output,
   array,
@@ -74,41 +72,9 @@ export const parseFlowSettings = async (
       positionalPassedTarget ?? argTarget ?? DEFAULT_INPUT_DIRECTORY_PATH;
   }
 
-  const targetAbs = resolve(target);
-
-  const gitIgnorePaths = await glob("**/.gitignore", {
-    cwd: targetAbs,
-    absolute: true,
-  });
-
-  let gitIgnored: string[] = [];
-  if (gitIgnorePaths.length > 0) {
-    printer.printConsoleMessage(
-      "info",
-      chalk.cyan(
-        "Found .gitignore file(s) in the target directory:",
-        `\n- ${gitIgnorePaths.join("\n- ")}`,
-        "Adding the ignored paths to the exclude list...",
-      ),
-    );
-
-    for (const gitIgnorePath of gitIgnorePaths) {
-      const gitIgnoreContents = await readFile(gitIgnorePath, "utf-8");
-      gitIgnored = gitIgnored.concat(
-        gitIgnoreContents
-          .split("\n")
-          .map((line) => line.trim())
-          .filter((line) => line.length > 0 && !line.startsWith("#"))
-          .map((line) => join(dirname(gitIgnorePath), line)),
-      );
-    }
-  }
-
   return {
     ...flowSettings,
-    target: targetAbs,
-    exclude: (flowSettings.exclude ?? [])
-      .concat(DEFAULT_EXCLUDE_PATTERNS)
-      .concat(gitIgnored),
+    target: resolve(target),
+    exclude: (flowSettings.exclude ?? []).concat(DEFAULT_EXCLUDE_PATTERNS),
   };
 };

--- a/packages/runner/src/schemata/flowSettingsSchema.ts
+++ b/packages/runner/src/schemata/flowSettingsSchema.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { type PrinterBlueprint, chalk } from "@codemod-com/printer";
 import { glob } from "fast-glob";
 import {
@@ -98,7 +98,8 @@ export const parseFlowSettings = async (
         gitIgnoreContents
           .split("\n")
           .map((line) => line.trim())
-          .filter((line) => line.length > 0 && !line.startsWith("#")),
+          .filter((line) => line.length > 0 && !line.startsWith("#"))
+          .map((line) => join(dirname(gitIgnorePath), line)),
       );
     }
   }

--- a/packages/runner/src/schemata/flowSettingsSchema.ts
+++ b/packages/runner/src/schemata/flowSettingsSchema.ts
@@ -12,7 +12,12 @@ import {
   string,
 } from "valibot";
 
-export const DEFAULT_EXCLUDE_PATTERNS = ["**/node_modules/**/*.*", "**/*.d.ts"];
+export const DEFAULT_EXCLUDE_PATTERNS = [
+  "**/node_modules/**/*.*",
+  "**/*.d.ts",
+  "**/.next/**/*.*",
+  "**/dist/**/*.*",
+];
 export const DEFAULT_INPUT_DIRECTORY_PATH = process.cwd();
 export const DEFAULT_ENABLE_PRETTIER = true;
 export const DEFAULT_CACHE = true;
@@ -25,7 +30,7 @@ export const flowSettingsSchema = object({
   _: array(string()),
   include: optional(array(string())),
   exclude: optional(array(string())),
-  target: optional(string(), DEFAULT_INPUT_DIRECTORY_PATH),
+  target: optional(string()),
   files: optional(array(string())),
   format: optional(boolean(), DEFAULT_ENABLE_PRETTIER),
   cache: optional(boolean(), DEFAULT_CACHE),
@@ -36,8 +41,9 @@ export const flowSettingsSchema = object({
 
 export type FlowSettings = Omit<
   Output<typeof flowSettingsSchema>,
-  "exclude"
+  "exclude" | "target"
 > & {
+  target: string;
   exclude: string[];
 };
 
@@ -61,7 +67,8 @@ export const parseFlowSettings = (
 
     target = argTarget;
   } else {
-    target = positionalPassedTarget ?? argTarget;
+    target =
+      positionalPassedTarget ?? argTarget ?? DEFAULT_INPUT_DIRECTORY_PATH;
   }
 
   return {

--- a/packages/runner/src/schemata/flowSettingsSchema.ts
+++ b/packages/runner/src/schemata/flowSettingsSchema.ts
@@ -14,9 +14,9 @@ import {
 
 export const DEFAULT_EXCLUDE_PATTERNS = [
   "**/node_modules/**/*.*",
-  "**/*.d.ts",
   "**/.next/**/*.*",
   "**/dist/**/*.*",
+  "**/build/**/*.*",
 ];
 export const DEFAULT_INPUT_DIRECTORY_PATH = process.cwd();
 export const DEFAULT_ENABLE_PRETTIER = true;
@@ -25,6 +25,7 @@ export const DEFAULT_INSTALL = true;
 export const DEFAULT_USE_JSON = false;
 export const DEFAULT_THREAD_COUNT = 4;
 export const DEFAULT_DRY_RUN = false;
+export const DEFAULT_TELEMETRY = true;
 
 export const flowSettingsSchema = object({
   _: array(string()),

--- a/packages/runner/src/schemata/flowSettingsSchema.ts
+++ b/packages/runner/src/schemata/flowSettingsSchema.ts
@@ -48,10 +48,10 @@ export type FlowSettings = Omit<
   exclude: string[];
 };
 
-export const parseFlowSettings = async (
+export const parseFlowSettings = (
   input: unknown,
   printer: PrinterBlueprint,
-): Promise<FlowSettings> => {
+): FlowSettings => {
   const flowSettings = parse(flowSettingsSchema, input);
 
   const positionalPassedTarget = flowSettings._.at(1);

--- a/packages/utilities/src/functions/projectRoot.ts
+++ b/packages/utilities/src/functions/projectRoot.ts
@@ -1,0 +1,117 @@
+import { constants, access } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { execPromise } from "./node.js";
+
+export type PackageManager = "yarn" | "npm" | "pnpm" | "bun";
+
+export const lockFilesToPmMap: Record<string, PackageManager> = {
+  "package-lock.json": "npm",
+  "yarn.lock": "yarn",
+  "pnpm-lock.yaml": "pnpm",
+  "bun.lockb": "bun",
+};
+
+export async function getProjectRootPathAndPackageManager(
+  target: string,
+  onlyRoot: true,
+): Promise<{ rootPath: string | null }>;
+export async function getProjectRootPathAndPackageManager(
+  target: string,
+  onlyRoot?: false,
+): Promise<{ rootPath: string | null; detectedPackageManager: string | null }>;
+export async function getProjectRootPathAndPackageManager(
+  target: string,
+  onlyRoot = false,
+): Promise<
+  | { rootPath: string | null }
+  | { rootPath: string | null; detectedPackageManager: string | null }
+> {
+  let detectedPackageManager: PackageManager | null = null;
+
+  let rootPath: string | null = null;
+  try {
+    const { stdout } = await execPromise("git rev-parse --show-toplevel", {
+      cwd: target,
+    });
+    const output = stdout.trim();
+    if (output.length) {
+      rootPath = output;
+
+      if (onlyRoot) {
+        return { rootPath };
+      }
+    }
+  } catch (error) {
+    //
+  }
+
+  // did not find root using git CLI. we can try to find it using .git directory
+  if (rootPath === null) {
+    let currentDir = target;
+
+    while (true) {
+      try {
+        await access(join(currentDir, ".git"), constants.R_OK | constants.W_OK);
+
+        const packageJsonPath = join(currentDir, "package.json");
+
+        await access(packageJsonPath, constants.R_OK | constants.W_OK);
+        rootPath = currentDir;
+      } catch {
+        //
+      }
+
+      if (rootPath) {
+        if (onlyRoot) {
+          return { rootPath };
+        }
+
+        break;
+      }
+
+      const parentDir = dirname(currentDir);
+      if (parentDir === currentDir) break; // Reached the filesystem root
+      currentDir = parentDir;
+    }
+  }
+
+  // do lockfiles lookup and determine package manager, set rootPath if it's still null
+  let currentDir = target;
+
+  while (true) {
+    for (const lockFile of Object.keys(lockFilesToPmMap)) {
+      try {
+        await access(
+          join(currentDir, lockFile),
+          constants.R_OK | constants.W_OK,
+        );
+
+        detectedPackageManager = lockFilesToPmMap[lockFile]!;
+        if (rootPath === null) {
+          rootPath = currentDir;
+        }
+
+        break;
+      } catch (err) {
+        //
+      }
+    }
+
+    if (rootPath) {
+      if (onlyRoot) {
+        return { rootPath };
+      }
+
+      break;
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) break; // Reached the filesystem root
+    currentDir = parentDir;
+  }
+
+  return {
+    rootPath,
+    detectedPackageManager,
+  };
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./constants.js";
-export * from "./schemata/types.js";
 export { debounce } from "./functions/debounce.js";
 export {
   backtickify,
@@ -16,6 +15,10 @@ export {
   streamToString,
 } from "./functions/hash.js";
 export { execPromise, isGeneratorEmpty, sleep } from "./functions/node.js";
+export {
+  getProjectRootPathAndPackageManager,
+  type PackageManager,
+} from "./functions/projectRoot.js";
 export {
   assertsNeitherNullOrUndefined,
   isNeitherNullNorUndefined,
@@ -42,6 +45,10 @@ export {
   getUnifiedEntry,
   trimLicense,
 } from "./registry.js";
+export type {
+  CodemodDownloadLinkResponse,
+  CodemodListResponse,
+} from "./schemata/apiResponses.js";
 export {
   argumentRecordSchema,
   argumentSchema,
@@ -68,27 +75,24 @@ export {
   type KnownEngines,
   type PiranhaLanguage,
 } from "./schemata/codemodConfigSchema.js";
-export type {
-  CodemodListResponse,
-  CodemodDownloadLinkResponse,
-} from "./schemata/apiResponses.js";
 export {
   codemodRunBodySchema,
   validateCodemodStatusParamsSchema,
   type CodemodRunResponse,
 } from "./schemata/codemodRunSchema.js";
 export {
+  engineOptionsSchema,
+  parseEngineOptions,
+  type EngineOptions,
+} from "./schemata/engineOptionsSchema.js";
+export {
   JOB_KIND,
   parseSurfaceAgnosticJob,
   type SurfaceAgnosticJob,
 } from "./schemata/surfaceAgnosticJobSchema.js";
+export * from "./schemata/types.js";
 export { type FileSystem } from "./schemata/types.js";
 export { type ValidateTokenResponse } from "./schemata/validateTokenResponse.js";
-export {
-  type EngineOptions,
-  engineOptionsSchema,
-  parseEngineOptions,
-} from "./schemata/engineOptionsSchema.js";
 export { CaseReadingService } from "./services/case/caseReadingService.js";
 export { CaseWritingService } from "./services/case/caseWritingService.js";
 export { FileWatcher } from "./services/case/fileWatcher.js";


### PR DESCRIPTION
- Now showing the target that codemod is going to run on in the run summary
- Codemod include and exclude patterns became smarter. If they are provided by user through options or through codemod config options, include patterns take priority. If they are determined by engine or set by ast-grep configuration, exclude patterns provided by user through arguments will take over. Depending on which one has the priority, the other list will be filtered to not contain patterns from the prioritized list.
- Added `dist`, `build`, `.next` folders to default excluded patterns
- Removed .d.ts files from ignored by default
- Now we assume that path is a directory and should be formatted as `**/path/**/*.*` glob pattern if user supplies it with a trailing slash
- Now supporting specifying target path through positional argument without needing to prepend `-t`
- Now populating exclude patterns from root `.gitignore` file in the target directory
- Improved argv options in general, now the help menu looks like this:
<img width="616" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/f5975379-342a-4be2-bbc1-21b96dadc845">
which is much more comprehensive for the user.

Some examples:
<img width="1140" alt="image" src="https://github.com/codemod-com/codemod/assets/44036750/8aa5663c-f715-4103-a7ea-1af9df4deab9">
