### PR TITLE
[Registry-www]: Fix SSG

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build projects
         run: pnpm build
         env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'YOUR_CLERK_PUBLISHABLE_KEY'
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: 'pk_test_c3VtbWFyeS13YWxydXMtMjUuY2xlcmsuYWNjb3VudHMuZGV2JA'
           NEXT_PUBLIC_API_URL: 'http://localhost:5173'
           HUBSPOT_CONTACT_FORM_ID: ${{ secrets.HUBSPOT_CONTACT_FORM_ID }}
           HUBSPOT_JOB_FORM_ID: ${{ secrets.HUBSPOT_JOB_FORM_ID }}

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-com/backend",
-  "version": "0.0.117",
+  "version": "0.0.118",
   "scripts": {
     "build": "node esbuild.config.js",
     "start": "node build/index.js",

--- a/apps/backend/src/publishHandler.test.ts
+++ b/apps/backend/src/publishHandler.test.ts
@@ -88,6 +88,7 @@ vi.mock("./schemata/env.js", async () => {
         CLERK_SECRET_KEY: "CLERK_SECRET_KEY",
         CLERK_JWT_KEY: "CLERK_JWT_KEY",
         TASK_MANAGER_QUEUE_NAME: "TASK_MANAGER_QUEUE_NAME",
+        CODEMOD_COM_API_URL: "https://codemod.com/api",
       };
     }),
   };
@@ -141,6 +142,8 @@ vi.mock("@codemod-com/utilities", async () => {
     TarService: mocks.TarService,
   };
 });
