### PR TITLE
fix(workflow engine): fix import paths when moving files on windows

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "codemod",
   "author": "Codemod, Inc.",
-  "version": "0.11.31",
+  "version": "0.11.32",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -2,7 +2,7 @@
   "name": "@codemod.com/workflow",
   "author": "Codemod, Inc.",
   "type": "module",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Workflow Engine for Codemod",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/workflow/src/fs/move.ts
+++ b/packages/workflow/src/fs/move.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import * as pathPosix from "node:path/posix";
 import * as glob from "glob";
 import type { PLazy } from "../PLazy.js";
 import {
@@ -48,8 +49,8 @@ const getRenamedPath = async (
   for (const ext of ALL_JS_EXTENSIONS) {
     const maybeFilePath = `${oldPath}.${ext}`;
     if (maybeFilePath in renames) {
-      return path.format({
-        ...path.parse(renames[maybeFilePath] as string),
+      return pathPosix.format({
+        ...pathPosix.parse(renames[maybeFilePath] as string),
         base: undefined,
         ext: undefined,
       });
@@ -59,10 +60,10 @@ const getRenamedPath = async (
   try {
     if ((await fs.stat(oldPath)).isDirectory()) {
       for (const ext of ALL_JS_EXTENSIONS) {
-        const maybeFilePath = `${path.join(oldPath, "index")}.${ext}`;
+        const maybeFilePath = `${pathPosix.join(oldPath, "index")}.${ext}`;
         if (maybeFilePath in renames) {
-          return path.format({
-            ...path.parse(renames[maybeFilePath] as string),
+          return pathPosix.format({
+            ...pathPosix.parse(renames[maybeFilePath] as string),
             base: undefined,
             ext: undefined,
             name: undefined,
@@ -88,33 +89,33 @@ const renameImport = async (
       newAbsoluteSelfPath,
       renames,
     );
-    const oldAbsoluteImportPath = path.resolve(
-      path.dirname(oldAbsoluteSelfPath ?? newAbsoluteSelfPath),
+    const oldAbsoluteImportPath = pathPosix.resolve(
+      pathPosix.dirname(oldAbsoluteSelfPath ?? newAbsoluteSelfPath),
       importPath,
     );
     const newAbsoluteImportPath =
       (await getRenamedPath(oldAbsoluteImportPath, renames)) ??
       oldAbsoluteImportPath;
-    let relativePath = path.join(
-      path.relative(
-        path.dirname(newAbsoluteSelfPath),
-        path.dirname(newAbsoluteImportPath),
+    let relativePath = pathPosix.join(
+      pathPosix.relative(
+        pathPosix.dirname(newAbsoluteSelfPath),
+        pathPosix.dirname(newAbsoluteImportPath),
       ),
-      path.basename(newAbsoluteImportPath),
+      pathPosix.basename(newAbsoluteImportPath),
     );
     if (!relativePath.startsWith(".")) {
       relativePath = `./${relativePath}`;
     }
 
-    let extension: string | undefined = path.extname(relativePath);
+    let extension: string | undefined = pathPosix.extname(relativePath);
     if (extension === ".ts") {
       extension = ".js";
     } else if (extension === ".tsx" || extension === ".jsx") {
       extension = undefined;
     }
 
-    relativePath = path.format({
-      ...path.parse(relativePath),
+    relativePath = pathPosix.format({
+      ...pathPosix.parse(relativePath),
       base: undefined,
       ext: extension,
     });
@@ -192,7 +193,7 @@ export function moveLogic(target: string): PLazy<Helpers> & Helpers {
           await files("**/*.{js,jsx,ts,tsx,cjs,mjs}").jsFam(
             async ({ astGrep }) => {
               const file = getFileContext().file;
-              const imports = await astGrep({
+              await astGrep({
                 rule: {
                   any: [
                     {


### PR DESCRIPTION
Use posix for manipulating path in imports of JS files on windows, otherwise imports are getting broken