### PR TITLE
error messages on output

### DIFF
--- a/apps/frontend/app/(website)/studio/main/PageBottomPane/hooks/useSnippetsPanels.ts
+++ b/apps/frontend/app/(website)/studio/main/PageBottomPane/hooks/useSnippetsPanels.ts
@@ -3,23 +3,23 @@ import { useToggleVisibility } from "@studio/hooks/useToggleVisibility";
 import { type PanelsRefs, panelsData } from "@studio/main/PageBottomPane";
 import { WarningTexts } from "@studio/main/PageBottomPane/Components/WarningTexts";
 import { inferVisibilities } from "@studio/main/PageBottomPane/utils/inferVisibilites";
+import { mergeDeepRight } from "ramda";
 import { useEffect } from "react";
 
 export const useSnippetsPanels = ({ panelRefs }: { panelRefs: PanelsRefs }) => {
   const { beforePanel, afterPanel, outputPanel } = panelsData;
   const codeDiff = useCodeDiff();
   const warnings = WarningTexts(codeDiff);
-  const afterWithMessages = {
+  const afterWithVisibilityOptions = {
     ...afterPanel,
     visibilityOptions: useToggleVisibility(),
-    snippetData: {
-      ...afterPanel.snippetData,
-      warnings,
-    },
   };
+  const outputWithMessages = mergeDeepRight(outputPanel, {
+    snippetData: { warnings },
+  });
   const { onlyAfterHidden } = inferVisibilities({
     beforePanel,
-    afterPanel: afterWithMessages,
+    afterPanel: afterWithVisibilityOptions,
     outputPanel,
   });
 
@@ -35,8 +35,8 @@ export const useSnippetsPanels = ({ panelRefs }: { panelRefs: PanelsRefs }) => {
 
   return {
     beforePanel,
-    afterPanel: afterWithMessages,
-    outputPanel,
+    afterPanel: afterWithVisibilityOptions,
+    outputPanel: outputWithMessages,
     codeDiff,
     onlyAfterHidden,
   };


### PR DESCRIPTION
Move error messages to output
<img width="556" alt="image" src="https://github.com/codemod-com/codemod/assets/8398557/76612aae-cace-4f0f-b18f-30ee89b093ad">
