### PR TITLE
fix(codemod): support partial defaultProps

### DIFF
--- a/packages/codemods/react/19/replace-default-props/__testfixtures__/partial-default-props.input.tsx
+++ b/packages/codemods/react/19/replace-default-props/__testfixtures__/partial-default-props.input.tsx
@@ -1,0 +1,7 @@
+const Span = ({ fontSize, children }) => {
+    return <span style={{ fontSize }}>{children}</span>;
+};
+
+Span.defaultProps = {
+    fontSize: '20px',
+};

--- a/packages/codemods/react/19/replace-default-props/__testfixtures__/partial-default-props.output.tsx
+++ b/packages/codemods/react/19/replace-default-props/__testfixtures__/partial-default-props.output.tsx
@@ -1,0 +1,3 @@
+const Span = ({ fontSize = '20px', children }) => {
+    return <span style={{ fontSize }}>{children}</span>;
+};

--- a/packages/codemods/react/19/replace-default-props/src/index.ts
+++ b/packages/codemods/react/19/replace-default-props/src/index.ts
@@ -97,12 +97,14 @@ export default function transform(
           return;
         }
 
-        isDirty = true;
-        property.value = buildPropertyWithDefaultValue(
-          j,
-          property,
-          defaultPropsMap.get(property.key.name),
-        );
+        if (defaultPropsMap.has(property.key.name)) {
+          isDirty = true;
+          property.value = buildPropertyWithDefaultValue(
+            j,
+            property,
+            defaultPropsMap.get(property.key.name),
+          );
+        }
       });
     }
 

--- a/packages/codemods/react/19/replace-default-props/test/test.ts
+++ b/packages/codemods/react/19/replace-default-props/test/test.ts
@@ -180,4 +180,32 @@ describe("react/19/replace-default-props", () => {
       OUTPUT.replace(/W/gm, ""),
     );
   });
+
+  it("should correctly transform when some but not all props are defaulted", async () => {
+    const INPUT = await readFile(
+      join(__dirname, "..", "__testfixtures__/partial-default-props.input.tsx"),
+      "utf-8",
+    );
+    const OUTPUT = await readFile(
+      join(
+        __dirname,
+        "..",
+        "__testfixtures__/partial-default-props.output.tsx",
+      ),
+      "utf-8",
+    );
+
+    const actualOutput = transform(
+      {
+        path: "index.js",
+        source: INPUT,
+      },
+      buildApi("tsx"),
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ""),
+      OUTPUT.replace(/W/gm, ""),
+    );
+  });
 });


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

- [x] I've read and accepted the [Contributor License Agreement](https://github.com/codemod-com/codemod/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT.md).


#### 📚 Description

It seems thats `replace-default-props` only works when all props are defaulted but when a prop is required it won't be included in `defaultProps`. This PR attempts to fix the issue by skipping props that don't have defaults.

Example error that we were seeing:

```
Error: undefined does not match field "right": Expression of type AssignmentPattern
 ❯ addParam ../../../../../node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/src/types.ts:599:17
 ❯ ../../../../../node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/src/types.ts:627:13
 ❯ Function.builder [as assignmentPattern] ../../../../../node_modules/.pnpm/ast-types@0.16.1/node_modules/ast-types/src/types.ts:625:26
 ❯ buildPropertyWithDefaultValue src/index.ts:44:12
     42|   defaultValue: any,
     43| ) => {
     44|   return j.assignmentPattern(property.value, defaultValue);
       |            ^
     45| };
     46|
 ❯ src/index.ts:101:26
 ❯ NodePath.<anonymous> src/index.ts:91:27
 ❯ ../../../../../node_modules/.pnpm/jscodeshift@0.15.2_@babel+preset-env@7.24.7/node_modules/jscodeshift/src/Collection.js:75:36
 ````


#### 🧪 Test Plan
Added a test.

#### 📄 Documentation to Update
N/A