### PR TITLE
[CLI] fix: version

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/executeMainThread.ts
+++ b/apps/cli/src/executeMainThread.ts
@@ -127,6 +127,10 @@ export const executeMainThread = async () => {
     yargs(slicedArgv).help().version(false),
   );
 
+  if (slicedArgv.includes("--version") || slicedArgv.includes("-v")) {
+    return console.log(version);
+  }
+
   argvObject
     .scriptName("codemod")
     .usage("Usage: <command> [options]")
@@ -332,10 +336,6 @@ export const executeMainThread = async () => {
   }
 
   const argv = await argvObject.parse();
-
-  if (argv.version) {
-    return console.log(version);
-  }
 
   {
     const { exit } = await initializeDependencies(argv);


### PR DESCRIPTION
Because our CLI has no dedicated command for running, it enters running command execution before it can reach the version console.log logic. It is also impossible to access yargs argv twice, so instead we are just checking for presence of the version flag manually without yargs help.