### PR TITLE
[CLI] fix: improve not found messages

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -183,7 +183,9 @@ export const handleRunCliCommand = async (
         }
       }
 
-      throw new Error(`Error while downloading codemod ${name}: ${error}`);
+      throw new Error(
+        `Error while downloading codemod ${codemodSettings.name}: ${error}`,
+      );
     }
 
     const engineOptions = buildCodemodEngineOptions(codemod.engine, args);

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -10,6 +10,7 @@ import {
   parseCodemodConfig,
 } from "@codemod-com/utilities";
 import type { TarService } from "@codemod-com/utilities";
+import type { AxiosError } from "axios";
 import inquirer from "inquirer";
 import type { Ora } from "ora";
 import semver from "semver";
@@ -65,10 +66,14 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 
     let linkResponse: CodemodDownloadLinkResponse;
     try {
+      console.log(1);
       linkResponse = await getCodemodDownloadURI(name, userData?.token);
     } catch (err) {
       spinner?.fail();
-      throw new Error(`Error getting download link for codemod:\n${err}`);
+      throw new Error(
+        (err as AxiosError<{ error: string }>).response?.data.error ??
+          "Error getting download link for codemod",
+      );
     }
     const localCodemodPath = join(directoryPath, "codemod.tar.gz");
 
@@ -77,22 +82,27 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
     >;
 
     try {
+      console.log(2);
       downloadResult = await this._fileDownloadService.download(
         linkResponse.link,
         localCodemodPath,
       );
     } catch (err) {
       spinner?.fail();
-      throw new Error(`Error downloading codemod:\n${err}`);
+      throw new Error(
+        (err as AxiosError<{ error: string }>).response?.data.error ??
+          "Error downloading codemod from the registry",
+      );
     }
 
     const { data, cacheUsed, cacheReason } = downloadResult;
 
     try {
+      console.log(3);
       await this._tarService.unpack(directoryPath, data);
     } catch (err) {
       spinner?.fail();
-      throw new Error(`Error unpacking codemod:\n${err}`);
+      throw new Error((err as Error).message ?? "Error unpacking codemod");
     }
 
     spinner?.succeed();

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -70,7 +70,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
     } catch (err) {
       spinner?.fail();
       throw new Error(
-        (err as AxiosError<{ error: string }>).response?.data.error ??
+        (err as AxiosError<{ error: string }>).response?.data?.error ??
           "Error getting download link for codemod",
       );
     }
@@ -88,7 +88,7 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
     } catch (err) {
       spinner?.fail();
       throw new Error(
-        (err as AxiosError<{ error: string }>).response?.data.error ??
+        (err as AxiosError<{ error: string }>).response?.data?.error ??
           "Error downloading codemod from the registry",
       );
     }

--- a/apps/cli/src/downloadCodemod.ts
+++ b/apps/cli/src/downloadCodemod.ts
@@ -66,7 +66,6 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
 
     let linkResponse: CodemodDownloadLinkResponse;
     try {
-      console.log(1);
       linkResponse = await getCodemodDownloadURI(name, userData?.token);
     } catch (err) {
       spinner?.fail();
@@ -82,7 +81,6 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
     >;
 
     try {
-      console.log(2);
       downloadResult = await this._fileDownloadService.download(
         linkResponse.link,
         localCodemodPath,
@@ -98,7 +96,6 @@ export class CodemodDownloader implements CodemodDownloaderBlueprint {
     const { data, cacheUsed, cacheReason } = downloadResult;
 
     try {
-      console.log(3);
       await this._tarService.unpack(directoryPath, data);
     } catch (err) {
       spinner?.fail();


### PR DESCRIPTION
Fixes a bug where CLI would throw weird error with no clear description if codemod was not found.