### PR TITLE
fix(cli): post-refactoring logic fixes

### DIFF
--- a/apps/backend/src/publishHandler.ts
+++ b/apps/backend/src/publishHandler.ts
@@ -116,7 +116,9 @@ export const publishHandler: RouteHandler<{
           });
         }
       }
-    } else {
+    }
+
+    if (codemodRc.engine !== "recipe") {
       const { path } = await getEntryPath({
         source: unpackPath,
         throwOnNotFound: false,

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#*": "./src/*"
   },
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -10,12 +10,12 @@ import type {
   VerifyTokenResponse,
 } from "@codemod-com/api-types";
 
-export const extractCLIApiError = (err: unknown): string => {
+export const extractPrintableApiError = (err: unknown): string => {
   if (!(err instanceof Error)) {
     return "An unknown error occurred.";
   }
 
-  return err instanceof AxiosError ? err.response?.data : err.message;
+  return err instanceof AxiosError ? err.response?.data.errorText : err.message;
 };
 
 export const getCLIAccessToken = async (

--- a/biome.json
+++ b/biome.json
@@ -112,7 +112,6 @@
     "formatWithErrors": true,
     "indentStyle": "space",
     "ignore": [
-      "./packages",
       "*.d.ts",
       "input.js",
       "output.js",

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
       "cache": false
     },
     "@codemod-com/database#build": {
+      "dependsOn": ["^build"],
       "cache": false
     },
     "build": {


### PR DESCRIPTION
#### 📚 Description
- include `packages` into biome.json formatter coverage
- bugfixes:
  - during recipe publishing, we attempted to build the codemod executable. recipe does not have one.
  - codemod list was requesting auth to view all the codemods by error (apparently was pushed with another PR)
  - any codemod path that included `temp` would get removed, when we only need to remove the ones that were created in the actual `temp` directory under `.codemod`