### PR TITLE
[studio] rename modgpt tab to assistant

### DIFF
--- a/apps/frontend/app/(website)/studio/main/PaneLayout/tabsData.tsx
+++ b/apps/frontend/app/(website)/studio/main/PaneLayout/tabsData.tsx
@@ -46,7 +46,7 @@ export const useTabsData = ({
   const tabs = [
     {
       value: TabNames.MODGPT,
-      name: "ModGPT",
+      name: "Assistant",
       content: (
         <>
           <Chat aiProps={aiAssistantData} isSignedIn={isSignedIn} />


### PR DESCRIPTION
The intention of this PR is to change the "ModGPT" tab in the studio to "Assistant".