### PR TITLE
feat(cli): add no-interactive flag

### DIFF
--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -100,10 +100,10 @@ export const handleRunCliCommand = async (options: {
 
   if (
     !flowSettings.dry &&
-    !args["disable-tree-version-check"] &&
     !args.readme &&
     !args.config &&
     !args.version &&
+    args.interactive &&
     !args.mode
   ) {
     await checkFileTreeVersioning(flowSettings.target);

--- a/apps/cli/src/fetch-codemod.ts
+++ b/apps/cli/src/fetch-codemod.ts
@@ -294,21 +294,21 @@ export const fetchCodemod = async (options: FetchOptions): Promise<Codemod> => {
   }
 
   if (config.engine === "recipe") {
-    const { names } = argv.noInteractive
-      ? { names: config.names }
-      : await inquirer.prompt<{ names: string[] }>({
-          name: "names",
-          type: "checkbox",
-          message:
-            "Select the codemods you would like to run. Codemods will be executed in order.",
-          choices: config.names,
-          default: config.names,
-        });
+    if (argv.interactive) {
+      const { names } = await inquirer.prompt<{ names: string[] }>({
+        name: "names",
+        type: "checkbox",
+        message:
+          "Select the codemods you would like to run. Codemods will be executed in order.",
+        choices: config.names,
+        default: config.names,
+      });
 
-    config.names = names;
+      config.names = names;
+    }
 
     const subCodemodsSpinner = printer.withLoaderMessage(
-      chalk.cyan(`Fetching ${names.length} recipe codemods...`),
+      chalk.cyan(`Fetching ${config.names.length} recipe codemods...`),
     );
 
     subCodemodsSpinner.stopAndPersist({

--- a/apps/cli/src/fetch-codemod.ts
+++ b/apps/cli/src/fetch-codemod.ts
@@ -294,14 +294,16 @@ export const fetchCodemod = async (options: FetchOptions): Promise<Codemod> => {
   }
 
   if (config.engine === "recipe") {
-    const { names } = await inquirer.prompt<{ names: string[] }>({
-      name: "names",
-      type: "checkbox",
-      message:
-        "Select the codemods you would like to run. Codemods will be executed in order.",
-      choices: config.names,
-      default: config.names,
-    });
+    const { names } = argv.noInteractive
+      ? { names: config.names }
+      : await inquirer.prompt<{ names: string[] }>({
+          name: "names",
+          type: "checkbox",
+          message:
+            "Select the codemods you would like to run. Codemods will be executed in order.",
+          choices: config.names,
+          default: config.names,
+        });
 
     config.names = names;
 

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -142,5 +142,10 @@ export const buildRunOptions = <T>(y: Argv<T>) => {
       type: "boolean",
       description: "Run codemod in the cloud",
       default: false,
+    })
+    .option("no-interactive", {
+      type: "boolean",
+      description: "Disable interactive mode",
+      default: false,
     });
 };

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -120,11 +120,6 @@ export const buildRunOptions = <T>(y: Argv<T>) => {
       description:
         "Disable packages installation for the codemod run if there is `deps` field declared in its configuration",
     })
-    .option("disable-tree-version-check", {
-      type: "boolean",
-      description: "Disable the tree version check",
-      hidden: true,
-    })
     .option("readme", {
       type: "boolean",
       description:

--- a/apps/cli/src/flags.ts
+++ b/apps/cli/src/flags.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_ENABLE_LOGGING,
   DEFAULT_ENABLE_PRETTIER,
   DEFAULT_INSTALL,
+  DEFAULT_INTERACTIVE,
   DEFAULT_TELEMETRY,
   DEFAULT_THREAD_COUNT,
   DEFAULT_USE_JSON,
@@ -143,9 +144,13 @@ export const buildRunOptions = <T>(y: Argv<T>) => {
       description: "Run codemod in the cloud",
       default: false,
     })
+    .option("interactive", {
+      type: "boolean",
+      default: DEFAULT_INTERACTIVE,
+      hidden: true,
+    })
     .option("no-interactive", {
       type: "boolean",
       description: "Disable interactive mode",
-      default: false,
     });
 };

--- a/apps/vsce/package.json
+++ b/apps/vsce/package.json
@@ -3,7 +3,7 @@
   "author": "Codemod, Inc.",
   "displayName": "Codemod.com",
   "description": " Discover, run & manage codemods faster & easier.",
-  "version": "0.38.32",
+  "version": "0.38.33",
   "publisher": "codemod",
   "icon": "img/codemod_square128.png",
   "repository": {

--- a/apps/vsce/src/components/buildArguments.ts
+++ b/apps/vsce/src/components/buildArguments.ts
@@ -68,7 +68,7 @@ export const buildArguments = (
   args.push("--json");
 
   args.push("--output", buildCrossplatformArg(storageUri.fsPath));
-  args.push("--disable-tree-version-check");
+  args.push("--no-interactive");
 
   args.push(...codemodArguments);
   args.push("--clientIdentifier", buildCrossplatformArg("VSCE"));

--- a/packages/runner/src/schemata/flow-settings.ts
+++ b/packages/runner/src/schemata/flow-settings.ts
@@ -27,6 +27,7 @@ export const DEFAULT_ENABLE_PRETTIER = false;
 export const DEFAULT_ENABLE_LOGGING = false;
 export const DEFAULT_CACHE = true;
 export const DEFAULT_INSTALL = true;
+export const DEFAULT_INTERACTIVE = true;
 export const DEFAULT_USE_JSON = false;
 export const DEFAULT_THREAD_COUNT = 4;
 export const DEFAULT_DRY_RUN = false;

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -2,7 +2,7 @@
   "name": "@codemod.com/workflow",
   "author": "Codemod, Inc.",
   "type": "module",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Workflow Engine for Codemod",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/workflow/src/codemod.ts
+++ b/packages/workflow/src/codemod.ts
@@ -5,26 +5,28 @@ import { exec } from "./exec.js";
 import { clc } from "./helpers.js";
 import { spawn } from "./spawn.js";
 
+export type CodemodReturn = PLazy<CodemodHelpers> & CodemodHelpers;
+
 /**
  * Run a codemod in current working directory
  * @param name The name of the codemod (check for available codemods at https://codemod.com/registry)
  * @param args Arguments to pass to the codemod, e.g. `{ dry: true }`, where `dry` is a flag that the codemod accepts
  *
  * @example
- * Simple run
  * ```ts
+ * // Simple run
  * await codemod("valibot/upgrade-v0.31");
  * ```
  *
  * @example
- * Run with arguments
  * ```ts
+ * // Run with arguments
  * await codemod("valibot/upgrade-v0.31", { dry: true });
  * ```
  *
  * @example
- * Chaining codemods
  * ```ts
+ * // Chaining codemods
  * await codemod("valibot/upgrade-v0.31")
  *   .codemod("valibot/upgrade-v0.32")
  *   .codemod("valibot/upgrade-v0.33");
@@ -36,7 +38,7 @@ export function codemodLogic(
     string,
     string | number | boolean | (string | number | boolean)[]
   >,
-): PLazy<CodemodHelpers> & CodemodHelpers {
+): CodemodReturn {
   return new FunctionExecutor("codemod")
     .arguments(() => ({
       name,
@@ -54,7 +56,7 @@ export function codemodLogic(
           }
           return acc;
         },
-        [] as string[],
+        ["--no-interactive"] as string[],
       );
       console.log(
         `${clc.blueBright(`codemod ${name} ${args.join(" ")}`)} ${cwd}`,
@@ -62,6 +64,7 @@ export function codemodLogic(
       await spawn("npx", ["codemod@latest", name, ...args], {
         cwd,
         doNotThrowError: true,
+        printOutput: true,
       });
       await next?.();
     })


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
Added no-interactive flag for running cli (for example do not ask which recipes to run)
