### PR TITLE
fix(cli,backend): patch a bug that incorrectly extracts codemod name and version

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-com/backend",
-  "version": "0.0.147",
+  "version": "0.0.148",
   "scripts": {
     "build": "tsc && node esbuild.config.js",
     "start": "node build/index.js",

--- a/apps/backend/src/unpublishHandler.ts
+++ b/apps/backend/src/unpublishHandler.ts
@@ -4,7 +4,7 @@ import type { RouteHandler } from "fastify";
 import type { UserDataPopulatedRequest } from "@codemod-com/auth";
 import { prisma } from "@codemod-com/database";
 import {
-  extractLibNameAndVersion,
+  extractNameAndVersion,
   isNeitherNullNorUndefined,
 } from "@codemod-com/utilities";
 
@@ -28,7 +28,7 @@ export const unpublishHandler: RouteHandler<{
     }
 
     const { name } = parseUnpublishBody(request.body);
-    const { libName: codemodName, version } = extractLibNameAndVersion(name);
+    const { name: codemodName, version } = extractNameAndVersion(name);
 
     const codemod = await prisma.codemod.findFirst({
       where: { name: codemodName },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#*": "./src/*"
   },
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/commands/unpublish.ts
+++ b/apps/cli/src/commands/unpublish.ts
@@ -3,7 +3,7 @@ import { AxiosError } from "axios";
 import { type Printer, chalk } from "@codemod-com/printer";
 import {
   doubleQuotify,
-  extractLibNameAndVersion,
+  extractNameAndVersion,
   isNeitherNullNorUndefined,
 } from "@codemod-com/utilities";
 import { unpublish } from "#api.js";
@@ -21,7 +21,7 @@ export const handleUnpublishCliCommand = async (options: {
     printer,
   });
 
-  const { libName: codemodName, version } = extractLibNameAndVersion(name);
+  const { name: codemodName, version } = extractNameAndVersion(name);
 
   if (
     isNeitherNullNorUndefined(codemodName) &&

--- a/apps/cli/src/install-dependencies.ts
+++ b/apps/cli/src/install-dependencies.ts
@@ -9,7 +9,7 @@ import {
   type CodemodConfig,
   doubleQuotify,
   execPromise,
-  extractLibNameAndVersion,
+  extractNameAndVersion,
   getProjectRootPathAndPackageManager,
 } from "@codemod-com/utilities";
 
@@ -86,10 +86,10 @@ export const handleInstallDependencies = async (options: {
     const toInstall: string[] = [];
     const toDelete: string[] = [];
     for (const dep of deps) {
-      const { libName } = extractLibNameAndVersion(dep);
+      const { name } = extractNameAndVersion(dep);
 
-      if (libName?.startsWith("-")) {
-        toDelete.push(libName.slice(1));
+      if (name?.startsWith("-")) {
+        toDelete.push(name.slice(1));
       } else {
         toInstall.push(dep);
       }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#*": "./src/*"
   },
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "The utilities used across Codemod.com packages",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utilities/src/functions/formatting.ts
+++ b/packages/utilities/src/functions/formatting.ts
@@ -101,3 +101,21 @@ export const buildCodemodSlug = (name: string) =>
     .replaceAll("@", "")
     .split(/[\/ ,.-]/)
     .join("-");
+
+export const extractNameAndVersion = (val: string) => {
+  const lastAtSymbolIndex = val.lastIndexOf("@");
+  const sliceUpToLastAtSymbol = val.substring(0, lastAtSymbolIndex);
+
+  // Starts with a @
+  if (sliceUpToLastAtSymbol.length === 0) {
+    return {
+      name: val,
+      version: null,
+    };
+  }
+
+  return {
+    name: sliceUpToLastAtSymbol,
+    version: val.substring(lastAtSymbolIndex + 1),
+  };
+};

--- a/packages/utilities/src/schemata/codemod-config.ts
+++ b/packages/utilities/src/schemata/codemod-config.ts
@@ -2,21 +2,8 @@ import semver from "semver";
 import type { InferInput, InferOutput } from "valibot";
 import * as v from "valibot";
 
+import { extractNameAndVersion } from "../functions/formatting.js";
 import { argumentSchema } from "./argument-record.js";
-
-export const extractLibNameAndVersion = (val: string) => {
-  const parts = val.split("@").filter(Boolean);
-  let version: string | null = null;
-  let libName: string;
-  if (parts.length > 1) {
-    version = parts.pop() ?? null;
-    libName = parts.join("@");
-  } else {
-    libName = val;
-  }
-
-  return { libName, version };
-};
 
 export const codemodNameRegex = /[a-zA-Z0-9_/@-]+/;
 
@@ -177,9 +164,9 @@ const configJsonBaseSchema = v.object({
           return false;
         }
 
-        const { libName, version } = extractLibNameAndVersion(val);
+        const { name, version } = extractNameAndVersion(val);
         // e.g. -jest
-        if (libName?.startsWith("-")) {
+        if (name?.startsWith("-")) {
           return true;
         }
 

--- a/packages/utilities/src/schemata/codemod-config.ts
+++ b/packages/utilities/src/schemata/codemod-config.ts
@@ -5,7 +5,7 @@ import * as v from "valibot";
 import { argumentSchema } from "./argument-record.js";
 
 export const extractLibNameAndVersion = (val: string) => {
-  const parts = val.split("@");
+  const parts = val.split("@").filter(Boolean);
   let version: string | null = null;
   let libName: string;
   if (parts.length > 1) {


### PR DESCRIPTION
running:
<img width="555" alt="image" src="https://github.com/user-attachments/assets/5d553f21-c8c6-4b54-aadd-2038dee786ca">



produces:
<img width="530" alt="image" src="https://github.com/user-attachments/assets/2c2d2b0b-7368-44c8-9cbc-5b9d1e505d24">
