### PR TITLE
fix(cli): allow `--logs` usage without codemod name, fix recipe runs

### DIFF
--- a/apps/cli/src/utils/logs.ts
+++ b/apps/cli/src/utils/logs.ts
@@ -7,6 +7,8 @@ import { doubleQuotify } from "@codemod-com/utilities";
 import { version } from "#/../package.json";
 import { codemodDirectoryPath } from "./constants.js";
 
+export const logsPath = join(codemodDirectoryPath, "logs");
+
 export const writeLogs = async (options: {
   prefix: string;
   content: string;
@@ -14,7 +16,6 @@ export const writeLogs = async (options: {
 }): Promise<string> => {
   const { prefix, content, fatal } = options;
 
-  const logsPath = join(codemodDirectoryPath, "logs");
   const logFilePath = join(
     logsPath,
     `${fatal ? "FATAL-" : ""}${new Date().toISOString()}-error.log`,


### PR DESCRIPTION
- Allow running `codemod --logs` which opens directory with logs
- Fixes logic for downloading recipe codemods