+
+vi.stubGlobal("fetch", vi.fn());
 
 describe("/publish route", async () => {
   const fastify = await runServer();

--- a/apps/backend/src/publishHandler.ts
+++ b/apps/backend/src/publishHandler.ts
@@ -405,6 +405,34 @@ export const publishHandler: CustomHandler<Record<string, never>> = async ({
       }
     }
 
+    /**
+     * Revalidate codemod tag and page
+     */
+
+    const slug = buildCodemodSlug(name);
+
+    const revalidateURL = new URL(
+      `${environment.CODEMOD_COM_API_URL}/revalidate`,
+    );
+    revalidateURL.searchParams.set("path", `registry/${slug}`);
+
+    const revalidateTagURL = new URL(
+      `${environment.CODEMOD_COM_API_URL}/revalidate-tag`,
+    );
+    revalidateTagURL.searchParams.set("tag", `codemod-${slug}`);
+
+    try {
+      await fetch(revalidateTagURL.toString());
+      await fetch(revalidateURL.toString());
+
+      console.info(`Successfully revalidated ${slug}`);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      console.error(
+        `Failed to revalidate the page: ${slug}. Reason: ${message}`,
+      );
+    }
+
     return reply.code(200).send({ success: true });
   } catch (err) {
     console.error(err);

--- a/apps/backend/src/unpublishHandler.ts
+++ b/apps/backend/src/unpublishHandler.ts
@@ -172,21 +172,25 @@ export const unpublishHandler: CustomHandler<Record<string, never>> = async ({
       });
     }
 
+    /**
+     * Revalidate codemod tag and page
+     */
+
+    const slug = buildCodemodSlug(name);
+
     const revalidateURL = new URL(
       `${environment.CODEMOD_COM_API_URL}/revalidate`,
     );
-    const slug = buildCodemodSlug(name);
-
     revalidateURL.searchParams.set("path", `registry/${slug}`);
 
-    try {
-      const res = await fetch(revalidateURL.toString(), {
-        headers: { "Content-Type": "application/json" },
-      });
+    const revalidateTagURL = new URL(
+      `${environment.CODEMOD_COM_API_URL}/revalidate-tag`,
+    );
+    revalidateTagURL.searchParams.set("tag", `codemod-${slug}`);
 
-      if (!res.ok) {
-        throw new Error(`Revalidation request failed`);
-      }
+    try {
+      await fetch(revalidateTagURL.toString());
+      await fetch(revalidateURL.toString());
 
       console.info(`Successfully revalidated ${slug}`);
     } catch (e) {

--- a/apps/frontend/app/(website)/auth/layout.tsx
+++ b/apps/frontend/app/(website)/auth/layout.tsx
@@ -1,0 +1,9 @@
+import AuthProvider from "@/app/context/AuthProvider";
+
+export default async function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AuthProvider>{children}</AuthProvider>;
+}

--- a/apps/frontend/app/(website)/page.tsx
+++ b/apps/frontend/app/(website)/page.tsx
@@ -3,7 +3,6 @@ import dynamic from "next/dynamic";
 import { draftMode } from "next/headers";
 import { notFound } from "next/navigation";
 
-import { TokenBuilder } from "@/components/TokenBuilder";
 import { Page } from "@/components/templates/ModularPage/Page";
 import { loadModularPage } from "@/data/sanity";
 import { resolveSanityRouteMetadata } from "@/data/sanity/resolveSanityRouteMetadata";
@@ -35,7 +34,6 @@ export default async function IndexRoute() {
     <PagePreview initial={initial} />
   ) : (
     <>
-      <TokenBuilder />
       <Page data={initial.data!} />
     </>
   );

--- a/apps/frontend/app/(website)/registry/[codemod]/page.tsx
+++ b/apps/frontend/app/(website)/registry/[codemod]/page.tsx
@@ -49,7 +49,8 @@ export default async function CodemodRoute({ params }) {
   // but for removed codemod it will return 400 (cache will never be updated)
   const initialAutomationData = await loadCodemod(params.codemod, {
     next: {
-      revalidate: 0,
+      revalidate: 60 * 60 * 24 * 30,
+      tags: [`codemod-${params.codemod}`],
     },
   });
   if (!initialAutomationData || "error" in initialAutomationData) {
@@ -70,5 +71,3 @@ export default async function CodemodRoute({ params }) {
 
   return <CodemodPage description={description} data={pageData} />;
 }
-
-export const dynamic = "force-static";

--- a/apps/frontend/app/(website)/registry/[codemod]/page.tsx
+++ b/apps/frontend/app/(website)/registry/[codemod]/page.tsx
@@ -43,10 +43,6 @@ export async function generateMetadata(
 }
 
 export default async function CodemodRoute({ params }) {
-  // Disabling cache for loadCodemod
-  // otherwise cache will not be revalidated properly when codemod is removed from the store
-  // because cache is updated only when original request returns status 200 https://github.com/vercel/next.js/blob/d7d5117777485fd3777f3429901369f4f244eb76/packages/next/src/server/lib/patch-fetch.ts#L584,
-  // but for removed codemod it will return 400 (cache will never be updated)
   const initialAutomationData = await loadCodemod(params.codemod, {
     next: {
       revalidate: 60 * 60 * 24 * 30,

--- a/apps/frontend/app/(website)/registry/[codemod]/page.tsx
+++ b/apps/frontend/app/(website)/registry/[codemod]/page.tsx
@@ -70,3 +70,5 @@ export default async function CodemodRoute({ params }) {
 
   return <CodemodPage description={description} data={pageData} />;
 }
+
+export const dynamic = "force-static";

--- a/apps/frontend/app/(website)/studio/page.tsx
+++ b/apps/frontend/app/(website)/studio/page.tsx
@@ -1,7 +1,8 @@
 "use client";
+import AuthProvider from "@/app/context/AuthProvider";
 import { isServer } from "@studio/config";
 import { MainPage } from "@studio/main/index";
-import { useEffect } from "react";
+import { Suspense, useEffect } from "react";
 import { Toaster } from "react-hot-toast";
 import { Tooltip } from "react-tooltip";
 
@@ -14,18 +15,20 @@ export default function Page() {
     document.documentElement.classList.add("light");
   }, [isDark]);
   return (
-    <>
-      <div className="studio">
-        <MainPage />
-        <Tooltip
-          className="z-50 w-40 bg-gray-light text-center text-xs text-gray-text-dark-title dark:bg-gray-lighter dark:text-gray-text-title "
-          delayHide={0}
-          delayShow={200}
-          id="button-tooltip"
-        />
-      </div>
-      <Toaster />
-    </>
+    <Suspense>
+      <AuthProvider>
+        <div className="studio">
+          <MainPage />
+          <Tooltip
+            className="z-50 w-40 bg-gray-light text-center text-xs text-gray-text-dark-title dark:bg-gray-lighter dark:text-gray-text-title "
+            delayHide={0}
+            delayShow={200}
+            id="button-tooltip"
+          />
+        </div>
+        <Toaster />
+      </AuthProvider>
+    </Suspense>
   );
 }
 

--- a/apps/frontend/app/api/revalidate-tag/route.ts
+++ b/apps/frontend/app/api/revalidate-tag/route.ts
@@ -1,0 +1,17 @@
+import { revalidateTag } from "next/cache";
+import type { NextRequest } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const tag = request.nextUrl.searchParams.get("tag");
+
+  if (tag) {
+    revalidateTag(tag);
+    return Response.json({ revalidated: true, now: Date.now() });
+  }
+
+  return Response.json({
+    revalidated: false,
+    now: Date.now(),
+    message: "Missing tag to revalidate",
+  });
+}

--- a/apps/frontend/app/context/AuthProvider.tsx
+++ b/apps/frontend/app/context/AuthProvider.tsx
@@ -12,8 +12,6 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
     throw new Error("Clerk Public Key not set");
   }
 
-  console.log(clerkPubKey, "clerkPubKey?");
-
   return (
     <ClerkProvider
       appearance={{

--- a/apps/frontend/app/context/AuthProvider.tsx
+++ b/apps/frontend/app/context/AuthProvider.tsx
@@ -12,6 +12,8 @@ const AuthProvider = ({ children }: { children: ReactNode }) => {
     throw new Error("Clerk Public Key not set");
   }
 
+  console.log(clerkPubKey, "clerkPubKey?");
+
   return (
     <ClerkProvider
       appearance={{

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -7,7 +7,6 @@ import dynamicFavicon from "@/headScripts/dynamic_favicon";
 import themeScript from "@/headScripts/theme";
 
 import "@/styles/globals.css";
-import AuthProvider from "@context/AuthProvider";
 import Script from "next/script";
 
 export default async function RootLayout({
@@ -35,10 +34,8 @@ export default async function RootLayout({
         />
       </head>
       <body>
-        <AuthProvider>
-          {children}
-          <Analytics />
-        </AuthProvider>
+        {children}
+        <Analytics />
       </body>
     </html>
   );

--- a/apps/frontend/components/global/Navigation/DesktopNavigation.tsx
+++ b/apps/frontend/components/global/Navigation/DesktopNavigation.tsx
@@ -1,3 +1,6 @@
+"use client";
+import AuthProvider from "@/app/context/AuthProvider";
+import { TokenBuilder } from "@/components/TokenBuilder";
 import Button from "@/components/shared/Button";
 import { TechLogo } from "@/components/shared/Icon";
 import type { NavigationPayload, SanityLinkType } from "@/types";
@@ -116,6 +119,12 @@ export function DesktopNavigationItems({ items }: DesktopNavigationProps) {
 export function DesktopNavigationRight(props: {
   items: NavigationPayload["navigationCtas"];
 }) {
+  const [shouldRenderAuth, setShouldRenderAuth] = useState(false);
+
+  useEffect(() => {
+    setShouldRenderAuth(true);
+  }, []);
+
   return (
     <div className="hidden gap-3 lg:flex lg:items-center lg:justify-center">
       {props.items?.map((item, index) => (
@@ -128,7 +137,13 @@ export function DesktopNavigationRight(props: {
           </Button>
         </NavigationLink>
       ))}
-      <AuthButtons variant="www" />
+
+      {shouldRenderAuth && (
+        <AuthProvider>
+          <AuthButtons variant="www" />
+          <TokenBuilder />
+        </AuthProvider>
+      )}
     </div>
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,8 +350,8 @@ importers:
         specifier: 4.30.3
         version: 4.30.3(react@18.2.0)
       '@clerk/nextjs':
-        specifier: 5.0.9
-        version: 5.0.9(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 5.1.4
+        version: 5.1.4(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/themes':
         specifier: 1.7.10
         version: 1.7.10(react@18.2.0)
@@ -6302,8 +6302,8 @@ packages:
     resolution: {integrity: sha512-iJTASBSitQqdgIUANzifwsRURmS+zaXJ2vtD/j3r/Ir/nmJWm1PwY9eGKWyE6rlk8iAnh+OoUmBJB1tz1SpXkw==}
     engines: {node: '>=14'}
 
-  '@clerk/backend@1.1.4':
-    resolution: {integrity: sha512-3Tgsh5JIuEX8UePlxf5ULl4DqSr5MKastuyMZ+HjytD4hqG7GALQILUNFCLIJGhvwpnaYnK5ZfQ/T2CH/G445A==}
+  '@clerk/backend@1.2.2':
+    resolution: {integrity: sha512-P007QPL9Ls3bwiBtK3Pat85HcSiL8rhwh/X1wifIEBK6OGF8kez1gOpcvt5/SmoCEecGg8AhH11A2fOIZcwPgA==}
     engines: {node: '>=18.17.0'}
 
   '@clerk/clerk-react@4.30.3':
@@ -6312,12 +6312,12 @@ packages:
     peerDependencies:
       react: '>=16'
 
-  '@clerk/clerk-react@5.0.5':
-    resolution: {integrity: sha512-L6ofmAD22oJy8TmF2HdWv8tAo+3+yAkpaDO6foBnFdRCdo5KDwbkxezKQ1dZ+H9B3+wlr+BNyWhuZX1U+YUn5w==}
+  '@clerk/clerk-react@5.2.3':
+    resolution: {integrity: sha512-1vd6mLHBJwaBx96ne/4HeI3W/ajt22gDrXuugEwVOe2lMauPQBaJq3jDttrNhErcKjMhamIMELeu8hhifpxNgA==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=18 || >=19.0.0-beta'
+      react-dom: '>=18 || >=19.0.0-beta'
 
   '@clerk/fastify@0.6.27':
     resolution: {integrity: sha512-JqPnD+q8hjSC+KX+fOHgfPQRAYmmCEFApL8ouZhY6UCuvZlZo0zIL05JDtmG8YWQV4H94gNLg99X+9l3QvizAg==}
@@ -6326,13 +6326,13 @@ packages:
       fastify: '>=4'
       fastify-plugin: ^4.5.0
 
-  '@clerk/nextjs@5.0.9':
-    resolution: {integrity: sha512-NIhft1y8Ynnm6GYevw/8fExHK3aRJxPG7hVaBd1LivxJPVSGZ3k8zbgeVc9UwtwYkjD5+xM/PnsMJ0aXGLa5+Q==}
+  '@clerk/nextjs@5.1.4':
+    resolution: {integrity: sha512-hi8MGA3nQERinHw9qG95fGzpesuxv11prmKQhxiRMicE+wCB5SoKLtBc2JMXAMNrnZC5rM8V9JV7HDSRFVxTTg==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
-      next: ^13.5.4 || ^14.0.3
-      react: '>=18'
-      react-dom: '>=18'
+      next: ^13.5.4 || ^14.0.3 || >=15.0.0-rc
+      react: '>=18 || >=19.0.0-beta'
+      react-dom: '>=18 || >=19.0.0-beta'
 
   '@clerk/shared@1.1.1':
     resolution: {integrity: sha512-pEzhalD1Yo/gGsOE2BQugVQTjlIl2aYmoeRld3BDXHRDV1jnk+yUE2CFOw6bojgFWN9sbeN/ph/47UWvvoCSOg==}
@@ -6350,12 +6350,12 @@ packages:
       react:
         optional: true
 
-  '@clerk/shared@2.1.0':
-    resolution: {integrity: sha512-8BwfjHFUHLtvFJzFFFvk66+maXb+EZlrf1NZ2GiRz6pOfT0VoYLK7MzLrY5GtHilNRtsvuTVlzg8Xxvn06AP6g==}
+  '@clerk/shared@2.2.2':
+    resolution: {integrity: sha512-ThbAXiK5drCabR2TtXSQVHXW0fNtO/RPfiQUiSrjHFdbJAiEkTbPwGSLvPaY1svw5hZHFHLCF735szIDvNHe1A==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=18 || >=19.0.0-beta'
+      react-dom: '>=18 || >=19.0.0-beta'
     peerDependenciesMeta:
       react:
         optional: true
@@ -6376,8 +6376,8 @@ packages:
     resolution: {integrity: sha512-RmQhWB7EMZw2nE24viQG79VyEUULZYWndYew5oXiZx06DyvysMNCorDyEGRmgBbprv7bnbYhHdOtKmx8Wj0jug==}
     engines: {node: '>=14'}
 
-  '@clerk/types@4.3.0':
-    resolution: {integrity: sha512-wsqnmyHLygj6Xgma175NihErsmMgXTEo6a+6eTCNQJTxfMb9fic8w6ssipSM1/rphVO3dLSkRNXeQGqiwOFesw==}
+  '@clerk/types@4.6.0':
+    resolution: {integrity: sha512-kowqVGqLfu0Zl2Pteum70MfkGHqBUoHHeR+u2+yWVl1lKHLCiyY1u8ntYBEIolAylBaQNDuRzxyMIDPSxjPE8g==}
     engines: {node: '>=18.17.0'}
 
   '@codemirror/autocomplete@6.16.0':
@@ -14711,9 +14711,6 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
-  path-to-regexp@6.2.1:
-    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
-
   path-to-regexp@6.2.2:
     resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
 
@@ -19340,9 +19337,10 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/backend@1.1.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/backend@1.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/types': 4.6.0
       cookie: 0.5.0
       snakecase-keys: 5.4.4
       tslib: 2.4.1
@@ -19357,10 +19355,10 @@ snapshots:
       react: 18.2.0
       tslib: 2.4.1
 
-  '@clerk/clerk-react@5.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/clerk-react@5.2.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/types': 4.3.0
+      '@clerk/shared': 2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/types': 4.6.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.4.1
@@ -19376,14 +19374,15 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/nextjs@5.0.9(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/nextjs@5.1.4(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/backend': 1.1.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/clerk-react': 5.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/shared': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/backend': 1.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/clerk-react': 5.2.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/types': 4.6.0
       crypto-js: 4.2.0
       next: 14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      path-to-regexp: 6.2.1
+      path-to-regexp: 6.2.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.4.1
@@ -19404,12 +19403,13 @@ snapshots:
     optionalDependencies:
       react: 18.2.0
 
-  '@clerk/shared@2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/shared@2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
+      '@clerk/types': 4.6.0
       glob-to-regexp: 0.4.1
-      js-cookie: 3.0.1
+      js-cookie: 3.0.5
       std-env: 3.7.0
-      swr: 2.2.0(react@18.2.0)
+      swr: 2.2.5(react@18.2.0)
     optionalDependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -19428,7 +19428,7 @@ snapshots:
     dependencies:
       csstype: 3.1.1
 
-  '@clerk/types@4.3.0':
+  '@clerk/types@4.6.0':
     dependencies:
       csstype: 3.1.1
 
@@ -28906,8 +28906,6 @@ snapshots:
     dependencies:
       lru-cache: 10.2.0
       minipass: 7.1.2
-
-  path-to-regexp@6.2.1: {}
 
   path-to-regexp@6.2.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,8 +350,8 @@ importers:
         specifier: 4.30.3
         version: 4.30.3(react@18.2.0)
       '@clerk/nextjs':
-        specifier: 5.1.4
-        version: 5.1.4(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 5.0.9
+        version: 5.0.9(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/themes':
         specifier: 1.7.10
         version: 1.7.10(react@18.2.0)
@@ -6302,8 +6302,8 @@ packages:
     resolution: {integrity: sha512-iJTASBSitQqdgIUANzifwsRURmS+zaXJ2vtD/j3r/Ir/nmJWm1PwY9eGKWyE6rlk8iAnh+OoUmBJB1tz1SpXkw==}
     engines: {node: '>=14'}
 
-  '@clerk/backend@1.2.2':
-    resolution: {integrity: sha512-P007QPL9Ls3bwiBtK3Pat85HcSiL8rhwh/X1wifIEBK6OGF8kez1gOpcvt5/SmoCEecGg8AhH11A2fOIZcwPgA==}
+  '@clerk/backend@1.1.4':
+    resolution: {integrity: sha512-3Tgsh5JIuEX8UePlxf5ULl4DqSr5MKastuyMZ+HjytD4hqG7GALQILUNFCLIJGhvwpnaYnK5ZfQ/T2CH/G445A==}
     engines: {node: '>=18.17.0'}
 
   '@clerk/clerk-react@4.30.3':
@@ -6312,12 +6312,12 @@ packages:
     peerDependencies:
       react: '>=16'
 
-  '@clerk/clerk-react@5.2.3':
-    resolution: {integrity: sha512-1vd6mLHBJwaBx96ne/4HeI3W/ajt22gDrXuugEwVOe2lMauPQBaJq3jDttrNhErcKjMhamIMELeu8hhifpxNgA==}
+  '@clerk/clerk-react@5.0.5':
+    resolution: {integrity: sha512-L6ofmAD22oJy8TmF2HdWv8tAo+3+yAkpaDO6foBnFdRCdo5KDwbkxezKQ1dZ+H9B3+wlr+BNyWhuZX1U+YUn5w==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
-      react: '>=18 || >=19.0.0-beta'
-      react-dom: '>=18 || >=19.0.0-beta'
+      react: '>=18'
+      react-dom: '>=18'
 
   '@clerk/fastify@0.6.27':
     resolution: {integrity: sha512-JqPnD+q8hjSC+KX+fOHgfPQRAYmmCEFApL8ouZhY6UCuvZlZo0zIL05JDtmG8YWQV4H94gNLg99X+9l3QvizAg==}
@@ -6326,13 +6326,13 @@ packages:
       fastify: '>=4'
       fastify-plugin: ^4.5.0
 
-  '@clerk/nextjs@5.1.4':
-    resolution: {integrity: sha512-hi8MGA3nQERinHw9qG95fGzpesuxv11prmKQhxiRMicE+wCB5SoKLtBc2JMXAMNrnZC5rM8V9JV7HDSRFVxTTg==}
+  '@clerk/nextjs@5.0.9':
+    resolution: {integrity: sha512-NIhft1y8Ynnm6GYevw/8fExHK3aRJxPG7hVaBd1LivxJPVSGZ3k8zbgeVc9UwtwYkjD5+xM/PnsMJ0aXGLa5+Q==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
-      next: ^13.5.4 || ^14.0.3 || >=15.0.0-rc
-      react: '>=18 || >=19.0.0-beta'
-      react-dom: '>=18 || >=19.0.0-beta'
+      next: ^13.5.4 || ^14.0.3
+      react: '>=18'
+      react-dom: '>=18'
 
   '@clerk/shared@1.1.1':
     resolution: {integrity: sha512-pEzhalD1Yo/gGsOE2BQugVQTjlIl2aYmoeRld3BDXHRDV1jnk+yUE2CFOw6bojgFWN9sbeN/ph/47UWvvoCSOg==}
@@ -6350,12 +6350,12 @@ packages:
       react:
         optional: true
 
-  '@clerk/shared@2.2.2':
-    resolution: {integrity: sha512-ThbAXiK5drCabR2TtXSQVHXW0fNtO/RPfiQUiSrjHFdbJAiEkTbPwGSLvPaY1svw5hZHFHLCF735szIDvNHe1A==}
+  '@clerk/shared@2.1.0':
+    resolution: {integrity: sha512-8BwfjHFUHLtvFJzFFFvk66+maXb+EZlrf1NZ2GiRz6pOfT0VoYLK7MzLrY5GtHilNRtsvuTVlzg8Xxvn06AP6g==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
-      react: '>=18 || >=19.0.0-beta'
-      react-dom: '>=18 || >=19.0.0-beta'
+      react: '>=18'
+      react-dom: '>=18'
     peerDependenciesMeta:
       react:
         optional: true
@@ -6376,8 +6376,8 @@ packages:
     resolution: {integrity: sha512-RmQhWB7EMZw2nE24viQG79VyEUULZYWndYew5oXiZx06DyvysMNCorDyEGRmgBbprv7bnbYhHdOtKmx8Wj0jug==}
     engines: {node: '>=14'}
 
-  '@clerk/types@4.6.0':
-    resolution: {integrity: sha512-kowqVGqLfu0Zl2Pteum70MfkGHqBUoHHeR+u2+yWVl1lKHLCiyY1u8ntYBEIolAylBaQNDuRzxyMIDPSxjPE8g==}
+  '@clerk/types@4.3.0':
+    resolution: {integrity: sha512-wsqnmyHLygj6Xgma175NihErsmMgXTEo6a+6eTCNQJTxfMb9fic8w6ssipSM1/rphVO3dLSkRNXeQGqiwOFesw==}
     engines: {node: '>=18.17.0'}
 
   '@codemirror/autocomplete@6.16.0':
@@ -14711,6 +14711,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  path-to-regexp@6.2.1:
+    resolution: {integrity: sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==}
+
   path-to-regexp@6.2.2:
     resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
 
@@ -19337,10 +19340,9 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/backend@1.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/backend@1.1.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/types': 4.6.0
+      '@clerk/shared': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       cookie: 0.5.0
       snakecase-keys: 5.4.4
       tslib: 2.4.1
@@ -19355,10 +19357,10 @@ snapshots:
       react: 18.2.0
       tslib: 2.4.1
 
-  '@clerk/clerk-react@5.2.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/clerk-react@5.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/types': 4.6.0
+      '@clerk/shared': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/types': 4.3.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.4.1
@@ -19374,15 +19376,14 @@ snapshots:
     transitivePeerDependencies:
       - react
 
-  '@clerk/nextjs@5.1.4(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/nextjs@5.0.9(next@14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/backend': 1.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/clerk-react': 5.2.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/shared': 2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/types': 4.6.0
+      '@clerk/backend': 1.1.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/clerk-react': 5.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       crypto-js: 4.2.0
       next: 14.2.3(@babel/core@7.24.4)(@opentelemetry/api@1.8.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      path-to-regexp: 6.2.2
+      path-to-regexp: 6.2.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.4.1
@@ -19403,13 +19404,12 @@ snapshots:
     optionalDependencies:
       react: 18.2.0
 
-  '@clerk/shared@2.2.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/shared@2.1.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/types': 4.6.0
       glob-to-regexp: 0.4.1
-      js-cookie: 3.0.5
+      js-cookie: 3.0.1
       std-env: 3.7.0
-      swr: 2.2.5(react@18.2.0)
+      swr: 2.2.0(react@18.2.0)
     optionalDependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -19428,7 +19428,7 @@ snapshots:
     dependencies:
       csstype: 3.1.1
 
-  '@clerk/types@4.6.0':
+  '@clerk/types@4.3.0':
     dependencies:
       csstype: 3.1.1
 
@@ -25478,7 +25478,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.34.1(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
@@ -25506,7 +25506,7 @@ snapshots:
       enhanced-resolve: 5.16.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.3
       is-core-module: 2.13.1
@@ -25528,7 +25528,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -28906,6 +28906,8 @@ snapshots:
     dependencies:
       lru-cache: 10.2.0
       minipass: 7.1.2
+
+  path-to-regexp@6.2.1: {}
 
   path-to-regexp@6.2.2: {}
 


### PR DESCRIPTION
 - removes clerk AuthProvider from global layout. (clerk auth provider uses `headers()` internally, which makes all pages dynamic);
 - adds revalidate-tag endpoint
 - fixes codemod caching strategy
 - triggers revalidation of both page and tag on publish/unpublish