### PR TITLE
[Registry] react/19/replace-reactdom-render support unmountComponentAtNode

### DIFF
--- a/packages/codemods/react/19/replace-reactdom-render/.codemodrc.json
+++ b/packages/codemods/react/19/replace-reactdom-render/.codemodrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": false,
   "name": "react/19/replace-reactdom-render",
   "engine": "jscodeshift",

--- a/packages/codemods/react/19/replace-reactdom-render/README.md
+++ b/packages/codemods/react/19/replace-reactdom-render/README.md
@@ -2,8 +2,9 @@
 
 ## Description
 
- - Replaces usages of `ReactDom.render()` with `createRoot(node).render()`.
- - Replaces usages of `ReactDom.hydrate()` with `hydrateRoot()`
+- Replaces usages of `ReactDom.render()` with `createRoot(node).render()`.
+- Replaces usages of `ReactDom.hydrate()` with `hydrateRoot()`
+- Replaces usages of `ReactDom.unmountComponentAtNode()` with `root.unmount()`
 
 ## Examples
 

--- a/packages/codemods/react/19/replace-reactdom-render/__testfixtures__/unmount.input.js
+++ b/packages/codemods/react/19/replace-reactdom-render/__testfixtures__/unmount.input.js
@@ -1,0 +1,3 @@
+import { unmountComponentAtNode } from "react-dom";
+
+unmountComponentAtNode(anything);

--- a/packages/codemods/react/19/replace-reactdom-render/__testfixtures__/unmount.output.js
+++ b/packages/codemods/react/19/replace-reactdom-render/__testfixtures__/unmount.output.js
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+import { unmountComponentAtNode } from "react-dom";
+
+const root = createRoot(anything);
+root.unmount();

