### PR TITLE
Gitignore fix, unsupported file extension fix

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.11.30",
+  "version": "0.11.31",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/packages/runner/src/runCodemod.ts
+++ b/packages/runner/src/runCodemod.ts
@@ -145,7 +145,15 @@ export const buildPatterns = async (
         .filter((line) => line.length > 0 && !line.startsWith("#"))
         .map(formatFunc);
 
-      allExcluded.push(...new Set(gitIgnored));
+      allExcluded.push(
+        ...new Set(gitIgnored),
+        // git ignores everything that starts with pattern, for glob we need to specify all files
+        ...new Set(
+          gitIgnored
+            .filter((match) => !match.endsWith("/"))
+            .map((match) => `${match}/**/*.*`),
+        ),
+      );
     } catch (err) {
       //
     }

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -2,7 +2,7 @@
   "name": "@codemod.com/workflow",
   "author": "Codemod, Inc.",
   "type": "module",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Workflow Engine for Codemod",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/workflow/src/astGrep/astGrep.ts
+++ b/packages/workflow/src/astGrep/astGrep.ts
@@ -12,6 +12,7 @@ import {
   getFileContext,
 } from "../contexts.js";
 import { FunctionExecutor, fnWrapper } from "../engineHelpers.js";
+import { clc } from "../helpers.js";
 import { filter } from "./filter.js";
 import { map } from "./map.js";
 import { replace } from "./replace.js";
@@ -265,6 +266,9 @@ export function astGrepLogic<
         }
         const lang = fileExtensionToLang[fileContext.extension];
         if (!lang) {
+          console.warn(
+            `${clc.yellow("WARN")} Unsupported file extension: ${fileContext.extension}`,
+          );
           return;
         }
         const nodes = parse(lang, await fileContext.contents())

--- a/packages/workflow/src/astGrep/astGrep.ts
+++ b/packages/workflow/src/astGrep/astGrep.ts
@@ -3,7 +3,6 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as util from "node:util";
 import { Lang, type NapiConfig, parse } from "@ast-grep/napi";
-import { invariant } from "ts-invariant";
 import * as YAML from "yaml";
 import type { PLazy } from "../PLazy.js";
 import { ai } from "../ai/ai.js";
@@ -22,6 +21,8 @@ const fileExtensionToLang: Record<string, Lang> = {
   html: Lang.Html,
   js: Lang.JavaScript,
   jsx: Lang.JavaScript,
+  mjs: Lang.JavaScript,
+  cjs: Lang.JavaScript,
   ts: Lang.TypeScript,
   tsx: Lang.Tsx,
   sh: Lang.Bash,
@@ -259,9 +260,13 @@ export function astGrepLogic<
           fileContext.file,
         );
       } else {
-        invariant(fileContext.extension, "File extension is not defined");
+        if (!fileContext.extension) {
+          return;
+        }
         const lang = fileExtensionToLang[fileContext.extension];
-        invariant(lang, `Unsupported file extension: ${fileContext.extension}`);
+        if (!lang) {
+          return;
+        }
         const nodes = parse(lang, await fileContext.contents())
           .root()
           .findAll(napiConfig as NapiConfig)


### PR DESCRIPTION
1. When directory is provided in `.gitignore` - codemod doesn't take it into account and doesn't ignore files inside.
2. When file with unknown extension is met for ast-grep in workflow engine - show warning.