### PR TITLE
feat(run-service): added ability to save output of codemod runs permanently

### DIFF
--- a/apps/run-service/src/services/Redis.ts
+++ b/apps/run-service/src/services/Redis.ts
@@ -1,6 +1,7 @@
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
 
+import type { parseCodemodRunBody } from "../schemata/schema.js";
 import { environment } from "../util.js";
 
 export const redis = environment.REDIS_HOST
@@ -11,8 +12,12 @@ export const redis = environment.REDIS_HOST
     })
   : null;
 
+type CodemodRunJob = ReturnType<typeof parseCodemodRunBody> & {
+  userId: string;
+};
+
 export const queue = redis
-  ? new Queue(environment.TASK_MANAGER_QUEUE_NAME ?? "", {
+  ? new Queue<CodemodRunJob>(environment.TASK_MANAGER_QUEUE_NAME ?? "", {
       connection: redis,
     })
   : null;

--- a/packages/utilities/src/schemata/github-run.ts
+++ b/packages/utilities/src/schemata/github-run.ts
@@ -9,6 +9,7 @@ export const codemodRunBodySchema = v.object({
   ]),
   repoUrl: v.optional(v.string()),
   branch: v.optional(v.string()),
+  persistent: v.optional(v.boolean()),
 });
 
 export type CodemodRunResponse = { success: boolean; codemodRunId: string };


### PR DESCRIPTION

<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
Permanently saving output for codemod runs
