### PR TITLE
fix(cli): allow targeting single file, preserve source scope

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#*": "./src/*"
   },
-  "version": "0.13.2",
+  "version": "0.13.3",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -90,7 +90,7 @@ export const handleRunCliCommand = async (options: {
 }) => {
   const { printer, args, telemetry, onExit } = options;
 
-  const flowSettings = parseFlowSettings(args, printer);
+  const flowSettings = await parseFlowSettings(args, printer);
 
   if (
     !flowSettings.dry &&

--- a/packages/printer/src/schemata/main-thread.ts
+++ b/packages/printer/src/schemata/main-thread.ts
@@ -9,7 +9,7 @@ const mainThreadMessageSchema = v.union([
   v.object({
     kind: v.literal("initialization"),
     path: v.string(),
-    transformer: v.nullable(v.string()),
+    codemodSource: v.string(),
     engine: v.union([
       v.literal("jscodeshift"),
       v.literal("ts-morph"),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -572,7 +572,7 @@ export class Runner {
             engine: "jscodeshift" | "ts-morph" | "ast-grep";
           };
         },
-        stringifiedTransformer: transformer?.toString() ?? null,
+        codemodSource,
         onError,
       });
     });

--- a/packages/runner/src/schemata/flow-settings.ts
+++ b/packages/runner/src/schemata/flow-settings.ts
@@ -1,6 +1,7 @@
-import { resolve } from "node:path";
+import { basename, dirname, resolve } from "node:path";
 import * as v from "valibot";
 
+import { constants, access, stat } from "node:fs/promises";
 import { type Printer, chalk } from "@codemod-com/printer";
 
 export const DEFAULT_EXCLUDE_PATTERNS = [
@@ -35,7 +36,7 @@ export const flowSettingsSchema = v.object({
   _: v.array(v.string()),
   include: v.optional(v.array(v.string())),
   exclude: v.optional(v.array(v.string()), []),
-  target: v.optional(v.string()),
+  target: v.optional(v.string(), DEFAULT_INPUT_DIRECTORY_PATH),
   files: v.optional(v.array(v.string())),
   dry: v.optional(v.boolean(), DEFAULT_DRY_RUN),
   format: v.optional(v.boolean(), DEFAULT_ENABLE_PRETTIER),
@@ -45,23 +46,19 @@ export const flowSettingsSchema = v.object({
   threads: v.optional(v.pipe(v.number(), v.minValue(0)), DEFAULT_THREAD_COUNT),
 });
 
-export type FlowSettings = Omit<
-  v.InferOutput<typeof flowSettingsSchema>,
-  "target"
-> & {
-  target: string;
-};
+export type FlowSettings = v.InferOutput<typeof flowSettingsSchema>;
 
-export const parseFlowSettings = (
+export const parseFlowSettings = async (
   input: unknown,
   printer: Printer,
-): FlowSettings => {
+): Promise<FlowSettings> => {
   const flowSettings = v.parse(flowSettingsSchema, input);
 
   const positionalPassedTarget = flowSettings._.at(1);
   const argTarget = flowSettings.target;
 
-  let target: string;
+  let target =
+    positionalPassedTarget ?? argTarget ?? DEFAULT_INPUT_DIRECTORY_PATH;
   if (positionalPassedTarget && argTarget) {
     printer.printConsoleMessage(
       "info",
@@ -71,13 +68,22 @@ export const parseFlowSettings = (
     );
 
     target = argTarget;
-  } else {
-    target =
-      positionalPassedTarget ?? argTarget ?? DEFAULT_INPUT_DIRECTORY_PATH;
   }
 
-  return {
-    ...flowSettings,
-    target: resolve(target),
-  };
+  await access(target, constants.F_OK).catch(() => {
+    throw new Error(`Execution target does not exist:\n${target}`);
+  });
+
+  flowSettings.target = resolve(target);
+
+  if ((await stat(target)).isFile()) {
+    flowSettings.include = [basename(target)].concat(
+      flowSettings.include ?? [],
+    );
+    flowSettings.target = dirname(target);
+  }
+
+  console.log(flowSettings);
+
+  return flowSettings;
 };

--- a/packages/runner/src/schemata/flow-settings.ts
+++ b/packages/runner/src/schemata/flow-settings.ts
@@ -83,7 +83,5 @@ export const parseFlowSettings = async (
     flowSettings.target = dirname(target);
   }
 
-  console.log(flowSettings);
-
   return flowSettings;
 };

--- a/packages/runner/src/worker-manager.ts
+++ b/packages/runner/src/worker-manager.ts
@@ -39,15 +39,11 @@ export class WorkerManager {
           engine: "jscodeshift" | "ts-morph" | "ast-grep";
         };
       };
-      stringifiedTransformer: string | null;
+      codemodSource: string;
       onError?: CodemodExecutionErrorCallback;
     },
   ) {
-    const {
-      codemod,
-      stringifiedTransformer: transformer,
-      flowSettings,
-    } = _options;
+    const { codemod, flowSettings, codemodSource } = _options;
 
     this.__workerCount = flowSettings.threads;
 
@@ -65,7 +61,7 @@ export class WorkerManager {
 
       worker.postMessage({
         kind: "initialization",
-        transformer,
+        codemodSource,
         ...codemod,
         ...codemod.config,
         ...flowSettings,


### PR DESCRIPTION
- Sets target as `dirname(target)` and does `include = [...include, basename(target)` when target is a file.
- Passes entire codemod source through worker thread message to avoid constructing new annonymous function that loses the scope. Previously I've done that in attempt to avoid calling`getTransformer` on every processed file, however I overlooked that this optimization would cause this bug and turn out to be inefficient, since calling `new Function()` is probably way heavier than just extracting the transformer. The architecture can be improved here in some way, for example passing the transformer *name* with the message, but for now let's leave it bare min so that it works as before.