### PR TITLE
feature: codemod: typescript: remove useless conversion to string

### DIFF
--- a/packages/codemods/typescript/use-template-literals/src/index.ts
+++ b/packages/codemods/typescript/use-template-literals/src/index.ts
@@ -9,11 +9,11 @@ const transformHelper = (node: BinaryExpression, api: API) => {
   const rightNode = node.right;
   const left =
     leftNode && leftNode.type === "StringLiteral"
-      ? j.literal(`${leftNode.value}`)
+      ? j.literal(leftNode.value)
       : leftNode;
   const right =
     rightNode && rightNode.type === "StringLiteral"
-      ? j.literal(`${rightNode.value}`)
+      ? j.literal(rightNode.value)
       : rightNode;
 
   return j.templateLiteral(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**:

-   [ ] The commit message follows [our code of conduct](https://github.com/codemod-com/codemod-registry/blob/main/CODE_OF_CONDUCT.md) and [contributing guidelines](https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md)
-   [ ] Tests for the changes have been added (for bug fixes/features)
-   [ ] Docs have been added / updated (for bug fixes / features)

**Please include the following information in your pull request**:

-   **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

-   **What is the current behavior?** (You can also link to an open issue here)

-   **What is the new behavior (if this is a feature change)?**

-   **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

-   **Any other information (if needed)**:

If that’s `StringLiteral` it’s value would be type of `string`, no need in additional conversion.