### PR TITLE
CDMD-3477 Fix/deps install

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@codemod-com/runner",
   "author": "Codemod, Inc.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The codemod runner used in Codemod.com ecosystem",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runner/src/runCodemod.ts
+++ b/packages/runner/src/runCodemod.ts
@@ -316,6 +316,7 @@ export const runCodemod = async (
           flowSettings,
           runSettings,
           async (command) => {
+            onCommand(command);
             commands.push(command);
           },
           (message) => {

--- a/packages/runner/src/runCodemod.ts
+++ b/packages/runner/src/runCodemod.ts
@@ -316,7 +316,6 @@ export const runCodemod = async (
           flowSettings,
           runSettings,
           async (command) => {
-            onCommand(command);
             commands.push(command);
           },
           (message) => {
@@ -345,6 +344,7 @@ export const runCodemod = async (
         );
 
         for (const command of commands) {
+          await onCommand(command);
           await modifyFileSystemUponCommand(fileSystem, runSettings, command);
         }
       }


### PR DESCRIPTION
 - supports tracking of `modifiedFilePaths` for recipes; this is needed because deps installation logic depends on modified path to find affected package jsons; 
