### PR TITLE
fix(cli, backend): patch for namespace logic & return codemod dep installation

### DIFF
--- a/apps/auth-service/package.json
+++ b/apps/auth-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-com/auth-service",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "scripts": {
     "build": "tsc && node esbuild.config.js",
     "start": "node build/index.js"

--- a/apps/auth-service/src/server.ts
+++ b/apps/auth-service/src/server.ts
@@ -156,7 +156,7 @@ const routes: FastifyPluginCallback = (instance, _opts, done) => {
       allowedNamespaces.unshift(user.username);
 
       if (environment.VERIFIED_PUBLISHERS.includes(user.username)) {
-        allowedNamespaces.push("codemod-com", "codemod.com");
+        allowedNamespaces.push("codemod-com");
       }
     }
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codemod-com/backend",
-  "version": "0.0.149",
+  "version": "0.0.150",
   "scripts": {
     "build": "tsc && node esbuild.config.js",
     "start": "node build/index.js",

--- a/apps/backend/src/unpublishHandler.ts
+++ b/apps/backend/src/unpublishHandler.ts
@@ -3,10 +3,7 @@ import type { RouteHandler } from "fastify";
 
 import type { UserDataPopulatedRequest } from "@codemod-com/auth";
 import { prisma } from "@codemod-com/database";
-import {
-  extractNameAndVersion,
-  isNeitherNullNorUndefined,
-} from "@codemod-com/utilities";
+import { extractNameAndVersion } from "@codemod-com/utilities";
 
 import { buildRevalidateHelper } from "./revalidate.js";
 import { parseUnpublishBody } from "./schemata/schema.js";
@@ -21,7 +18,7 @@ export const unpublishHandler: RouteHandler<{
 }> = async (request: UserDataPopulatedRequest, reply) => {
   try {
     const { username } = request.user!;
-    const orgs = request.organizations!;
+    const allowedNamespaces = request.allowedNamespaces!;
 
     if (username === null) {
       throw new Error("The username of the current user does not exist");
@@ -52,11 +49,6 @@ export const unpublishHandler: RouteHandler<{
     }
 
     let skipCheck = false;
-
-    const allowedNamespaces = [
-      username,
-      ...orgs.map((org) => org.organization.slug),
-    ].filter(isNeitherNullNorUndefined);
 
     // Allow Codemod engineers to unpublish anything if required
     if (environment.VERIFIED_PUBLISHERS.includes(username)) {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#*": "./src/*"
   },
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -17,11 +17,13 @@ import {
   type ProjectDownloadInput,
   backtickify,
   doubleQuotify,
+  execPromise,
   getCodemodProjectFiles,
   isJavaScriptName,
   parseCodemodConfig,
 } from "@codemod-com/utilities";
 import { getCurrentUserData } from "#auth-utils.js";
+import { oraCheckmark } from "#utils/constants.js";
 import { isFile } from "#utils/general.js";
 
 const CODEMOD_ENGINE_CHOICES: (KnownEngines | "recipe")[] = [
@@ -172,6 +174,32 @@ export const handleInitCliCommand = async (options: {
     "info",
     chalk.cyan("Codemod package created at", `${chalk.bold(codemodBaseDir)}.`),
   );
+
+  const installSpinner = printer.withLoaderMessage(
+    chalk.cyan("Installing npm dependencies..."),
+  );
+
+  // Install packages
+  try {
+    await execPromise("pnpm i", { cwd: codemodBaseDir });
+  } catch (err) {
+    try {
+      await execPromise("npm i", { cwd: codemodBaseDir });
+    } catch (err) {
+      installSpinner.fail();
+      printer.printConsoleMessage(
+        "error",
+        `Failed to install npm dependencies:\n${(err as Error).message}.`,
+      );
+    }
+  }
+
+  if (installSpinner.isSpinning) {
+    installSpinner.stopAndPersist({
+      symbol: oraCheckmark,
+      text: chalk.green("Dependencies installed."),
+    });
+  }
 
   const howToRunText = chalk(
     `Run ${chalk.bold(doubleQuotify(`codemod --source ${codemodBaseDir}`))}`,


### PR DESCRIPTION
- Patches logic which used to set namespace to username unconditionally
- Brings back `npm install` logic to `codemod init` as it was removed in previous PRs due to assuming it was working incorrectly. Article written by one of our users has proven this wrong and it seemed like users actually want this behaviour.