--- a/packages/codemods/react/19/replace-reactdom-render/src/index.ts
+++ b/packages/codemods/react/19/replace-reactdom-render/src/index.ts
@@ -219,13 +219,13 @@ export default function transform(
   );
 
   root.find(j.CallExpression).forEach((path) => {
-    const name = matchMethod(path);
+    const match = matchMethod(path);
 
-    if (name === null) {
+    if (match === null) {
       return;
     }
 
-    const replaceMethod = replacementFunctions[name];
+    const replaceMethod = replacementFunctions[match];
 
     replaceMethod(j, root, path);
     isDirty = true;

--- a/packages/codemods/react/19/replace-reactdom-render/src/index.ts
+++ b/packages/codemods/react/19/replace-reactdom-render/src/index.ts
@@ -115,6 +115,41 @@ export default function transform(
     });
 
   /**
+   * replace unmountComponentAtNode
+   */
+
+  findMethodCalls(
+    j,
+    root,
+    "unmountComponentAtNode",
+    reactNamedImportNamesToLocalNamesMap.get("unmountComponentAtNode") ?? "",
+    reactDomDefaultImportName ?? "",
+  ).forEach((path) => {
+    const args = path.value.arguments;
+
+    const createRoot = j.variableDeclaration("const", [
+      j.variableDeclarator(
+        j.identifier("root"),
+        j.callExpression(j.identifier("createRoot"), [args[0]]),
+      ),
+    ]);
+
+    const unmount = j.expressionStatement(
+      j.callExpression(
+        j.memberExpression(j.identifier("root"), j.identifier("unmount")),
+        [],
+      ),
+    );
+
+    addNamedImport(j, root, "createRoot", "react-dom/client");
+
+    path.parent.replace(createRoot);
+    path.parent.insertAfter(unmount);
+
+    isDirty = true;
+  });
+
+  /**
    * replace ReactDOM.hydrate
    */
 

--- a/packages/codemods/react/19/replace-reactdom-render/src/index.ts
+++ b/packages/codemods/react/19/replace-reactdom-render/src/index.ts
@@ -1,37 +1,39 @@
 import type {
   API,
+  ASTPath,
+  CallExpression,
   Collection,
   FileInfo,
   JSCodeshift,
-  Options,
 } from "jscodeshift";
 
-const findMethodCalls = (
-  j: JSCodeshift,
-  root: Collection<any>,
-  methodName: string,
-  namedImportLocalName: string,
-  defaultImportName: string,
-) =>
-  root.find(j.CallExpression).filter((path) => {
+const getMatcher =
+  (
+    j: JSCodeshift,
+    importSpecifiersLocalNames: string[],
+    importedModuleName: string,
+  ) =>
+  (path: ASTPath<CallExpression>) => {
     const { callee } = path.value;
 
-    if (j.Identifier.check(callee) && callee.name === namedImportLocalName) {
-      return true;
+    if (
+      j.Identifier.check(callee) &&
+      importSpecifiersLocalNames.includes(callee.name)
+    ) {
+      return callee.name;
     }
 
     if (
       j.MemberExpression.check(callee) &&
       j.Identifier.check(callee.object) &&
-      callee.object.name === defaultImportName &&
-      j.Identifier.check(callee.property) &&
-      callee.property.name === methodName
+      callee.object.name === importedModuleName &&
+      j.Identifier.check(callee.property)
     ) {
-      return true;
+      return callee.property.name;
     }
 
-    return false;
-  });
+    return null;
+  };
 
 const getImportDeclaration = (
   j: JSCodeshift,
@@ -77,132 +79,156 @@ const addNamedImport = (
   }
 };
 
-export default function transform(
-  file: FileInfo,
-  api: API,
-  options?: Options,
-): string | undefined {
-  const j = api.jscodeshift;
-  const root = j(file.source);
+const collectImportNames = (
+  j: JSCodeshift,
+  root: Collection,
+  source: string,
+) => {
+  const importSpecifierLocalNames = new Map<string, string>();
 
-  const reactNamedImportNamesToLocalNamesMap = new Map<string, string>();
+  let importDefaultSpecifierName: string | null = null;
+  let importNamespaceSpecifierName: string | null = null;
 
-  let reactDomDefaultImportName: string | null = null;
-
-  let isDirty = false;
   root
     .find(j.ImportDeclaration, {
-      source: { value: "react-dom" },
+      source: { value: source },
     })
     .forEach((path) => {
       path.value.specifiers?.forEach((specifier) => {
-        // named import
         if (j.ImportSpecifier.check(specifier)) {
-          reactNamedImportNamesToLocalNamesMap.set(
+          importSpecifierLocalNames.set(
             specifier.imported.name,
             specifier.local?.name ?? "",
           );
         }
 
-        // default and wildcard import
-        if (
-          j.ImportDefaultSpecifier.check(specifier) ||
-          j.ImportNamespaceSpecifier.check(specifier)
-        ) {
-          reactDomDefaultImportName = specifier.local?.name ?? null;
+        if (j.ImportDefaultSpecifier.check(specifier) && specifier.local) {
+          importDefaultSpecifierName = specifier.local.name;
+        }
+
+        if (j.ImportNamespaceSpecifier.check(specifier) && specifier.local) {
+          importNamespaceSpecifierName = specifier.local.name;
         }
       });
     });
 
-  /**
-   * replace unmountComponentAtNode
-   */
+  return {
+    importSpecifierLocalNames,
+    importDefaultSpecifierName,
+    importNamespaceSpecifierName,
+  };
+};
 
-  findMethodCalls(
+const replaceHydrate = (
+  j: JSCodeshift,
+  root: Collection,
+  path: ASTPath<CallExpression>,
+) => {
+  const args = path.value.arguments;
+
+  const hydrateRoot = j.expressionStatement(
+    j.callExpression(j.identifier("hydrateRoot"), [args[1], args[0]]),
+  );
+
+  addNamedImport(j, root, "hydrateRoot", "react-dom/client");
+  path.parent.replace(hydrateRoot);
+};
+
+const replaceRender = (
+  j: JSCodeshift,
+  root: Collection,
+  path: ASTPath<CallExpression>,
+) => {
+  const args = path.value.arguments;
+
+  const createRoot = j.variableDeclaration("const", [
+    j.variableDeclarator(
+      j.identifier("root"),
+      j.callExpression(j.identifier("createRoot"), [args[1]]),
+    ),
+  ]);
+
+  const render = j.expressionStatement(
+    j.callExpression(
+      j.memberExpression(j.identifier("root"), j.identifier("render")),
+      [args[0]],
+    ),
+  );
+
+  addNamedImport(j, root, "createRoot", "react-dom/client");
+
+  path.parent.replace(createRoot);
+  path.parent.insertAfter(render);
+};
+
+const replaceUnmountComponentAtNode = (
+  j: JSCodeshift,
+  root: Collection,
+  path: ASTPath<CallExpression>,
+) => {
+  const args = path.value.arguments;
+
+  const createRoot = j.variableDeclaration("const", [
+    j.variableDeclarator(
+      j.identifier("root"),
+      j.callExpression(j.identifier("createRoot"), [args[0]]),
+    ),
+  ]);
+
+  const unmount = j.expressionStatement(
+    j.callExpression(
+      j.memberExpression(j.identifier("root"), j.identifier("unmount")),
+      [],
+    ),
+  );
+
+  addNamedImport(j, root, "createRoot", "react-dom/client");
+
+  path.parent.replace(createRoot);
+  path.parent.insertAfter(unmount);
+};
+
+const replacementFunctions: Record<string, (...args: any) => any> = {
+  render: replaceRender,
+  hydrate: replaceHydrate,
+  unmountComponentAtNode: replaceUnmountComponentAtNode,
+};
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  let isDirty = false;
+
+  const {
+    importNamespaceSpecifierName,
+    importDefaultSpecifierName,
+    importSpecifierLocalNames,
+  } = collectImportNames(j, root, "react-dom");
+
+  const importedModuleName =
+    importDefaultSpecifierName ?? importNamespaceSpecifierName ?? "";
+
+  const matchMethod = getMatcher(
     j,
-    root,
-    "unmountComponentAtNode",
-    reactNamedImportNamesToLocalNamesMap.get("unmountComponentAtNode") ?? "",
-    reactDomDefaultImportName ?? "",
-  ).forEach((path) => {
-    const args = path.value.arguments;
+    [...importSpecifierLocalNames.values()],
+    importedModuleName,
+  );
 
-    const createRoot = j.variableDeclaration("const", [
-      j.variableDeclarator(
-        j.identifier("root"),
-        j.callExpression(j.identifier("createRoot"), [args[0]]),
-      ),
-    ]);
+  root.find(j.CallExpression).forEach((path) => {
+    const name = matchMethod(path);
 
-    const unmount = j.expressionStatement(
-      j.callExpression(
-        j.memberExpression(j.identifier("root"), j.identifier("unmount")),
-        [],
-      ),
-    );
+    if (name === null) {
+      return;
+    }
 
-    addNamedImport(j, root, "createRoot", "react-dom/client");
+    const replaceMethod = replacementFunctions[name];
 
-    path.parent.replace(createRoot);
-    path.parent.insertAfter(unmount);
-
+    replaceMethod(j, root, path);
     isDirty = true;
-  });
-
-  /**
-   * replace ReactDOM.hydrate
-   */
-
-  findMethodCalls(
-    j,
-    root,
-    "hydrate",
-    reactNamedImportNamesToLocalNamesMap.get("hydrate") ?? "",
-    reactDomDefaultImportName ?? "",
-  ).forEach((path) => {
-    const args = path.value.arguments;
-
-    const hydrateRoot = j.expressionStatement(
-      j.callExpression(j.identifier("hydrateRoot"), [args[1], args[0]]),
-    );
-
-    isDirty = true;
-
-    addNamedImport(j, root, "hydrateRoot", "react-dom/client");
-    path.parent.replace(hydrateRoot);
-  });
-
-  /**
-   * replace ReactDOM.render
-   */
-  findMethodCalls(
-    j,
-    root,
-    "render",
-    reactNamedImportNamesToLocalNamesMap.get("render") ?? "",
-    reactDomDefaultImportName ?? "",
-  ).forEach((path) => {
-    const args = path.value.arguments;
-
-    const createRoot = j.variableDeclaration("const", [
-      j.variableDeclarator(
-        j.identifier("root"),
-        j.callExpression(j.identifier("createRoot"), [args[1]]),
-      ),
-    ]);
-
-    const render = j.expressionStatement(
-      j.callExpression(
-        j.memberExpression(j.identifier("root"), j.identifier("render")),
-        [args[0]],
-      ),
-    );
-
-    isDirty = true;
-    addNamedImport(j, root, "createRoot", "react-dom/client");
-
-    path.parent.replace(createRoot);
-    path.parent.insertAfter(render);
   });
 
   return isDirty ? root.toSource() : undefined;

--- a/packages/codemods/react/19/replace-reactdom-render/test/test.ts
+++ b/packages/codemods/react/19/replace-reactdom-render/test/test.ts
@@ -111,7 +111,29 @@ describe("react/19/replace-reactdom-render", () => {
       buildApi("tsx"),
     );
 
-    console.log(actualOutput, "???");
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
+
+  it("should replace reactdom.unmountComponentAtNode with root.unmount()", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/unmount.input.js"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/unmount.output.js"),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
 
     assert.deepEqual(
       actualOutput?.replace(/W/gm, ""),


### PR DESCRIPTION
 - support replacement of `reactDom. unmountComponentAtNode`
 - refactor codemod

