### PR TITLE
[CLI] fix: ensure process exits when user selects 'No' in git tracking prompt

### DIFF
--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -72,19 +72,17 @@ const checkFileTreeVersioning = async (target: string) => {
       });
 
       force = res.force;
+    } else {
+      const res = await inquirer.prompt<{ force: boolean }>({
+        type: "confirm",
+        name: "force",
+        message:
+          "Could not run git working tree check. Codemod changes might be irreversible. Proceed anyway?",
+        default: false,
+      });
 
-      return;
+      force = res.force;
     }
-
-    const res = await inquirer.prompt<{ force: boolean }>({
-      type: "confirm",
-      name: "force",
-      message:
-        "Could not run git working tree check. Codemod changes might be irreversible. Proceed anyway?",
-      default: false,
-    });
-
-    force = res.force;
   }
 
   if (!force) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**:

-   [x] The commit message follows [our code of conduct](https://github.com/codemod-com/codemod-registry/blob/main/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md)
-   [ ] Tests for the changes have been added (for bug fixes/features)
-   [ ] Docs have been added / updated (for bug fixes / features)

**Please include the following information in your pull request**:

-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

-   **What is the current behavior?** (You can also link to an open issue here)

When the target folder is not tracked by git and the user selects 'No' in the prompt indicating that the codemod changes might be irreversible, the process continues instead of exiting. This is due to a return statement that causes the function to exit prematurely.

-   **What is the new behavior (if this is a feature change)?**

The process now correctly exits when the user selects 'No' in the prompt, ensuring that the codemod changes are not applied if the target folder is not tracked by git.

-   **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No, this PR does not introduce any breaking changes.

-   **Any other information (if needed)**:
