### PR TITLE
[vsce] fix styles of loading screen and cli not found screen

### DIFF
--- a/apps/vsce/webview/src/CodemodEngineNodeNotFound/index.tsx
+++ b/apps/vsce/webview/src/CodemodEngineNodeNotFound/index.tsx
@@ -2,10 +2,11 @@ import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react";
 import cn from "classnames";
 import styles from "./style.module.css";
 
-const INSTALL_CODEMOD_ENGINE_NODE_COMMAND = "npm i -g codemod";
+const INSTALL_CODEMOD_ENGINE_NODE_COMMAND_NPM = "npm i -g codemod";
+const INSTALL_CODEMOD_ENGINE_NODE_COMMAND_PNPM = "pnpm i -g codemod";
 
-const handleCopyCommand = () => {
-  navigator.clipboard.writeText(INSTALL_CODEMOD_ENGINE_NODE_COMMAND);
+const handleCopyCommand = (command: string) => {
+  navigator.clipboard.writeText(command);
 };
 
 const CodemodEngineNodeNotFound = () => {
@@ -13,24 +14,31 @@ const CodemodEngineNodeNotFound = () => {
     <div className={styles.root}>
       <h1>Halfway there!</h1>
       <p>
-        Use this command to install the latest Codemod CLI and complete the
-        installation:
+        Use one of the two commands below to install the latest Codemod CLI and
+        complete the installation:
       </p>
-      <VSCodeTextField
-        className={styles.command}
-        readOnly
-        value={INSTALL_CODEMOD_ENGINE_NODE_COMMAND}
-      >
-        <span
-          slot="start"
-          className={cn(styles.icon, "codicon", "codicon-chevron-right")}
-        />
-        <span
-          slot="end"
-          className={cn(styles.icon, "codicon", "codicon-copy")}
-          onClick={handleCopyCommand}
-        />
-      </VSCodeTextField>
+      {[
+        INSTALL_CODEMOD_ENGINE_NODE_COMMAND_NPM,
+        INSTALL_CODEMOD_ENGINE_NODE_COMMAND_PNPM,
+      ].map((command) => (
+        <VSCodeTextField
+          key={command}
+          className={styles.command}
+          readOnly
+          value={command}
+        >
+          <span
+            slot="start"
+            className={cn(styles.icon, "codicon", "codicon-chevron-right")}
+          />
+          <span
+            slot="end"
+            className={cn(styles.icon, "codicon", "codicon-copy")}
+            onClick={() => handleCopyCommand(command)}
+          />
+        </VSCodeTextField>
+      ))}
+
       <small className={styles.reminder}>
         Reminder, Codemod is CLI-centric so you can use its core features
         without an IDE and easily integrate it with the existing tools in your

--- a/apps/vsce/webview/src/CodemodEngineNodeNotFound/style.module.css
+++ b/apps/vsce/webview/src/CodemodEngineNodeNotFound/style.module.css
@@ -1,22 +1,22 @@
 .root {
-	text-align: center;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	height: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  margin-left: 1rem;
 }
 
 .icon {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 .command {
-	width: 200px;
+  width: 200px;
+  margin-bottom: 1rem;
 }
 
 .reminder {
-	/* margin-top: 10px; */
-	position: absolute;
-	margin-bottom: 20px;
-	bottom: 0;
+  /* margin-top: 10px; */
+  position: absolute;
+  margin-bottom: 20px;
+  bottom: 0;
 }

--- a/apps/vsce/webview/src/LoadingRegistry/index.tsx
+++ b/apps/vsce/webview/src/LoadingRegistry/index.tsx
@@ -3,7 +3,7 @@ import styles from "./style.module.css";
 const LoadingRegistry = () => {
   return (
     <div className={styles.root}>
-      <h1>Loading the most up-to-date codemod registry...</h1>
+      <p className={styles.text}>Loading the latest codemod registry...</p>
     </div>
   );
 };

--- a/apps/vsce/webview/src/LoadingRegistry/style.module.css
+++ b/apps/vsce/webview/src/LoadingRegistry/style.module.css
@@ -1,7 +1,11 @@
 .root {
-  text-align: center;
   display: flex;
   flex-direction: column;
-  align-items: center;
   height: 100%;
+  margin-left: 1rem;
+}
+
+.text {
+  font-size: 1rem;
+  font-weight: 500;
 }


### PR DESCRIPTION
<img width="356" alt="codemod-cli-not-found" src="https://github.com/codemod-com/codemod/assets/32841130/a7907d12-6fe4-428d-a548-fe4f88517974">
<img width="353" alt="registry-loading" src="https://github.com/codemod-com/codemod/assets/32841130/f69d658d-3894-4b56-86a7-35565e717402">
