### PR TITLE
[CLI, Runner] fix: filemod paths generation, execution progress bar cutoff, excluded patterns color (CDMD-3635)

### DIFF
--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -18,10 +18,10 @@ import {
   doubleQuotify,
   execPromise,
   parseCodemodConfig,
+  sleep,
 } from "@codemod-com/utilities";
 import { AxiosError } from "axios";
 import inquirer from "inquirer";
-import terminalLink from "terminal-link";
 import type { TelemetryEvent } from "../analytics/telemetry.js";
 import { buildSourcedCodemodOptions } from "../buildCodemodOptions.js";
 import { buildCodemodEngineOptions } from "../buildEngineOptions.js";
@@ -239,17 +239,19 @@ export const handleRunCliCommand = async (options: {
       : [codemodDefinition.codemod];
   const runner = new Runner(codemodsToRun, fs, runSettings, flowSettings);
 
-  if (runSettings.dryRun) {
-    printer.printConsoleMessage(
-      "log",
-      terminalLink(
-        "Click to view the live results of this run in the Codemod VSCode Extension!",
-        `vscode://codemod.codemod-vscode-extension/cases/${runSettings.caseHashDigest.toString(
-          "base64url",
-        )}`,
-      ),
-    );
-  }
+  // Currently unsupported
+
+  // if (runSettings.dryRun) {
+  //   printer.printConsoleMessage(
+  //     "log",
+  //     terminalLink(
+  //       "Click to view the live results of this run in the Codemod VSCode Extension!",
+  //       `vscode://codemod.codemod-vscode-extension/cases/${runSettings.caseHashDigest.toString(
+  //         "base64url",
+  //       )}`,
+  //     ),
+  //   );
+  // }
 
   const depsToInstall: Record<
     string,
@@ -324,17 +326,19 @@ export const handleRunCliCommand = async (options: {
     (message) => printer.printMessage(message),
   );
 
-  if (runSettings.dryRun) {
-    printer.printConsoleMessage(
-      "log",
-      terminalLink(
-        "The run has finished! Click to open the Codemod VSCode Extension and view the results.",
-        `vscode://codemod.codemod-vscode-extension/cases/${runSettings.caseHashDigest.toString(
-          "base64url",
-        )}`,
-      ),
-    );
-  }
+  // Currently unsupported
+
+  // if (runSettings.dryRun) {
+  //   printer.printConsoleMessage(
+  //     "log",
+  //     terminalLink(
+  //       "The run has finished! Click to open the Codemod VSCode Extension and view the results.",
+  //       `vscode://codemod.codemod-vscode-extension/cases/${runSettings.caseHashDigest.toString(
+  //         "base64url",
+  //       )}`,
+  //     ),
+  //   );
+  // }
 
   if (executionErrors && executionErrors.length > 0) {
     const logsPath = join(


### PR DESCRIPTION
- fixes paths generation for filemod (only does it once now and makes sure they are the same as our CLI generates)
- fixes execution progress bar not going up to 100% by awaiting onSuccess() method (it gives time for progress bar update to go through, it seems like this operation is being executed on process.nextTick() or something similar, basically it's not a sync operation apparently)
- excluded patterns color is now yellow instead of red as per request from Jacob Paris
