### PR TITLE
chore(cli): rename source to target in publish

### DIFF
--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -252,8 +252,9 @@ export const main = async () => {
       "publish",
       "publish the codemod to Codemod Registry",
       (y) =>
-        y.option("source", {
+        y.option("target", {
           type: "string",
+          alias: "t",
           description: "path to the codemod to be published",
         }),
       async (args) => {
@@ -263,7 +264,7 @@ export const main = async () => {
         return executeCliCommand(async () => {
           await handlePublishCliCommand({
             printer,
-            source: args.source ?? process.cwd(),
+            target: args.target ?? process.cwd(),
             telemetry: telemetryService,
           });
         });

--- a/apps/docs/deploying-codemods/cli.mdx
+++ b/apps/docs/deploying-codemods/cli.mdx
@@ -88,10 +88,10 @@ To do so, use the `publish` command inside the codemod package directory:
 codemod publish
 ```
 
-Alternatively, you can publish a codemod from <Tooltip tip="This path can point to a simple transform file or a Codemod-compatible package.">source path</Tooltip>:
+Alternatively, you can publish a codemod at <Tooltip tip="This path can point to a simple transform file or a Codemod-compatible package.">the target path</Tooltip>:
 
 ```bash
-codemod publish [path] --source
+codemod publish [path] --target
 ```
 
 ### `codemod unpublish`

--- a/apps/docs/guides/sharing/publishing-codemods.mdx
+++ b/apps/docs/guides/sharing/publishing-codemods.mdx
@@ -48,14 +48,14 @@ Creating and publishing a [Codemod-compatible package](/guides/building-codemods
         ```
     </Step>
     <Step title="Publish codemod">
-        Publish the codemod from source path:
+        Publish the codemod at the target path:
 
         <Note>
         To generate a [Codemod-compatible package](/guides/building-codemods/package-requirements), Codemod CLI will ask you a few questions about your codemod to generate the [`codemodrc.json` configuration file](/guides/building-codemods/package-requirements#codemodrc-json-reference) automatically for you.
         </Note>
 
         ```bash
-        codemod publish [path] --source
+        codemod publish [path] --target
         ```
     </Step>
 </Steps>


### PR DESCRIPTION
Arguably is a more self-explanatory and easy to understand naming