### PR TITLE
fix(codemod): ignore type imports in replace-act-import

### DIFF
--- a/packages/codemods/react/19/replace-act-import/__testfixtures__/existing-type-import.input.js
+++ b/packages/codemods/react/19/replace-act-import/__testfixtures__/existing-type-import.input.js
@@ -1,0 +1,4 @@
+import type { FC } from "react";
+import { act } from "react-dom/test-utils";
+
+act();

--- a/packages/codemods/react/19/replace-act-import/__testfixtures__/existing-type-import.output.js
+++ b/packages/codemods/react/19/replace-act-import/__testfixtures__/existing-type-import.output.js
@@ -1,0 +1,4 @@
+import type { FC } from "react";
+import { act } from "react";
+
+act();

--- a/packages/codemods/react/19/replace-act-import/src/index.ts
+++ b/packages/codemods/react/19/replace-act-import/src/index.ts
@@ -101,6 +101,9 @@ export default function transform(
 
       const existingReactImportCollection = root.find(j.ImportDeclaration, {
         source: { value: "react" },
+        importKind(value) {
+          return value === "value" || value == null;
+        },
         specifiers: [{ type: "ImportSpecifier" }],
       });
 

--- a/packages/codemods/react/19/replace-act-import/test/test.ts
+++ b/packages/codemods/react/19/replace-act-import/test/test.ts
@@ -190,4 +190,29 @@ describe("react/19/replace-act-import: TestUtils.act -> React.act", () => {
       OUTPUT.replace(/\W/gm, ""),
     );
   });
+
+  it("should not add import specifier to existing type import", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/existing-type-import.input.js"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/existing-type-import.output.js"),
+      "utf-8",
+    );
+
+    const fileInfo: FileInfo = {
+      path: "index.ts",
+      source: INPUT,
+    };
+
+    const actualOutput = transform(fileInfo, buildApi("tsx"), {
+      quote: "single",
+    });
+
+    assert.deepEqual(
+      actualOutput?.replace(/\W/gm, ""),
+      OUTPUT.replace(/\W/gm, ""),
+    );
+  });
 });


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
We ran into an issue with the `replace-act-import` codemod where the `act` import gets added to a type import like

```diff
- import { act } from 'react-dom/test-utils';
- import type { ReactNode } from 'react';
+ import type { ReactNode, act } from 'react';
```

My fix here is to filter out any `importKind` that is not `value` or `undefined`

#### 🧪 Test Plan
I added a unit test in the PR

#### 📄 Documentation to Update
N/A