### PR TITLE
fix(cli): fix relative path codemod build from source

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "imports": {
     "#*": "./src/*"
   },
-  "version": "0.13.9",
+  "version": "0.13.10",
   "description": "A codemod engine for Node.js libraries (jscodeshift, ts-morph, etc.)",
   "type": "module",
   "exports": null,

--- a/packages/runner/src/source-code.ts
+++ b/packages/runner/src/source-code.ts
@@ -47,10 +47,7 @@ export const getTransformer = (source: string) => {
 
 export const BUILT_SOURCE_PATH = "cdmd_dist/index.cjs";
 
-export const bundleJS = async (options: {
-  entry: string;
-  output?: string;
-}) => {
+export const bundleJS = async (options: { entry: string; output?: string }) => {
   const { entry, output = join(dirname(entry), BUILT_SOURCE_PATH) } = options;
   const EXTERNAL_DEPENDENCIES = ["jscodeshift", "ts-morph", "@ast-grep/napi"];
 
@@ -71,7 +68,9 @@ export const bundleJS = async (options: {
   const { outputFiles } = await esbuild.build(buildOptions);
 
   const sourceCode =
-    outputFiles?.find((file) => file.path.endsWith(output))?.text ?? null;
+    outputFiles?.find((file) =>
+      file.path.endsWith(output.replace(/\.\.\//g, "").replace(/\.\//g, "")),
+    )?.text ?? null;
 
   if (sourceCode === null) {
     throw new Error(`Could not find ${output} in output files`);


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
fix issue with building from source code if relative path is used
