### PR TITLE
chore(actions): Automated npm releases using changeset

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@3.0.2/schema.json",
+  "changelog": "@changesets/cli/changelog",
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+            node-version: 20
+
+      - name: Install modules
+        uses: pnpm/action-setup@v4
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/modgpt/package.json
+++ b/apps/modgpt/package.json
@@ -9,6 +9,7 @@
   "keywords": [],
   "author": "Codemod inc.",
   "license": "ISC",
+  "private": true,
   "dependencies": {
     "@codemod-com/auth": "workspace:*",
     "@fastify/cors": "catalog:",

--- a/apps/vsce/package.json
+++ b/apps/vsce/package.json
@@ -14,6 +14,7 @@
     "vscode": "^1.74.0",
     "node": "^20.0.0"
   },
+  "private": true,
   "categories": ["Programming Languages", "Formatters", "Linters"],
   "keywords": [
     "codemod",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:win": "vitest run packages/codemods/next/13/app-directory-boilerplate/test/test.win.ts",
     "coverage": "pnpm test:unit --coverage",
     "prepare": "husky install",
+    "release": "pnpm changeset publish",
     "release:changelog": "node scripts/releaseChangelog.mjs",
     "db:up": "docker-compose up -d",
     "db:generate": "turbo run db:generate",
@@ -65,6 +66,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.6.4",
+    "@changesets/cli": "^2.27.7",
     "@codemod-com/tsconfig": "workspace:*",
     "@codemod-com/utilities": "workspace:*",
     "@total-typescript/ts-reset": "^0.4.2",

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -8,6 +8,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
+  "private": true,
   "files": [
     "./dist",
     "!**/*.test.js",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -8,6 +8,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
+  "private": true,
   "files": [
     "./dist",
     "!**/*.test.js",

--- a/packages/codemods/Feature Flags/remove-unused-feature-flags/package.json
+++ b/packages/codemods/Feature Flags/remove-unused-feature-flags/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/Go/remove-unnecessary-nested-block/package.json
+++ b/packages/codemods/Go/remove-unnecessary-nested-block/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-go-remove-unnecessary-nested-block",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/Java/delete-unused-fields/package.json
+++ b/packages/codemods/Java/delete-unused-fields/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-java-delete-unused-fields",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/antd/5/props-changed-migration/package.json
+++ b/packages/codemods/antd/5/props-changed-migration/package.json
@@ -8,6 +8,7 @@
     "jscodeshift": "^0.15.1",
     "@types/jscodeshift": "^0.11.10"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/antd/5/remove-style-import/package.json
+++ b/packages/codemods/antd/5/remove-style-import/package.json
@@ -10,6 +10,7 @@
     "jscodeshift": "^0.15.1",
     "@types/jscodeshift": "^0.11.10"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/antd/5/removed-component-migration/package.json
+++ b/packages/codemods/antd/5/removed-component-migration/package.json
@@ -9,6 +9,7 @@
     "jscodeshift": "^0.15.1",
     "@types/jscodeshift": "^0.11.10"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/antd/5/removed-static-method-migration/package.json
+++ b/packages/codemods/antd/5/removed-static-method-migration/package.json
@@ -9,6 +9,7 @@
     "jscodeshift": "^0.15.1",
     "@types/jscodeshift": "^0.11.10"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/antd/5/utils/package.json
+++ b/packages/codemods/antd/5/utils/package.json
@@ -2,6 +2,7 @@
   "name": "@codemod-com/antd5-utils",
   "type": "module",
   "exports": "./index.js",
+  "private": true,
   "devDependencies": {
     "jscodeshift": "^0.15.1"
   }

--- a/packages/codemods/axios/fetch/package.json
+++ b/packages/codemods/axios/fetch/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fetch",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",

--- a/packages/codemods/bull/bullmq/package.json
+++ b/packages/codemods/bull/bullmq/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/cal.com/app-directory-boilerplate-calcom/package.json
+++ b/packages/codemods/cal.com/app-directory-boilerplate-calcom/package.json
@@ -19,6 +19,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/cal.com/generate-metadata-tests-calcom/package.json
+++ b/packages/codemods/cal.com/generate-metadata-tests-calcom/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/cal.com/generate-url-patterns/package.json
+++ b/packages/codemods/cal.com/generate-url-patterns/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/codemod-com/migrate-codemod-registry/package.json
+++ b/packages/codemods/codemod-com/migrate-codemod-registry/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/codemod-com/update-git-urls/package.json
+++ b/packages/codemods/codemod-com/update-git-urls/package.json
@@ -9,6 +9,7 @@
     "typescript": "^5.2.2",
     "vitest": "^1.0.1"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/devcycle/launchdarkly-to-devcycle/package.json
+++ b/packages/codemods/devcycle/launchdarkly-to-devcycle/package.json
@@ -1,6 +1,7 @@
 {
   "name": "launchdarkly-to-devcycle",
   "author": "dmytrohryshyn",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@types/node": "20.9.0",

--- a/packages/codemods/devcycle/replace-feature-flag/package.json
+++ b/packages/codemods/devcycle/replace-feature-flag/package.json
@@ -1,6 +1,7 @@
 {
   "name": "devcycle/replace-feature-flag",
   "author": "dmytrohryshyn",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@types/node": "20.9.0",

--- a/packages/codemods/ember/5/app-controller-router-props/package.json
+++ b/packages/codemods/ember/5/app-controller-router-props/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/array-wrapper/package.json
+++ b/packages/codemods/ember/5/array-wrapper/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/convert-module-for-to-setup-test/package.json
+++ b/packages/codemods/ember/5/convert-module-for-to-setup-test/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/cp-property-map/package.json
+++ b/packages/codemods/ember/5/cp-property-map/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/cp-property/package.json
+++ b/packages/codemods/ember/5/cp-property/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/cp-volatile/package.json
+++ b/packages/codemods/ember/5/cp-volatile/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/deprecate-merge/package.json
+++ b/packages/codemods/ember/5/deprecate-merge/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/deprecate-router-events/package.json
+++ b/packages/codemods/ember/5/deprecate-router-events/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/ember-jquery-legacy/package.json
+++ b/packages/codemods/ember/5/ember-jquery-legacy/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/es5-getter-ember-codemod/package.json
+++ b/packages/codemods/ember/5/es5-getter-ember-codemod/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/fpe-computed/package.json
+++ b/packages/codemods/ember/5/fpe-computed/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/fpe-observes/package.json
+++ b/packages/codemods/ember/5/fpe-observes/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/fpe-on/package.json
+++ b/packages/codemods/ember/5/fpe-on/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/jquery-apis/package.json
+++ b/packages/codemods/ember/5/jquery-apis/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/jquery-event/package.json
+++ b/packages/codemods/ember/5/jquery-event/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/notify-property-change/package.json
+++ b/packages/codemods/ember/5/notify-property-change/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/ember/5/object-new-constructor/package.json
+++ b/packages/codemods/ember/5/object-new-constructor/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/eslint/biome/migrate-rules/package.json
+++ b/packages/codemods/eslint/biome/migrate-rules/package.json
@@ -12,6 +12,7 @@
     "valibot": "catalog:",
     "vitest": "^1.0.1"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "generate": "tsx generate-latest-dts.ts",

--- a/packages/codemods/history/4/replace-state-object/package.json
+++ b/packages/codemods/history/4/replace-state-object/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/history/4/use-back/package.json
+++ b/packages/codemods/history/4/use-back/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/history/4/use-block/package.json
+++ b/packages/codemods/history/4/use-block/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/history/4/use-location/package.json
+++ b/packages/codemods/history/4/use-location/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/i18n/package.json
+++ b/packages/codemods/i18n/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/immutable/0/add-deprecation-comment/package.json
+++ b/packages/codemods/immutable/0/add-deprecation-comment/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/nest-from-js/package.json
+++ b/packages/codemods/immutable/0/nest-from-js/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/remove-from-js/package.json
+++ b/packages/codemods/immutable/0/remove-from-js/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/remove-import/package.json
+++ b/packages/codemods/immutable/0/remove-import/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/remove-to-js/package.json
+++ b/packages/codemods/immutable/0/remove-to-js/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/replace-get-in/package.json
+++ b/packages/codemods/immutable/0/replace-get-in/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/replace-get/package.json
+++ b/packages/codemods/immutable/0/replace-get/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/replace-merge/package.json
+++ b/packages/codemods/immutable/0/replace-merge/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/replace-set-in/package.json
+++ b/packages/codemods/immutable/0/replace-set-in/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/0/replace-set/package.json
+++ b/packages/codemods/immutable/0/replace-set/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/4/isterable-to-iscollection/package.json
+++ b/packages/codemods/immutable/4/isterable-to-iscollection/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/immutable/4/map-to-array/package.json
+++ b/packages/codemods/immutable/4/map-to-array/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/immutable/4/rename-to-seq/package.json
+++ b/packages/codemods/immutable/4/rename-to-seq/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/jest/vitest/package.json
+++ b/packages/codemods/jest/vitest/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/mocha/vitest/migrate-configuration/package.json
+++ b/packages/codemods/mocha/vitest/migrate-configuration/package.json
@@ -14,6 +14,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/mocha/vitest/migrate-tests/package.json
+++ b/packages/codemods/mocha/vitest/migrate-tests/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/mocha/vitest/recipe/package.json
+++ b/packages/codemods/mocha/vitest/recipe/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-mocha-vitest-recipe",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/msw/2/callback-signature/package.json
+++ b/packages/codemods/msw/2/callback-signature/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/ctx-fetch/package.json
+++ b/packages/codemods/msw/2/ctx-fetch/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/imports/package.json
+++ b/packages/codemods/msw/2/imports/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/lifecycle-events-signature/package.json
+++ b/packages/codemods/msw/2/lifecycle-events-signature/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/print-handler/package.json
+++ b/packages/codemods/msw/2/print-handler/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/req-passthrough/package.json
+++ b/packages/codemods/msw/2/req-passthrough/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/request-changes/package.json
+++ b/packages/codemods/msw/2/request-changes/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/response-usages/package.json
+++ b/packages/codemods/msw/2/response-usages/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/msw/2/type-args/package.json
+++ b/packages/codemods/msw/2/type-args/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/msw/2/upgrade-recipe/package.json
+++ b/packages/codemods/msw/2/upgrade-recipe/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-msw-2-upgrade-recipe",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/mui/5/core-styles-import/package.json
+++ b/packages/codemods/mui/5/core-styles-import/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.1/addBuildEventContext/package.json
+++ b/packages/codemods/netlify-sdk/0.8.1/addBuildEventContext/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.1/addBuildEventHandler/package.json
+++ b/packages/codemods/netlify-sdk/0.8.1/addBuildEventHandler/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.1/disableBuildEventHandlers/package.json
+++ b/packages/codemods/netlify-sdk/0.8.1/disableBuildEventHandlers/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.1/enableBuildEventHandlers/package.json
+++ b/packages/codemods/netlify-sdk/0.8.1/enableBuildEventHandlers/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.1/exportZod/package.json
+++ b/packages/codemods/netlify-sdk/0.8.1/exportZod/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.4/addApiHandler/package.json
+++ b/packages/codemods/netlify-sdk/0.8.4/addApiHandler/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.5/createEnvironmentVariable/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/createEnvironmentVariable/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.5/createOrUpdateVariable/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/createOrUpdateVariable/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/netlify-sdk/0.8.5/createOrUpdateVariables/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/createOrUpdateVariables/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariable/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariable/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariables/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/deleteEnvironmentVariables/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/netlify-sdk/0.8.5/getEnvironmentVariables/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/getEnvironmentVariables/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/netlify-sdk/0.8.5/netlify-sdk-0.8.5-recipe/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/netlify-sdk-0.8.5-recipe/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-netlify-sdk-0.8.5-netlify-sdk-0.8.5-recipe",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/netlify-sdk/0.8.5/patchEnvironmentVariable/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/patchEnvironmentVariable/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/netlify-sdk/0.8.5/updateEnvironmentVariable/package.json
+++ b/packages/codemods/netlify-sdk/0.8.5/updateEnvironmentVariable/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/netlify/add-zod-validation/package.json
+++ b/packages/codemods/netlify/add-zod-validation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "add-zod-validation",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",

--- a/packages/codemods/netlify/replace-feature-flag/package.json
+++ b/packages/codemods/netlify/replace-feature-flag/package.json
@@ -1,6 +1,7 @@
 {
   "name": "netlify/replace-feature-flag",
   "author": "dmytrohryshyn",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@types/node": "20.9.0",

--- a/packages/codemods/next-i18next/copy-keys/package.json
+++ b/packages/codemods/next-i18next/copy-keys/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/ab-test/package.json
+++ b/packages/codemods/next/13/ab-test/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/app-directory-boilerplate/package.json
+++ b/packages/codemods/next/13/app-directory-boilerplate/package.json
@@ -19,6 +19,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run test.ts",

--- a/packages/codemods/next/13/app-router-recipe/package.json
+++ b/packages/codemods/next/13/app-router-recipe/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-next-13-app-router-recipe",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/next/13/built-in-next-font/package.json
+++ b/packages/codemods/next/13/built-in-next-font/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/next/13/comment-deletable-files/package.json
+++ b/packages/codemods/next/13/comment-deletable-files/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/move-css-in-js-styles/package.json
+++ b/packages/codemods/next/13/move-css-in-js-styles/package.json
@@ -12,6 +12,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/new-image-experimental/package.json
+++ b/packages/codemods/next/13/new-image-experimental/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/new-link/package.json
+++ b/packages/codemods/next/13/new-link/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/next-image-to-legacy-image/package.json
+++ b/packages/codemods/next/13/next-image-to-legacy-image/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/next/13/remove-get-static-props/package.json
+++ b/packages/codemods/next/13/remove-get-static-props/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/remove-next-export/package.json
+++ b/packages/codemods/next/13/remove-next-export/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/replace-api-routes/package.json
+++ b/packages/codemods/next/13/replace-api-routes/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/replace-next-head/package.json
+++ b/packages/codemods/next/13/replace-next-head/package.json
@@ -20,6 +20,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/replace-next-router/package.json
+++ b/packages/codemods/next/13/replace-next-router/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/replace-use-search-params/package.json
+++ b/packages/codemods/next/13/replace-use-search-params/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/13/upsert-use-client-directive/package.json
+++ b/packages/codemods/next/13/upsert-use-client-directive/package.json
@@ -9,6 +9,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/14/metadata-to-viewport-export/package.json
+++ b/packages/codemods/next/14/metadata-to-viewport-export/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/next/14/next-og-import/package.json
+++ b/packages/codemods/next/14/next-og-import/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/nextAuth/useSession-array-to-Object-destrucutring/package.json
+++ b/packages/codemods/nextAuth/useSession-array-to-Object-destrucutring/package.json
@@ -1,6 +1,7 @@
 {
   "name": "nextjs-use-session-array-to-object-destructuring",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",

--- a/packages/codemods/npm/esm-first-in-exports/package.json
+++ b/packages/codemods/npm/esm-first-in-exports/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemod/npm-esm-first-in-exports",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",

--- a/packages/codemods/nuxt/4/absolute-watch-path/package.json
+++ b/packages/codemods/nuxt/4/absolute-watch-path/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod/nuxt-4-absolute-watch-path",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/packages/codemods/nuxt/4/default-data-error-value/package.json
+++ b/packages/codemods/nuxt/4/default-data-error-value/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod/nuxt-4-default-data-error-value",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/packages/codemods/nuxt/4/deprecated-dedupe-value/package.json
+++ b/packages/codemods/nuxt/4/deprecated-dedupe-value/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod/nuxt-4-deprecated-dedupe-value",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/packages/codemods/nuxt/4/file-structure/package.json
+++ b/packages/codemods/nuxt/4/file-structure/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@codemod/nuxt-4-file-structure",
+  "private": true,
   "license": "MIT",
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",
     "vitest": "^1.0.1",
-    "@codemod.com/workflow": "0.0.16"
+    "@codemod.com/workflow": "workspace:*"
   },
   "files": ["README.md", ".codemodrc.json", "/dist/index.cjs"],
   "type": "module"

--- a/packages/codemods/nuxt/4/migration-recipe/package.json
+++ b/packages/codemods/nuxt/4/migration-recipe/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod/nuxt-4-migration-recipe",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/nuxt/4/shallow-function-reactivity/package.json
+++ b/packages/codemods/nuxt/4/shallow-function-reactivity/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod/nuxt-4-shallow-data-reactivity",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/packages/codemods/nuxt/4/template-compilation-changes/package.json
+++ b/packages/codemods/nuxt/4/template-compilation-changes/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod/nuxt-4-template-compilation-changes",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "typescript": "^5.2.2",

--- a/packages/codemods/openFeature/replace-feature-flags/package.json
+++ b/packages/codemods/openFeature/replace-feature-flags/package.json
@@ -1,6 +1,7 @@
 {
   "name": "openFeature/replace-feature-flag",
   "author": "dmytrohryshyn",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@types/node": "20.9.0",

--- a/packages/codemods/pnpm/catalog/package.json
+++ b/packages/codemods/pnpm/catalog/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemod.com/pnpm-catalog",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",

--- a/packages/codemods/prisma/5/json-protocol/package.json
+++ b/packages/codemods/prisma/5/json-protocol/package.json
@@ -13,6 +13,7 @@
     "valibot": "catalog:",
     "vitest": "^1.0.1"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/python/orjson/recipe/package.json
+++ b/packages/codemods/python/orjson/recipe/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-python-orjson-recipe",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/react-native/74/migrate-to-fire-interval-seconds/package.json
+++ b/packages/codemods/react-native/74/migrate-to-fire-interval-seconds/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-native/74/remove-alert-action/package.json
+++ b/packages/codemods/react-native/74/remove-alert-action/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-native/74/remove-event-listener-callback/package.json
+++ b/packages/codemods/react-native/74/remove-event-listener-callback/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-redux/0/add-state-type/package.json
+++ b/packages/codemods/react-redux/0/add-state-type/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/add-exact-prop/package.json
+++ b/packages/codemods/react-router/4/add-exact-prop/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/browser-router/package.json
+++ b/packages/codemods/react-router/4/browser-router/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/create-hash-history/package.json
+++ b/packages/codemods/react-router/4/create-hash-history/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/hash-router/package.json
+++ b/packages/codemods/react-router/4/hash-router/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/index-route/package.json
+++ b/packages/codemods/react-router/4/index-route/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/move-HOC-to-global-scope/package.json
+++ b/packages/codemods/react-router/4/move-HOC-to-global-scope/package.json
@@ -8,6 +8,7 @@
     "jscodeshift": "^0.15.1",
     "@types/jscodeshift": "^0.11.10"
   },
+  "private": true,
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest watch"

--- a/packages/codemods/react-router/4/remove-with-props/package.json
+++ b/packages/codemods/react-router/4/remove-with-props/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/rename-imports/package.json
+++ b/packages/codemods/react-router/4/rename-imports/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/replace-location-query/package.json
+++ b/packages/codemods/react-router/4/replace-location-query/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/replace-nested-routes/package.json
+++ b/packages/codemods/react-router/4/replace-nested-routes/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/replace-param-prop/package.json
+++ b/packages/codemods/react-router/4/replace-param-prop/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/4/use-history-hook/package.json
+++ b/packages/codemods/react-router/4/use-history-hook/package.json
@@ -11,6 +11,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "build:cjs": "cjs-builder ./src/index.ts",

--- a/packages/codemods/react-router/4/wrap-with-switch/package.json
+++ b/packages/codemods/react-router/4/wrap-with-switch/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/6/compat-route/package.json
+++ b/packages/codemods/react-router/6/compat-route/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/compat-router/package.json
+++ b/packages/codemods/react-router/6/compat-router/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/link-to-props/package.json
+++ b/packages/codemods/react-router/6/link-to-props/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/match-path-arguments/package.json
+++ b/packages/codemods/react-router/6/match-path-arguments/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/navlink-exact-end/package.json
+++ b/packages/codemods/react-router/6/navlink-exact-end/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/redirect-to-navigate/package.json
+++ b/packages/codemods/react-router/6/redirect-to-navigate/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/remove-active-classname/package.json
+++ b/packages/codemods/react-router/6/remove-active-classname/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/6/remove-active-style/package.json
+++ b/packages/codemods/react-router/6/remove-active-style/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/6/remove-compat-router/package.json
+++ b/packages/codemods/react-router/6/remove-compat-router/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/remove-go-hooks/package.json
+++ b/packages/codemods/react-router/6/remove-go-hooks/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/remove-redirect-inside-switch/package.json
+++ b/packages/codemods/react-router/6/remove-redirect-inside-switch/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react-router/6/rename-compat-imports/package.json
+++ b/packages/codemods/react-router/6/rename-compat-imports/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/static-router-imports/package.json
+++ b/packages/codemods/react-router/6/static-router-imports/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/use-location/package.json
+++ b/packages/codemods/react-router/6/use-location/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/use-navigate/package.json
+++ b/packages/codemods/react-router/6/use-navigate/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/use-params/package.json
+++ b/packages/codemods/react-router/6/use-params/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react-router/6/use-route-match/package.json
+++ b/packages/codemods/react-router/6/use-route-match/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/react/19/migration-recipe/package.json
+++ b/packages/codemods/react/19/migration-recipe/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@codemod-com/codemod-react-19-migration-recipe",
   "files": ["./README.md", "./.codemodrc.json"],
-  "type": "module"
+  "type": "module",
+  "private": true
 }

--- a/packages/codemods/react/19/remove-context-provider/package.json
+++ b/packages/codemods/react/19/remove-context-provider/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react/19/remove-forward-ref/package.json
+++ b/packages/codemods/react/19/remove-forward-ref/package.json
@@ -11,6 +11,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react/19/remove-legacy-context/package.json
+++ b/packages/codemods/react/19/remove-legacy-context/package.json
@@ -1,6 +1,7 @@
 {
   "name": "remove-legacy-context",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@codemod.com/codemod-utils": "workspace:*",
     "@types/node": "20.9.0",

--- a/packages/codemods/react/19/remove-memoization/package.json
+++ b/packages/codemods/react/19/remove-memoization/package.json
@@ -11,6 +11,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react/19/replace-act-import/package.json
+++ b/packages/codemods/react/19/replace-act-import/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemod-com/codemod-react-replace-act-import",
   "version": "1.0.0",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.12.3",

--- a/packages/codemods/react/19/replace-create-factory/package.json
+++ b/packages/codemods/react/19/replace-create-factory/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-19-replace-create-factory",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@codemod.com/codemod-utils": "workspace:*",
     "@types/node": "20.9.0",

--- a/packages/codemods/react/19/replace-default-props/package.json
+++ b/packages/codemods/react/19/replace-default-props/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-19-replace-default-props",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@codemod.com/codemod-utils": "workspace:*",
     "@types/node": "20.9.0",

--- a/packages/codemods/react/19/replace-react-test-renderer-import/package.json
+++ b/packages/codemods/react/19/replace-react-test-renderer-import/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react/19/replace-react-test-renderer-import",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",

--- a/packages/codemods/react/19/replace-reactdom-render/package.json
+++ b/packages/codemods/react/19/replace-reactdom-render/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react/19/replace-reactdom-render",
   "author": "dmytrohryshyn",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@codemod.com/codemod-utils": "workspace:*",

--- a/packages/codemods/react/19/replace-string-ref/package.json
+++ b/packages/codemods/react/19/replace-string-ref/package.json
@@ -12,6 +12,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react/19/replace-use-form-state/package.json
+++ b/packages/codemods/react/19/replace-use-form-state/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemod-com/codemod-react-replace-use-form-state",
   "version": "1.0.0",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^20.12.3",

--- a/packages/codemods/react/19/use-context-hook/package.json
+++ b/packages/codemods/react/19/use-context-hook/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react/prop-types-typescript/package.json
+++ b/packages/codemods/react/prop-types-typescript/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/react/replace-react-fc-typescript/package.json
+++ b/packages/codemods/react/replace-react-fc-typescript/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/redwoodjs/core/4/auth-decoder/package.json
+++ b/packages/codemods/redwoodjs/core/4/auth-decoder/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/redwoodjs/core/4/redwood-apollo-provider/package.json
+++ b/packages/codemods/redwoodjs/core/4/redwood-apollo-provider/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/redwoodjs/core/4/router-use-auth/package.json
+++ b/packages/codemods/redwoodjs/core/4/router-use-auth/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/redwoodjs/core/4/use-armor/package.json
+++ b/packages/codemods/redwoodjs/core/4/use-armor/package.json
@@ -10,6 +10,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {},
   "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],

--- a/packages/codemods/remove-unused-feature-flags-2/package.json
+++ b/packages/codemods/remove-unused-feature-flags-2/package.json
@@ -13,6 +13,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/replace-feature-flag-core/package.json
+++ b/packages/codemods/replace-feature-flag-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "replace-feature-flag-core",
   "author": "dmytrohryshyn",
+  "private": true,
   "dependencies": {},
   "devDependencies": {
     "@types/node": "20.9.0",

--- a/packages/codemods/sql/add-index-before-select/package.json
+++ b/packages/codemods/sql/add-index-before-select/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@codemod-com/sql-add-index-before-select",
   "license": "MIT",
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "^5.2.2",

--- a/packages/codemods/statsig/replace-gate/package.json
+++ b/packages/codemods/statsig/replace-gate/package.json
@@ -2,6 +2,7 @@
   "name": "statsig/replace-gate",
   "author": "dmytrohryshyn",
   "dependencies": {},
+  "private": true,
   "devDependencies": {
     "@types/node": "20.9.0",
     "typescript": "5.2.2",

--- a/packages/codemods/typescript/remove-public-modifier/package.json
+++ b/packages/codemods/typescript/remove-public-modifier/package.json
@@ -11,6 +11,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/typescript/use-template-literals/package.json
+++ b/packages/codemods/typescript/use-template-literals/package.json
@@ -11,6 +11,7 @@
     "vitest": "^1.0.1",
     "@vitest/coverage-v8": "catalog:"
   },
+  "private": true,
   "main": "./dist/index.cjs",
   "scripts": {
     "test": "vitest run",

--- a/packages/codemods/vue/3/render-function-api/package.json
+++ b/packages/codemods/vue/3/render-function-api/package.json
@@ -9,6 +9,7 @@
     "typescript": "^5.2.2",
     "vitest": "^1.0.1"
   },
+  "private": true,
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest watch"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -7,6 +7,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": ["dist/**"],
+  "private": true,
   "scripts": {
     "build": "pnpm run db:generate && tsc",
     "db:migrate:create": "prisma migrate dev",

--- a/packages/deprecated/package.json
+++ b/packages/deprecated/package.json
@@ -1,8 +1,10 @@
 {
+  "name": "@codemod/deprecated",
   "author": "Codemod, Inc.",
   "version": "0.0.1",
   "description": "Deprecated code that is not used in Codemod.com products anymore, but could be reused later",
   "sideEffects": false,
+  "private": true,
   "files": [
     "./dist",
     "!**/*.test.js",

--- a/packages/filemod/package.json
+++ b/packages/filemod/package.json
@@ -7,6 +7,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "private": true,
   "files": [
     "./dist",
     "!**/*.test.js",

--- a/packages/printer/package.json
+++ b/packages/printer/package.json
@@ -15,6 +15,7 @@
     "README.md",
     "tsconfig.json"
   ],
+  "private": true,
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -4,6 +4,7 @@
   "imports": {
     "#*": "./src/*"
   },
+  "private": true,
   "version": "1.1.1",
   "description": "The codemod runner used in Codemod.com ecosystem",
   "type": "module",

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -14,6 +14,7 @@
     "README.md",
     "tsconfig.json"
   ],
+  "private": true,
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -19,6 +19,7 @@
     "README.md",
     "tsconfig.json"
   ],
+  "private": true,
   "scripts": {
     "build": "tsc",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,6 +849,9 @@ importers:
       '@biomejs/biome':
         specifier: ^1.6.4
         version: 1.8.2
+      '@changesets/cli':
+        specifier: ^2.27.7
+        version: 2.27.7
       '@codemod-com/tsconfig':
         specifier: workspace:*
         version: link:packages/tsconfig
@@ -1035,7 +1038,7 @@ importers:
         version: 5.4.1
       langchain:
         specifier: 'catalog:'
-        version: 0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
+        version: 0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
       openai:
         specifier: 'catalog:'
         version: 4.23.0
@@ -4727,8 +4730,8 @@ importers:
   packages/codemods/nuxt/4/file-structure:
     devDependencies:
       '@codemod.com/workflow':
-        specifier: 0.0.16
-        version: 0.0.16
+        specifier: workspace:*
+        version: link:../../../../workflow
       '@types/node':
         specifier: 20.9.0
         version: 20.9.0
@@ -6259,6 +6262,8 @@ importers:
         specifier: ^4.11.0
         version: 4.15.7
 
+  packages/database/generated/client: {}
+
   packages/deprecated: {}
 
   packages/filemod:
@@ -6695,22 +6700,10 @@ packages:
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
 
-  '@ast-grep/cli-darwin-arm64@0.24.1':
-    resolution: {integrity: sha512-fxCMiwbgwEe0mg2Rk7zgMidKYIDm78uDPBkUHcTxiK1NnS6VdjlBUZKGF4sXY0kUoNnAhSq/tN5q0A7//kFF3Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@ast-grep/cli-darwin-arm64@0.25.4':
     resolution: {integrity: sha512-mzoQiHSYy3Kk/YjibVbkkDYD24+ajKopq1hq7vMrFtQjn6eYzk/ki1WFq0642qv5qxLrB3cyijUk5J97dQNInw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@ast-grep/cli-darwin-x64@0.24.1':
-    resolution: {integrity: sha512-sFrHao6OHP5FVVALgWsc4JViC2u+4Mmxo8KOp+W4n6OPSRGvLDBjclc6wMRabm01TV0zsx60aHnomGUHJl7Yiw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [darwin]
 
   '@ast-grep/cli-darwin-x64@0.25.4':
@@ -6719,22 +6712,10 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@ast-grep/cli-linux-arm64-gnu@0.24.1':
-    resolution: {integrity: sha512-Xhr3G7yVJ4OgnfDb94kDRNBtTwTnFbBdJuA8WE/9dcbw2D/4nOMoCL1Z+wvXUw8+Gk/2rVi7m1hu02rY7kOE0Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
   '@ast-grep/cli-linux-arm64-gnu@0.25.4':
     resolution: {integrity: sha512-JWkZHLZlTxlprQ+IXNOv/bZR8MVMMhj2d+7QGBWPqOTC+R2YrH4zz1+iaaPLWoTkUUFHcBcXFnYz0jakHs8XrQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [linux]
-
-  '@ast-grep/cli-linux-x64-gnu@0.24.1':
-    resolution: {integrity: sha512-9hmVidjHRFWev/PYR9W+f9HAffHtkpY7A8s1VHju6Yz0hXl0uhs1xX1ProuZHoGUSpUEWf4tG92oWhqqyjRrDg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
     os: [linux]
 
   '@ast-grep/cli-linux-x64-gnu@0.25.4':
@@ -6743,22 +6724,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@ast-grep/cli-win32-arm64-msvc@0.24.1':
-    resolution: {integrity: sha512-BRr4dbmirNXUGUZaMKlo9Y0yS0BHgLo+nr9tTVd0AxN5WKixIq4wDeXWt192ve9PQmRkoy3H7BeCLHySzapF0Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@ast-grep/cli-win32-arm64-msvc@0.25.4':
     resolution: {integrity: sha512-ryBRHT5sNUhLKLAVV+KIE7oc3sSzA7yewxhq4cpHM2FG8FfdAF8kgYDY6J6fFLWlW30OyImdOW9Bz8ufki/UWw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@ast-grep/cli-win32-ia32-msvc@0.24.1':
-    resolution: {integrity: sha512-2siLfAS/2yP4otf6ApSJeHM8erj9E/P98UrifsTv//9Qmwe6cigO54v1Wuf1HpkjQKckppDmLrmNcm6pNwGS5A==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
     os: [win32]
 
   '@ast-grep/cli-win32-ia32-msvc@0.25.4':
@@ -6767,33 +6736,16 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@ast-grep/cli-win32-x64-msvc@0.24.1':
-    resolution: {integrity: sha512-Mv+bkF/zEHAnrQSrG2BuBIUvBAD+2QgK5CbzV1oNIDufSvMFiC1d/Cu375XUs+kNZlWh5Z2FHl4/BGNbfnT/pg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
   '@ast-grep/cli-win32-x64-msvc@0.25.4':
     resolution: {integrity: sha512-3DSl6pdrn2OPtLKAACa7AwkCCiF58S3Y0zyzipIaAwQ8Bz9aymwHBwZH3xmJS1A6LkcbxN7Un9LJtsMU/XXzKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@ast-grep/cli@0.24.1':
-    resolution: {integrity: sha512-FgUFTECYawnU1PGcD4O+Z/1hcPBo63/krp0PrGPhIZzuq/grXfLk6RGIAgT1Sk16N7lqrKlS4eEAO8mBH0PILw==}
-    engines: {node: '>= 12.0.0'}
-    hasBin: true
-
   '@ast-grep/cli@0.25.4':
     resolution: {integrity: sha512-m55UEv2EO1jAb3hgNp6TipydKsEff/odKSjpy2BF3eX4YaY9st/t/JBFakMqhfUA2lvGgrP894vYXPEzzs3kqA==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
-
-  '@ast-grep/napi-darwin-arm64@0.24.1':
-    resolution: {integrity: sha512-0lb5/GDTGIeEMak996kKNIjnnF0JRkzfLvDCpSr4wrh14qHScDzJ9eaeyElRcpawdB+7PxJM7aMNt1K7IgxHtQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
 
   '@ast-grep/napi-darwin-arm64@0.25.4':
     resolution: {integrity: sha512-qjqj0nARO1dJcsG2AQ2vaxtPV7je1A6SoYv3AG58/4mXdFg56hoVL4Op5DJpHNvg0e8rqkFJpJ7YIEFF2sQuAw==}
@@ -6801,23 +6753,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@ast-grep/napi-darwin-x64@0.24.1':
-    resolution: {integrity: sha512-2P439egpgHBlFPYantwPDMJf3gH7nIdLsfrrS9OYyjtzYyO8XoJh9jr0GKz/krr87V2SdrM0exF4oNnqBwFe4A==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
   '@ast-grep/napi-darwin-x64@0.25.4':
     resolution: {integrity: sha512-1JhmH7Nwpz90TtX2+4joN29kkn69j96guLZGueN1uE0q084po7DB8hJHmn37o3eL1WCdeh1cptGGoHCfBnYBWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
-
-  '@ast-grep/napi-linux-arm64-gnu@0.24.1':
-    resolution: {integrity: sha512-FQB7xLJ55ZQi4lQOpzhfC4xThz4c5sPO6qKUHdCDwsQlvUAVE0a/1FYgIuIN8BCff+ssht/KCEYYJZrlf5u5Aw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
 
   '@ast-grep/napi-linux-arm64-gnu@0.25.4':
     resolution: {integrity: sha512-0oC/czHjMJ3mtu5+o374xf4aOmr4/0xyW4JKyjSSJKlWhME/LZH/O4BOPPBi/xAOsqmb+t0J/lYEO4MoJOKeaA==}
@@ -6831,20 +6771,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@ast-grep/napi-linux-x64-gnu@0.24.1':
-    resolution: {integrity: sha512-RfEvgv4YpROjqpyz95hNDNBiHwlIL2bTDw9kyUM/90ah2PUaGs0IbN68/R0gppvQp9j4MLsw+YUNlP7nf2gtIQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
   '@ast-grep/napi-linux-x64-gnu@0.25.4':
     resolution: {integrity: sha512-ttBnrapPkJQPjgE6dCjOTWkpBjKz9y2Sc/ZiOB1B5xEQWCy0Oh35W8xkBdRjlfiU9RvVBCq5LrR5VX6nvKPZlQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@ast-grep/napi-linux-x64-musl@0.24.1':
-    resolution: {integrity: sha512-jTtbX+pJt2KW1G8eT/qnfFSD6HWEUsKGsHD1McOd43StcTEeuDyS7TbdjDfHI617Dg2IHc9AJMVfaIOsYzlEpA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -6855,22 +6783,10 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@ast-grep/napi-win32-arm64-msvc@0.24.1':
-    resolution: {integrity: sha512-JXQ2WXXBm+W4tjwB9mHxDSVAjcW7GrEBE6q8iRYClFILbhhaDUXFgKs2V2K0kVy+KPVjYoIi20gP42ILRjUCLA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
   '@ast-grep/napi-win32-arm64-msvc@0.25.4':
     resolution: {integrity: sha512-FOCxrPFWR7WgfpCz9vmE1SJGM2RB26ZaB3aRvnmopBkQVvZTZ/CyjG9Eee2zzu659OA4SoDO4eQ0m/VdL3LXUA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
-    os: [win32]
-
-  '@ast-grep/napi-win32-ia32-msvc@0.24.1':
-    resolution: {integrity: sha512-9sVEBOGJOSADu8TsqFdtf9GQJAKMyP+hatNud3Qn8MAWRu8NOfo0vMR4VCnBNr9gS6bShBJEj63FXkfLKI2oNQ==}
-    engines: {node: '>= 10'}
-    cpu: [ia32]
     os: [win32]
 
   '@ast-grep/napi-win32-ia32-msvc@0.25.4':
@@ -6879,21 +6795,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@ast-grep/napi-win32-x64-msvc@0.24.1':
-    resolution: {integrity: sha512-8/q0JyTEBAvo0vb5t4uF5stqkqyjLU2loOEOtOMXNBbqus9pxyVJ1HfzN4Iju/x2st9vomUMk2Vw3LokxsiSlQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
   '@ast-grep/napi-win32-x64-msvc@0.25.4':
     resolution: {integrity: sha512-itYPveFAbV19XyqaHIVO78N4doPMqGjbnTFjZD2fvCHXzUujxqlCXEt45+tNq9iXtn38e4wZB21ew0N2bX6IEw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
-
-  '@ast-grep/napi@0.24.1':
-    resolution: {integrity: sha512-586Jk2gW5+m8HgoZNLxikpHUMTdUfj56+S2veiPKuls4JMiJJdB0ujwPGjv6PGIA7LlAGE3Z+ppkSc2SLX+qMA==}
-    engines: {node: '>= 10'}
 
   '@ast-grep/napi@0.25.4':
     resolution: {integrity: sha512-Ax6OBQehjv6Fw/qU3BlTvUmugK3BfMK7eV0aPrLAxJ3+0neQcE+p7QP42iiHsf1n/vG7npv7uUaBRfjzHH4hiQ==}
@@ -7948,6 +7854,61 @@ packages:
     resolution: {integrity: sha512-QBEeUmc5K6kzut0uurwBtJhJW2fc/KEdKhST2/71Ln6V3j4b4qzK1/OeDsUHAt/RM2Dxe5TjWNn82r6WzmrAIQ==}
     engines: {node: '>=18'}
 
+  '@changesets/apply-release-plan@7.0.4':
+    resolution: {integrity: sha512-HLFwhKWayKinWAul0Vj+76jVx1Pc2v55MGPVjZ924Y/ROeSsBMFutv9heHmCUj48lJyRfOTJG5+ar+29FUky/A==}
+
+  '@changesets/assemble-release-plan@6.0.3':
+    resolution: {integrity: sha512-bLNh9/Lgl1VwkjWZTq8JmRqH+hj7/Yzfz0jsQ/zJJ+FTmVqmqPj3szeKOri8O/hEM8JmHW019vh2gTO9iq5Cuw==}
+
+  '@changesets/changelog-git@0.2.0':
+    resolution: {integrity: sha512-bHOx97iFI4OClIT35Lok3sJAwM31VbUM++gnMBV16fdbtBhgYu4dxsphBF/0AZZsyAHMrnM0yFcj5gZM1py6uQ==}
+
+  '@changesets/cli@2.27.7':
+    resolution: {integrity: sha512-6lr8JltiiXPIjDeYg4iM2MeePP6VN/JkmqBsVA5XRiy01hGS3y629LtSDvKcycj/w/5Eur1rEwby/MjcYS+e2A==}
+    hasBin: true
+
+  '@changesets/config@3.0.2':
+    resolution: {integrity: sha512-cdEhS4t8woKCX2M8AotcV2BOWnBp09sqICxKapgLHf9m5KdENpWjyrFNMjkLqGJtUys9U+w93OxWT0czorVDfw==}
+
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+
+  '@changesets/get-dependents-graph@2.1.1':
+    resolution: {integrity: sha512-LRFjjvigBSzfnPU2n/AhFsuWR5DK++1x47aq6qZ8dzYsPtS/I5mNhIGAS68IAxh1xjO9BTtz55FwefhANZ+FCA==}
+
+  '@changesets/get-release-plan@4.0.3':
+    resolution: {integrity: sha512-6PLgvOIwTSdJPTtpdcr3sLtGatT+Jr22+cQwEBJBy6wP0rjB4yJ9lv583J9fVpn1bfQlBkDa8JxbS2g/n9lIyA==}
+
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+
+  '@changesets/git@3.0.0':
+    resolution: {integrity: sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==}
+
+  '@changesets/logger@0.1.0':
+    resolution: {integrity: sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==}
+
+  '@changesets/parse@0.4.0':
+    resolution: {integrity: sha512-TS/9KG2CdGXS27S+QxbZXgr8uPsP4yNJYb4BC2/NeFUj80Rni3TeD2qwWmabymxmrLo7JEsytXH1FbpKTbvivw==}
+
+  '@changesets/pre@2.0.0':
+    resolution: {integrity: sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==}
+
+  '@changesets/read@0.6.0':
+    resolution: {integrity: sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==}
+
+  '@changesets/should-skip-package@0.1.0':
+    resolution: {integrity: sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.0.0':
+    resolution: {integrity: sha512-b1UkfNulgKoWfqyHtzKS5fOZYSJO+77adgL7DLRDr+/7jhChN+QcHnbjiQVOz/U+Ts3PGNySq7diAItzDgugfQ==}
+
+  '@changesets/write@0.3.1':
+    resolution: {integrity: sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==}
+
   '@chevrotain/cst-dts-gen@10.5.0':
     resolution: {integrity: sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==}
 
@@ -8105,9 +8066,6 @@ packages:
 
   '@codemirror/view@6.28.2':
     resolution: {integrity: sha512-A3DmyVfjgPsGIjiJqM/zvODUAPQdQl3ci0ghehYNnbt5x+o76xq+dL5+mMBuysDXnI3kapgOkoeJ0sbtL/3qPw==}
-
-  '@codemod.com/workflow@0.0.16':
-    resolution: {integrity: sha512-VbLCN51aVlZ/hxjc9Gp64O/8PvjZWzuWeRZQ48ES+z4q5PaQtq9C1h0e6FJWPJtmXnhRtks7azvdAWdMK8vFvg==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -9736,6 +9694,12 @@ packages:
   '@lukeed/ms@2.0.2':
     resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
     engines: {node: '>=8'}
+
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
   '@microsoft/applicationinsights-web-snippet@1.0.1':
     resolution: {integrity: sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ==}
@@ -12033,6 +11997,9 @@ packages:
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
 
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
   '@types/node@16.18.101':
     resolution: {integrity: sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA==}
 
@@ -12614,6 +12581,10 @@ packages:
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -12683,6 +12654,9 @@ packages:
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -12922,6 +12896,10 @@ packages:
 
   before-after-hook@3.0.2:
     resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -13197,6 +13175,10 @@ packages:
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
 
   cjs-module-lexer@1.3.1:
     resolution: {integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==}
@@ -13557,6 +13539,9 @@ packages:
 
   cron@3.1.7:
     resolution: {integrity: sha512-tlBg7ARsAMQLzgwqVxy8AZl/qlTc5nibqYwtNGoCrd+cV+ugI+tvZC1oT/8dFH8W455YrywGykx/KMmAqOr7Jw==}
+
+  cross-spawn@5.1.0:
+    resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
 
   cross-spawn@6.0.5:
     resolution: {integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==}
@@ -14062,6 +14047,10 @@ packages:
     resolution: {integrity: sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==}
     engines: {node: '>=10.13.0'}
 
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+
   entities@2.1.0:
     resolution: {integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==}
 
@@ -14450,6 +14439,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -14634,6 +14626,9 @@ packages:
     resolution: {integrity: sha512-2kCCtc+JvcZ86IGAz3Z2Y0A1baIz9fL31pH/0S1IqZr9Iwnjq8izfPtrCyQKO6TLMPELLsQMre7VDqeIKCsHkA==}
     engines: {node: '>=18'}
 
+  find-yarn-workspace-root2@1.2.16:
+    resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
+
   findup-sync@4.0.0:
     resolution: {integrity: sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==}
     engines: {node: '>= 8'}
@@ -14757,6 +14752,14 @@ packages:
   fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
     engines: {node: '>=14.14'}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
 
   fs-extra@9.1.0:
     resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
@@ -15144,6 +15147,9 @@ packages:
   https-proxy-agent@7.0.4:
     resolution: {integrity: sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==}
     engines: {node: '>= 14'}
+
+  human-id@1.0.2:
+    resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
 
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
@@ -15559,6 +15565,10 @@ packages:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
 
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
   is-symbol@1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
@@ -15711,6 +15721,10 @@ packages:
   js-tokens@9.0.0:
     resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
 
+  js-yaml@3.14.1:
+    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -15815,6 +15829,9 @@ packages:
 
   jsonc-parser@3.2.1:
     resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
@@ -16116,6 +16133,10 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
+  load-yaml-file@0.2.0:
+    resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
+    engines: {node: '>=6'}
+
   loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
@@ -16286,6 +16307,9 @@ packages:
   lru-cache@10.2.2:
     resolution: {integrity: sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==}
     engines: {node: 14 || >=16.14}
+
+  lru-cache@4.1.5:
+    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -17301,9 +17325,16 @@ packages:
     resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
     engines: {node: '>=0.10.0'}
 
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
   p-each-series@3.0.0:
     resolution: {integrity: sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==}
     engines: {node: '>=12'}
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
 
   p-filter@4.1.0:
     resolution: {integrity: sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==}
@@ -17364,6 +17395,10 @@ packages:
   p-map@1.2.0:
     resolution: {integrity: sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==}
     engines: {node: '>=4'}
+
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
 
   p-map@7.0.2:
     resolution: {integrity: sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==}
@@ -17811,6 +17846,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  preferred-pm@3.1.4:
+    resolution: {integrity: sha512-lEHd+yEm22jXdCphDrkvIJQU66EuLojPPtvZkpKIkiD+l0DMThF/niqZKJSoU8Vl7iuvtmzyMhir9LdVy5WMnA==}
+    engines: {node: '>=10'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -18038,6 +18077,9 @@ packages:
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pseudomap@1.0.2:
+    resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
   psl@1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
@@ -18462,6 +18504,10 @@ packages:
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
     engines: {node: '>=18'}
+
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
 
   read@1.0.7:
     resolution: {integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==}
@@ -19155,6 +19201,9 @@ packages:
   spawn-error-forwarder@1.0.0:
     resolution: {integrity: sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==}
 
+  spawndamnit@2.0.0:
+    resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -19180,6 +19229,9 @@ packages:
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   sswr@2.0.0:
     resolution: {integrity: sha512-mV0kkeBHcjcb0M5NqKtKVg/uTIYNlIIniyDfSGrSfxpEdM9C365jK0z55pl9K0xAkNTJi2OAOVFQpgMPUk+V0w==}
@@ -19541,6 +19593,10 @@ packages:
   tempy@3.1.0:
     resolution: {integrity: sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==}
     engines: {node: '>=14.16'}
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
 
   terminal-link@3.0.0:
     resolution: {integrity: sha512-flFL3m4wuixmf6IfhFJd1YPiLiMuxEc8uHRM1buzIeZPm22Au2pDqBJQgdo7n1WfPU1ONFGv7YDwpFBmHGF6lg==}
@@ -20102,6 +20158,10 @@ packages:
   universal-user-agent@7.0.2:
     resolution: {integrity: sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==}
 
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -20557,6 +20617,10 @@ packages:
     resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
     engines: {node: '>= 0.4'}
 
+  which-pm@2.2.0:
+    resolution: {integrity: sha512-MOiaDbA5ZZgUjkeMWM5EkJp4loW5ZRoa5bc3/aeMox/PJelMhE6t7S/mLuiY43DBupyxH+S0U1bTui9kWUlmsw==}
+    engines: {node: '>=8.15'}
+
   which-typed-array@1.1.15:
     resolution: {integrity: sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==}
     engines: {node: '>= 0.4'}
@@ -20686,6 +20750,9 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
+
+  yallist@2.1.2:
+    resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -20833,59 +20900,26 @@ snapshots:
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
 
-  '@ast-grep/cli-darwin-arm64@0.24.1':
-    optional: true
-
   '@ast-grep/cli-darwin-arm64@0.25.4':
-    optional: true
-
-  '@ast-grep/cli-darwin-x64@0.24.1':
     optional: true
 
   '@ast-grep/cli-darwin-x64@0.25.4':
     optional: true
 
-  '@ast-grep/cli-linux-arm64-gnu@0.24.1':
-    optional: true
-
   '@ast-grep/cli-linux-arm64-gnu@0.25.4':
-    optional: true
-
-  '@ast-grep/cli-linux-x64-gnu@0.24.1':
     optional: true
 
   '@ast-grep/cli-linux-x64-gnu@0.25.4':
     optional: true
 
-  '@ast-grep/cli-win32-arm64-msvc@0.24.1':
-    optional: true
-
   '@ast-grep/cli-win32-arm64-msvc@0.25.4':
-    optional: true
-
-  '@ast-grep/cli-win32-ia32-msvc@0.24.1':
     optional: true
 
   '@ast-grep/cli-win32-ia32-msvc@0.25.4':
     optional: true
 
-  '@ast-grep/cli-win32-x64-msvc@0.24.1':
-    optional: true
-
   '@ast-grep/cli-win32-x64-msvc@0.25.4':
     optional: true
-
-  '@ast-grep/cli@0.24.1':
-    dependencies:
-      detect-libc: 2.0.3
-    optionalDependencies:
-      '@ast-grep/cli-darwin-arm64': 0.24.1
-      '@ast-grep/cli-darwin-x64': 0.24.1
-      '@ast-grep/cli-linux-arm64-gnu': 0.24.1
-      '@ast-grep/cli-linux-x64-gnu': 0.24.1
-      '@ast-grep/cli-win32-arm64-msvc': 0.24.1
-      '@ast-grep/cli-win32-ia32-msvc': 0.24.1
-      '@ast-grep/cli-win32-x64-msvc': 0.24.1
 
   '@ast-grep/cli@0.25.4':
     dependencies:
@@ -20899,19 +20933,10 @@ snapshots:
       '@ast-grep/cli-win32-ia32-msvc': 0.25.4
       '@ast-grep/cli-win32-x64-msvc': 0.25.4
 
-  '@ast-grep/napi-darwin-arm64@0.24.1':
-    optional: true
-
   '@ast-grep/napi-darwin-arm64@0.25.4':
     optional: true
 
-  '@ast-grep/napi-darwin-x64@0.24.1':
-    optional: true
-
   '@ast-grep/napi-darwin-x64@0.25.4':
-    optional: true
-
-  '@ast-grep/napi-linux-arm64-gnu@0.24.1':
     optional: true
 
   '@ast-grep/napi-linux-arm64-gnu@0.25.4':
@@ -20920,46 +20945,20 @@ snapshots:
   '@ast-grep/napi-linux-arm64-musl@0.25.4':
     optional: true
 
-  '@ast-grep/napi-linux-x64-gnu@0.24.1':
-    optional: true
-
   '@ast-grep/napi-linux-x64-gnu@0.25.4':
-    optional: true
-
-  '@ast-grep/napi-linux-x64-musl@0.24.1':
     optional: true
 
   '@ast-grep/napi-linux-x64-musl@0.25.4':
     optional: true
 
-  '@ast-grep/napi-win32-arm64-msvc@0.24.1':
-    optional: true
-
   '@ast-grep/napi-win32-arm64-msvc@0.25.4':
-    optional: true
-
-  '@ast-grep/napi-win32-ia32-msvc@0.24.1':
     optional: true
 
   '@ast-grep/napi-win32-ia32-msvc@0.25.4':
     optional: true
 
-  '@ast-grep/napi-win32-x64-msvc@0.24.1':
-    optional: true
-
   '@ast-grep/napi-win32-x64-msvc@0.25.4':
     optional: true
-
-  '@ast-grep/napi@0.24.1':
-    optionalDependencies:
-      '@ast-grep/napi-darwin-arm64': 0.24.1
-      '@ast-grep/napi-darwin-x64': 0.24.1
-      '@ast-grep/napi-linux-arm64-gnu': 0.24.1
-      '@ast-grep/napi-linux-x64-gnu': 0.24.1
-      '@ast-grep/napi-linux-x64-musl': 0.24.1
-      '@ast-grep/napi-win32-arm64-msvc': 0.24.1
-      '@ast-grep/napi-win32-ia32-msvc': 0.24.1
-      '@ast-grep/napi-win32-x64-msvc': 0.24.1
 
   '@ast-grep/napi@0.25.4':
     optionalDependencies:
@@ -22608,6 +22607,162 @@ snapshots:
       hotscript: 1.0.13
       nanoid: 5.0.7
 
+  '@changesets/apply-release-plan@7.0.4':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/config': 3.0.2
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.0
+      '@changesets/should-skip-package': 0.1.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.6.2
+
+  '@changesets/assemble-release-plan@6.0.3':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.1
+      '@changesets/should-skip-package': 0.1.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.6.2
+
+  '@changesets/changelog-git@0.2.0':
+    dependencies:
+      '@changesets/types': 6.0.0
+
+  '@changesets/cli@2.27.7':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/apply-release-plan': 7.0.4
+      '@changesets/assemble-release-plan': 6.0.3
+      '@changesets/changelog-git': 0.2.0
+      '@changesets/config': 3.0.2
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.1
+      '@changesets/get-release-plan': 4.0.3
+      '@changesets/git': 3.0.0
+      '@changesets/logger': 0.1.0
+      '@changesets/pre': 2.0.0
+      '@changesets/read': 0.6.0
+      '@changesets/should-skip-package': 0.1.0
+      '@changesets/types': 6.0.0
+      '@changesets/write': 0.3.1
+      '@manypkg/get-packages': 1.1.3
+      '@types/semver': 7.5.8
+      ansi-colors: 4.1.3
+      chalk: 2.4.2
+      ci-info: 3.9.0
+      enquirer: 2.4.1
+      external-editor: 3.1.0
+      fs-extra: 7.0.1
+      human-id: 1.0.2
+      mri: 1.2.0
+      outdent: 0.5.0
+      p-limit: 2.3.0
+      preferred-pm: 3.1.4
+      resolve-from: 5.0.0
+      semver: 7.6.2
+      spawndamnit: 2.0.0
+      term-size: 2.2.1
+
+  '@changesets/config@3.0.2':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.1
+      '@changesets/logger': 0.1.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.7
+
+  '@changesets/errors@0.2.0':
+    dependencies:
+      extendable-error: 0.1.7
+
+  '@changesets/get-dependents-graph@2.1.1':
+    dependencies:
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      chalk: 2.4.2
+      fs-extra: 7.0.1
+      semver: 7.6.2
+
+  '@changesets/get-release-plan@4.0.3':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/assemble-release-plan': 6.0.3
+      '@changesets/config': 3.0.2
+      '@changesets/pre': 2.0.0
+      '@changesets/read': 0.6.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/get-version-range-type@0.4.0': {}
+
+  '@changesets/git@3.0.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.7
+      spawndamnit: 2.0.0
+
+  '@changesets/logger@0.1.0':
+    dependencies:
+      chalk: 2.4.2
+
+  '@changesets/parse@0.4.0':
+    dependencies:
+      '@changesets/types': 6.0.0
+      js-yaml: 3.14.1
+
+  '@changesets/pre@2.0.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+
+  '@changesets/read@0.6.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/git': 3.0.0
+      '@changesets/logger': 0.1.0
+      '@changesets/parse': 0.4.0
+      '@changesets/types': 6.0.0
+      chalk: 2.4.2
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+
+  '@changesets/should-skip-package@0.1.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/types': 6.0.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/types@4.1.0': {}
+
+  '@changesets/types@6.0.0': {}
+
+  '@changesets/write@0.3.1':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/types': 6.0.0
+      fs-extra: 7.0.1
+      human-id: 1.0.2
+      prettier: 2.8.8
+
   '@chevrotain/cst-dts-gen@10.5.0':
     dependencies:
       '@chevrotain/gast': 10.5.0
@@ -22858,25 +23013,6 @@ snapshots:
       '@codemirror/state': 6.4.1
       style-mod: 4.1.2
       w3c-keyname: 2.2.8
-
-  '@codemod.com/workflow@0.0.16':
-    dependencies:
-      '@ast-grep/cli': 0.24.1
-      '@ast-grep/napi': 0.24.1
-      '@sindresorhus/slugify': 2.2.1
-      colors-cli: 1.0.33
-      filenamify: 6.0.0
-      glob: 10.4.2
-      lodash-es: 4.17.21
-      magic-string: 0.30.10
-      openai: 4.23.0
-      prettier: 3.3.2
-      simple-git: 3.25.0
-      tree-kill: 1.2.2
-      ts-invariant: 0.10.3
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   '@colors/colors@1.5.0':
     optional: true
@@ -23844,13 +23980,13 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(chromadb@1.7.2(openai@4.23.0))(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)':
+  '@langchain/community@0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(chromadb@1.7.2(openai@4.23.0))(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)':
     dependencies:
-      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
-      '@langchain/openai': 0.0.34(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))
+      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
+      '@langchain/openai': 0.0.34(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))
       expr-eval: 2.0.2
       flat: 5.0.2
-      langsmith: 0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
+      langsmith: 0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
       uuid: 9.0.1
       zod: 3.23.8
       zod-to-json-schema: 3.23.1(zod@3.23.8)
@@ -23871,13 +24007,13 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)':
+  '@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.12
-      langsmith: 0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
+      langsmith: 0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
       ml-distance: 4.0.1
       mustache: 4.2.0
       p-queue: 6.6.2
@@ -23889,13 +24025,13 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)':
+  '@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)':
     dependencies:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.12
-      langsmith: 0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)
+      langsmith: 0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)
       ml-distance: 4.0.1
       mustache: 4.2.0
       p-queue: 6.6.2
@@ -23907,9 +24043,9 @@ snapshots:
       - langchain
       - openai
 
-  '@langchain/openai@0.0.34(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))':
+  '@langchain/openai@0.0.34(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))':
     dependencies:
-      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)
+      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)
       js-tiktoken: 1.0.12
       openai: 4.52.0
       zod: 3.23.8
@@ -23981,6 +24117,22 @@ snapshots:
       type-fest: 2.19.0
 
   '@lukeed/ms@2.0.2': {}
+
+  '@manypkg/find-root@1.1.0':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+
+  '@manypkg/get-packages@1.1.3':
+    dependencies:
+      '@babel/runtime': 7.24.7
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
 
   '@microsoft/applicationinsights-web-snippet@1.0.1': {}
 
@@ -26846,6 +26998,8 @@ snapshots:
       '@types/node': 20.14.8
       form-data: 4.0.0
 
+  '@types/node@12.20.55': {}
+
   '@types/node@16.18.101': {}
 
   '@types/node@18.11.18': {}
@@ -27689,6 +27843,8 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  ansi-colors@4.1.3: {}
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -27767,6 +27923,10 @@ snapshots:
   arg@4.1.3: {}
 
   arg@5.0.2: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -28046,6 +28206,10 @@ snapshots:
   before-after-hook@2.2.3: {}
 
   before-after-hook@3.0.2: {}
+
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
 
   bidi-js@1.0.3:
     dependencies:
@@ -28344,6 +28508,8 @@ snapshots:
       - encoding
 
   chrome-trace-event@1.0.4: {}
+
+  ci-info@3.9.0: {}
 
   cjs-module-lexer@1.3.1: {}
 
@@ -28737,6 +28903,12 @@ snapshots:
     dependencies:
       '@types/luxon': 3.4.2
       luxon: 3.4.4
+
+  cross-spawn@5.1.0:
+    dependencies:
+      lru-cache: 4.1.5
+      shebang-command: 1.2.0
+      which: 1.3.1
 
   cross-spawn@6.0.5:
     dependencies:
@@ -29341,6 +29513,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
 
   entities@2.1.0: {}
 
@@ -30024,6 +30201,8 @@ snapshots:
 
   extend@3.0.2: {}
 
+  extendable-error@0.1.7: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -30217,6 +30396,11 @@ snapshots:
       semver-regex: 4.0.5
       super-regex: 1.0.0
 
+  find-yarn-workspace-root2@1.2.16:
+    dependencies:
+      micromatch: 4.0.7
+      pkg-dir: 4.2.0
+
   findup-sync@4.0.0:
     dependencies:
       detect-file: 1.0.0
@@ -30336,6 +30520,18 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.1
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
 
   fs-extra@9.1.0:
     dependencies:
@@ -30786,6 +30982,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-id@1.0.2: {}
+
   human-signals@5.0.0: {}
 
   human-signals@7.0.0: {}
@@ -31161,6 +31359,10 @@ snapshots:
     dependencies:
       has-tostringtag: 1.0.2
 
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
   is-symbol@1.0.4:
     dependencies:
       has-symbols: 1.0.3
@@ -31313,6 +31515,11 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.0: {}
+
+  js-yaml@3.14.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.0:
     dependencies:
@@ -31486,6 +31693,10 @@ snapshots:
 
   jsonc-parser@3.2.1: {}
 
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
   jsonfile@6.1.0:
     dependencies:
       universalify: 2.0.1
@@ -31570,12 +31781,12 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0):
+  langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0):
     dependencies:
       '@anthropic-ai/sdk': 0.9.1
-      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(chromadb@1.7.2(openai@4.23.0))(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
-      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
-      '@langchain/openai': 0.0.34(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))
+      '@langchain/community': 0.0.57(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(chromadb@1.7.2(openai@4.23.0))(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
+      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
+      '@langchain/openai': 0.0.34(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))
       binary-extensions: 2.3.0
       expr-eval: 2.0.2
       js-tiktoken: 1.0.12
@@ -31681,7 +31892,7 @@ snapshots:
       p-retry: 4.6.2
       uuid: 9.0.1
 
-  langsmith@0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0):
+  langsmith@0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0):
     dependencies:
       '@types/uuid': 9.0.8
       commander: 10.0.1
@@ -31689,11 +31900,11 @@ snapshots:
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
-      langchain: 0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
+      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.23.0)
+      langchain: 0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
       openai: 4.23.0
 
-  langsmith@0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0):
+  langsmith@0.1.32(@langchain/core@0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0))(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0):
     dependencies:
       '@types/uuid': 9.0.8
       commander: 10.0.1
@@ -31701,8 +31912,8 @@ snapshots:
       p-retry: 4.6.2
       uuid: 9.0.1
     optionalDependencies:
-      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)
-      langchain: 0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
+      '@langchain/core': 0.1.63(langchain@0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0))(openai@4.52.0)
+      langchain: 0.0.209(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-s3@3.600.0)(@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0))(@aws-sdk/client-sts@3.600.0))(@smithy/util-utf8@2.3.0)(axios@1.7.2)(cheerio@1.0.0-rc.12)(chromadb@1.7.2(openai@4.23.0))(ignore@5.3.1)(ioredis@5.4.1)(jsdom@23.2.0)(jsonwebtoken@9.0.2)(lodash@4.17.21)(openai@4.23.0)(pg@8.12.0)(replicate@0.25.2)(ws@8.18.0)
       openai: 4.52.0
 
   language-subtag-registry@0.3.23: {}
@@ -31777,6 +31988,13 @@ snapshots:
       graceful-fs: 4.2.11
       parse-json: 4.0.0
       pify: 3.0.0
+      strip-bom: 3.0.0
+
+  load-yaml-file@0.2.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.14.1
+      pify: 4.0.1
       strip-bom: 3.0.0
 
   loader-runner@4.3.0: {}
@@ -31939,6 +32157,11 @@ snapshots:
   lru-cache@10.2.0: {}
 
   lru-cache@10.2.2: {}
+
+  lru-cache@4.1.5:
+    dependencies:
+      pseudomap: 1.0.2
+      yallist: 2.1.2
 
   lru-cache@5.1.1:
     dependencies:
@@ -33326,7 +33549,13 @@ snapshots:
 
   os-tmpdir@1.0.2: {}
 
+  outdent@0.5.0: {}
+
   p-each-series@3.0.0: {}
+
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
 
   p-filter@4.1.0:
     dependencies:
@@ -33379,6 +33608,8 @@ snapshots:
       p-limit: 4.0.0
 
   p-map@1.2.0: {}
+
+  p-map@2.1.0: {}
 
   p-map@7.0.2: {}
 
@@ -33802,6 +34033,13 @@ snapshots:
       tar-fs: 2.1.1
       tunnel-agent: 0.6.0
 
+  preferred-pm@3.1.4:
+    dependencies:
+      find-up: 5.0.0
+      find-yarn-workspace-root2: 1.2.16
+      path-exists: 4.0.0
+      which-pm: 2.2.0
+
   prelude-ls@1.2.1: {}
 
   pretender@3.4.7:
@@ -34015,6 +34253,8 @@ snapshots:
       ipaddr.js: 1.9.1
 
   proxy-from-env@1.1.0: {}
+
+  pseudomap@1.0.2: {}
 
   psl@1.9.0: {}
 
@@ -34498,6 +34738,13 @@ snapshots:
       parse-json: 8.1.0
       type-fest: 4.20.1
       unicorn-magic: 0.1.0
+
+  read-yaml-file@1.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.14.1
+      pify: 4.0.1
+      strip-bom: 3.0.0
 
   read@1.0.7:
     dependencies:
@@ -35487,6 +35734,11 @@ snapshots:
 
   spawn-error-forwarder@1.0.0: {}
 
+  spawndamnit@2.0.0:
+    dependencies:
+      cross-spawn: 5.1.0
+      signal-exit: 3.0.7
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -35510,6 +35762,8 @@ snapshots:
       through2: 2.0.5
 
   split2@4.2.0: {}
+
+  sprintf-js@1.0.3: {}
 
   sswr@2.0.0(svelte@4.2.18):
     dependencies:
@@ -35963,6 +36217,8 @@ snapshots:
       temp-dir: 3.0.0
       type-fest: 2.19.0
       unique-string: 3.0.0
+
+  term-size@2.2.1: {}
 
   terminal-link@3.0.0:
     dependencies:
@@ -36616,6 +36872,8 @@ snapshots:
   universal-user-agent@6.0.1: {}
 
   universal-user-agent@7.0.2: {}
+
+  universalify@0.1.2: {}
 
   universalify@0.2.0: {}
 
@@ -37587,6 +37845,11 @@ snapshots:
       is-weakmap: 2.0.2
       is-weakset: 2.0.3
 
+  which-pm@2.2.0:
+    dependencies:
+      load-yaml-file: 0.2.0
+      path-exists: 4.0.0
+
   which-typed-array@1.1.15:
     dependencies:
       available-typed-arrays: 1.0.7
@@ -37700,6 +37963,8 @@ snapshots:
   xtend@4.0.2: {}
 
   y18n@5.0.8: {}
+
+  yallist@2.1.2: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
This PR adds and configures [changesets](https://github.com/changesets/) to manage the versioning and release process for npm packages.

For packages that don't need to be published to the registry, I added `"private": true` to have changesets ignore them.

#### 🔗 Linked Issue
n/a

#### 🧪 Test Plan
I've tested this approach in a few other repos. If it doesn't work on the first try, I'll need to make follow up commits and PRs (typical github action testing workflow!)

#### 📄 Documentation to Update
n/a