### PR TITLE
feat(codemod): codemods and recipe for migrating Sentry.js from v7.x to v8.x

### DIFF
--- a/packages/codemods/sentry/v8/migration-recipe/.codemodrc.json
+++ b/packages/codemods/sentry/v8/migration-recipe/.codemodrc.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "sentry/v8/migration-recipe",
+  "version": "1.0.0",
+  "private": false,
+  "engine": "recipe",
+  "names": [
+    "sentry/v8/removal-Severity-Enum",
+    "sentry/v8/remove-replay-package-and-update-integration",
+    "sentry/v8/removal-of-addGlobalEventProcessor",
+    "sentry/v8/Removal-Sentry.configureScope-method",
+    "sentry/v8/replace-span-status-from-http-code",
+    "sentry/v8/removal-of-void-from-transport-return-types"
+  ],
+  "meta": {
+    "tags": ["sentry", "migration", "codemod"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/sentry/v8/migration-recipe"
+  },
+  "applicability": {
+    "from": [["sentry", "<=", "7"]],
+    "to": [["sentry", ">=", "8"]]
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx"]
+}

--- a/packages/codemods/sentry/v8/migration-recipe/README.md
+++ b/packages/codemods/sentry/v8/migration-recipe/README.md
@@ -1,0 +1,10 @@
+This recipe is a set of codemods that will help migrate sentry.js v7.x to v8.x.  
+
+The recipe includes the following codemods:
+
+- sentry/v8/removal-Severity-Enum
+- sentry/v8/remove-replay-package-and-update-integration
+- sentry/v8/removal-of-addGlobalEventProcessor
+- sentry/v8/Removal-Sentry.configureScope-method
+- sentry/v8/replace-span-status-from-http-code
+- sentry/v8/removal-of-void-from-transport-return-types

--- a/packages/codemods/sentry/v8/migration-recipe/package.json
+++ b/packages/codemods/sentry/v8/migration-recipe/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@codemod/sentry-v8-migration-recipe",
+  "files": ["./README.md", "./.codemodrc.json"],
+  "type": "module",
+  "private": true
+}

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/.codemodrc.json
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/.codemodrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "sentry/v8/Removal-Sentry.configureScope-method",
+  "description": "Codemod to replace deprecated Sentry.configureScope with Sentry.getCurrentScope for accessing and mutating the current scope in migration from Sentry 7.x to 8.x.",
+  "version": "1.0.2",
+  "engine": "jscodeshift",
+  "private": false,
+  "applicability": {
+    "from": [["sentry", "<=", "7"]],
+    "to": [["sentry", ">=", "8"]]
+  },
+  "arguments": [],
+  "meta": {
+    "tags": ["sentry", "migration", "codemod"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/sentry/v8/removal-Sentry-configureScope-method"
+  }
+}

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/LICENSE
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/README.md
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/README.md
@@ -1,0 +1,76 @@
+This codemod facilitates the migration from Sentry version 7.x to 8.x by removing the deprecated Sentry.configureScope method. Instead, it transforms the code to utilize Sentry.getCurrentScope() for accessing and mutating the current scope. This change simplifies the API and aligns with the latest Sentry practices.
+
+## Example
+
+### Before
+
+```ts
+Sentry.configureScope((scope) => {
+  scope.setTag('key', 'value');
+});
+```
+
+### After
+
+```ts
+Sentry.getCurrentScope().setTag('key', 'value');
+```
+,
+### Before
+
+```ts
+Sentry.configureScope((scope) => {
+  scope.setTag('user', '123');
+});
+```
+
+### After
+
+```ts
+Sentry.getCurrentScope().setTag('user', '123');
+```
+,
+### Before
+
+```ts
+Sentry.configureScope((scope) => {
+  scope.setUser({ id: '456', email: 'user@example.com' });
+});
+```
+
+### After
+
+```ts
+Sentry.getCurrentScope().setUser({ id: '456', email: 'user@example.com' });
+```
+,
+### Before
+
+```ts
+Sentry.configureScope((scope) => {
+  scope.setExtra('key', 'value');
+});
+```
+
+### After
+
+```ts
+Sentry.getCurrentScope().setExtra('key', 'value');
+```
+,
+### Before
+
+```ts
+Sentry.configureScope((scope) => {
+  scope.setTag('level', 'info');
+  scope.setTag('action', 'click');
+});
+```
+
+### After
+
+```ts
+Sentry.getCurrentScope().setTag('action', 'click');
+Sentry.getCurrentScope().setTag('level', 'info');
+```
+

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,3 @@
+Sentry.configureScope((scope) => {
+  scope.setTag('key', 'value');
+});

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,1 @@
+Sentry.getCurrentScope().setTag('key', 'value');

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,3 @@
+Sentry.configureScope((scope) => {
+  scope.setTag('user', '123');
+});

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,1 @@
+Sentry.getCurrentScope().setTag('user', '123');

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture3.input.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture3.input.ts
@@ -1,0 +1,3 @@
+Sentry.configureScope((scope) => {
+  scope.setUser({ id: '456', email: 'user@example.com' });
+});

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture3.output.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture3.output.ts
@@ -1,0 +1,1 @@
+Sentry.getCurrentScope().setUser({ id: '456', email: 'user@example.com' });

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture4.input.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture4.input.ts
@@ -1,0 +1,3 @@
+Sentry.configureScope((scope) => {
+  scope.setExtra('key', 'value');
+});

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture4.output.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture4.output.ts
@@ -1,0 +1,1 @@
+Sentry.getCurrentScope().setExtra('key', 'value');

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture5.input.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture5.input.ts
@@ -1,0 +1,4 @@
+Sentry.configureScope((scope) => {
+  scope.setTag('level', 'info');
+  scope.setTag('action', 'click');
+});

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture5.output.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/__testfixtures__/fixture5.output.ts
@@ -1,0 +1,2 @@
+Sentry.getCurrentScope().setTag('action', 'click');
+Sentry.getCurrentScope().setTag('level', 'info');

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/cdmd_dist/index.cjs
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;root.find(j.CallExpression,{callee:{type:"MemberExpression",object:{name:"Sentry"},property:{name:"configureScope"}}}).forEach(path=>{const callback=path.node.arguments[0];if(j.FunctionExpression.check(callback)||j.ArrowFunctionExpression.check(callback)){const scopeParam=callback.params[0];if(scopeParam&&j.Identifier.check(scopeParam)){const scopeName=scopeParam.name;const methodCalls=[];j(callback.body).find(j.CallExpression,{callee:{type:"MemberExpression",object:{name:scopeName}}}).forEach(callPath=>{const method=callPath.node.callee.property;const args=callPath.node.arguments;methodCalls.push(j.expressionStatement(j.callExpression(j.memberExpression(j.callExpression(j.memberExpression(j.identifier("Sentry"),j.identifier("getCurrentScope")),[]),method),args)));dirtyFlag=true});if(methodCalls.length>0){const parent=path.parentPath;methodCalls.forEach(call=>{j(parent).insertAfter(call)});j(path).remove()}}}});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/package.json
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "Removal-Sentry.configureScope-method",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "akash-kumar-dev"
+}

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/src/index.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/src/index.ts
@@ -1,0 +1,93 @@
+import { API, FileInfo, JSCodeshift } from 'jscodeshift';
+import {
+  Collection,
+  ASTPath,
+  CallExpression,
+  FunctionExpression,
+  ArrowFunctionExpression,
+  Identifier,
+  MemberExpression,
+} from 'jscodeshift/src/core';
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+): string | undefined {
+  const j: JSCodeshift = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Find all instances of Sentry.configureScope
+  root.find(j.CallExpression, {
+    callee: {
+      type: 'MemberExpression',
+      object: { name: 'Sentry' },
+      property: { name: 'configureScope' },
+    },
+  }).forEach((path: ASTPath < CallExpression > ) => {
+    const callback = path.node.arguments[0];
+
+    // Ensure the argument is a function expression
+    if (
+      j.FunctionExpression.check(callback) ||
+      j.ArrowFunctionExpression.check(callback)
+    ) {
+      const scopeParam = (
+        callback as FunctionExpression | ArrowFunctionExpression
+      ).params[0];
+
+      // Ensure the function has a parameter
+      if (scopeParam && j.Identifier.check(scopeParam)) {
+        const scopeName = (scopeParam as Identifier).name;
+
+        // Collect all method calls on the scope parameter
+        const methodCalls: Collection < CallExpression > = [];
+        j(callback.body)
+          .find(j.CallExpression, {
+            callee: {
+              type: 'MemberExpression',
+              object: { name: scopeName },
+            },
+          })
+          .forEach((callPath: ASTPath < CallExpression > ) => {
+            const method = callPath.node.callee
+              .property as Identifier;
+            const args = callPath.node.arguments;
+
+            // Create new call expression Sentry.getCurrentScope().method(args)
+            methodCalls.push(
+              j.expressionStatement(
+                j.callExpression(
+                  j.memberExpression(
+                    j.callExpression(
+                      j.memberExpression(
+                        j.identifier('Sentry'),
+                        j.identifier('getCurrentScope'),
+                      ),
+                      [],
+                    ),
+                    method,
+                  ),
+                  args,
+                ),
+              ),
+            );
+            dirtyFlag = true;
+          });
+
+        // Replace the original Sentry.configureScope call with the new method calls
+        if (methodCalls.length > 0) {
+          // Insert the new method calls after the current path
+          const parent = path.parentPath as ASTPath < any > ;
+          methodCalls.forEach((call) => {
+            j(parent).insertAfter(call);
+          });
+          // Remove the original Sentry.configureScope call
+          j(path).remove();
+        }
+      }
+    }
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/test/test.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/test/test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('sentry/configure-scope-to-get-current-scope', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #4', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #5', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/tsconfig.json
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/vitest.config.ts
+++ b/packages/codemods/sentry/v8/removal-Sentry-configureScope-method/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/.codemodrc.json
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/.codemodrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "sentry/v8/removal-Severity-Enum",
+  "description": "Codemod to replace the deprecated Severity enum with the SeverityLevel type in Sentry from version 7.x to 8.x.",
+  "version": "1.0.4",
+  "engine": "jscodeshift",
+  "private": false,
+  "applicability": {
+    "from": [["sentry", "<=", "7"]],
+    "to": [["sentry", ">=", "8"]]
+  },
+  "arguments": [],
+  "meta": {
+    "tags": ["sentry", "migration", "codemod"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/sentry/v8/removal-Severity-Enum"
+  }
+}

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/LICENSE
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/README.md
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/README.md
@@ -1,0 +1,70 @@
+Codemod to replace the deprecated Severity enum with the SeverityLevel type in Sentry from version 7.x to 8.x.
+
+## Example
+
+### Before
+
+```ts
+import { Severity } from '@sentry/types';
+```
+
+### After
+
+```ts
+import { SeverityLevel } from '@sentry/types';
+```
+,
+### Before
+
+```ts
+const level = Severity.error;
+```
+
+### After
+
+```ts
+const level: SeverityLevel = 'error';
+```
+,
+### Before
+
+```ts
+const warningLevel = Severity.warning;
+const infoLevel = Severity.info;
+```
+
+### After
+
+```ts
+const warningLevel: SeverityLevel = 'warning';
+const infoLevel: SeverityLevel = 'info';
+```
+,
+### Before
+
+```ts
+let currentLevel = Severity.fatal;
+```
+
+### After
+
+```ts
+let currentLevel: SeverityLevel = 'fatal';
+```
+,
+### Before
+
+```ts
+function getSeverity() {
+  return Severity.debug;
+}
+```
+
+### After
+
+```ts
+function getSeverity(): SeverityLevel {
+  return 'debug';
+}
+```
+

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,1 @@
+import { Severity } from '@sentry/types';

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,1 @@
+import { SeverityLevel } from '@sentry/types';

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,1 @@
+const level = Severity.error;

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,1 @@
+const level: SeverityLevel = "error";

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture3.input.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture3.input.ts
@@ -1,0 +1,2 @@
+const warningLevel = Severity.warning;
+const infoLevel = Severity.info;

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture3.output.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture3.output.ts
@@ -1,0 +1,2 @@
+const warningLevel: SeverityLevel = "warning";
+const infoLevel: SeverityLevel = "info";

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture4.input.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture4.input.ts
@@ -1,0 +1,1 @@
+let currentLevel = Severity.fatal;

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture4.output.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture4.output.ts
@@ -1,0 +1,1 @@
+let currentLevel: SeverityLevel = "fatal";

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture5.input.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture5.input.ts
@@ -1,0 +1,3 @@
+function getSeverity() {
+  return Severity.debug;
+}

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture5.output.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/__testfixtures__/fixture5.output.ts
@@ -1,0 +1,3 @@
+function getSeverity(): SeverityLevel {
+  return "debug";
+}

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/cdmd_dist/index.cjs
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;root.find(j.ImportDeclaration).forEach(path=>{if(j.Literal.check(path.node.source)&&path.node.source.value==="@sentry/types"){path.node.specifiers.forEach(specifier=>{if(j.ImportSpecifier.check(specifier)&&specifier.imported.name==="Severity"){specifier.imported.name="SeverityLevel";dirtyFlag=true}})}});root.find(j.MemberExpression).forEach(path=>{if(j.Identifier.check(path.node.object)&&path.node.object.name==="Severity"){const severityLevel=path.node.property.name;const parent=path.parent.node;if(j.VariableDeclarator.check(parent)){parent.init=j.literal(severityLevel);parent.id.typeAnnotation=j.typeAnnotation(j.genericTypeAnnotation(j.identifier("SeverityLevel"),null));dirtyFlag=true}else if(j.AssignmentExpression.check(parent)){parent.right=j.literal(severityLevel);const closestScope=j(path).closestScope();closestScope.find(j.VariableDeclarator,{id:{name:parent.left.name}}).forEach(varPath=>{varPath.node.id.typeAnnotation=j.typeAnnotation(j.genericTypeAnnotation(j.identifier("SeverityLevel"),null))});dirtyFlag=true}else if(j.ReturnStatement.check(parent)){path.replace(j.literal(severityLevel));const closestFunction=j(path).closest(j.FunctionDeclaration);if(closestFunction.size()>0){closestFunction.get().node.returnType=j.typeAnnotation(j.genericTypeAnnotation(j.identifier("SeverityLevel"),null))}dirtyFlag=true}}});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/package.json
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "removal-Severity-Enum",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "akash-kumar-dev"
+}

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/src/index.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/src/index.ts
@@ -1,0 +1,111 @@
+import type {
+  API,
+  ASTNode,
+  ASTPath,
+  Block,
+  CommentBlock,
+  CommentLine,
+  FileInfo,
+  Line,
+  Node,
+  Options,
+} from 'jscodeshift';
+
+type CommentKind = Block | Line | CommentBlock | CommentLine;
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+  options?: Options,
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Helper function to preserve comments when replacing nodes
+  function replaceWithComments(
+      path: ASTPath<ASTNode & { comments?: CommentKind[] | null }>,
+      newNode: Node,
+  ) {
+      // If the original node had comments, add them to the new node
+      if (path.node.comments) {
+          newNode.comments = path.node.comments;
+      }
+
+      // Replace the node
+      j(path).replaceWith(newNode);
+  }
+
+  // Replace import { Severity } with import { SeverityLevel }
+  root.find(j.ImportDeclaration).forEach((path) => {
+      if (
+          j.Literal.check(path.node.source) &&
+          path.node.source.value === '@sentry/types'
+      ) {
+          path.node.specifiers.forEach((specifier) => {
+              if (
+                  j.ImportSpecifier.check(specifier) &&
+                  specifier.imported.name === 'Severity'
+              ) {
+                  specifier.imported.name = 'SeverityLevel';
+                  dirtyFlag = true;
+              }
+          });
+      }
+  });
+
+  // Replace Severity.<level> with '<level>' and add type annotation : SeverityLevel
+  root.find(j.MemberExpression).forEach((path) => {
+      if (
+          j.Identifier.check(path.node.object) &&
+          path.node.object.name === 'Severity'
+      ) {
+          const severityLevel = path.node.property.name;
+          const parent = path.parent.node;
+
+          if (j.VariableDeclarator.check(parent)) {
+              const newLiteral = j.literal(severityLevel);
+              replaceWithComments(path, newLiteral);
+              parent.id.typeAnnotation = j.typeAnnotation(
+                  j.genericTypeAnnotation(
+                      j.identifier('SeverityLevel'),
+                      null,
+                  ),
+              );
+              dirtyFlag = true;
+          } else if (j.AssignmentExpression.check(parent)) {
+              const newLiteral = j.literal(severityLevel);
+              replaceWithComments(path, newLiteral);
+              const closestScope = j(path).closestScope();
+              closestScope
+                  .find(j.VariableDeclarator, {
+                      id: { name: parent.left.name },
+                  })
+                  .forEach((varPath) => {
+                      varPath.node.id.typeAnnotation = j.typeAnnotation(
+                          j.genericTypeAnnotation(
+                              j.identifier('SeverityLevel'),
+                              null,
+                          ),
+                      );
+                  });
+              dirtyFlag = true;
+          } else if (j.ReturnStatement.check(parent)) {
+              const newLiteral = j.literal(severityLevel);
+              replaceWithComments(path, newLiteral);
+              const closestFunction = j(path).closest(j.FunctionDeclaration);
+              if (closestFunction.size() > 0) {
+                  closestFunction.get().node.returnType = j.typeAnnotation(
+                      j.genericTypeAnnotation(
+                          j.identifier('SeverityLevel'),
+                          null,
+                      ),
+                  );
+              }
+              dirtyFlag = true;
+          }
+      }
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/test/test.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/test/test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('sentry/types/severity-to-severity-level', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #4', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #5', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/tsconfig.json
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/sentry/v8/removal-Severity-Enum/vitest.config.ts
+++ b/packages/codemods/sentry/v8/removal-Severity-Enum/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/.codemodrc.json
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/.codemodrc.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "sentry/v8/removal-of-addGlobalEventProcessor",
+  "description": "Codemod to replace deprecated Sentry.addGlobalEventProcessor with Sentry.getGlobalScope().addEventProcessor in migration from version 7.x to 8.x.",
+  "version": "1.0.1",
+  "engine": "jscodeshift",
+  "private": false,
+  "applicability": {
+    "from": [
+      [
+        "sentry",
+        "<=",
+        "7"
+      ]
+    ],
+    "to": [
+      [
+        "sentry",
+        ">=",
+        "8"
+      ]
+    ]
+  },
+  "arguments": [],
+  "meta": {
+    "tags": [
+      "sentry",
+      "migration",
+      "codemod"
+    ],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor"
+  }
+}

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/.gitignore
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/LICENSE
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/README.md
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/README.md
@@ -1,0 +1,94 @@
+This codemod facilitates the migration from Sentry v7.x to v8.x by replacing the deprecated `addGlobalEventProcessor` function with the new `getGlobalScope().addEventProcessor` method. 
+
+## Example
+
+### Before
+
+```ts
+Sentry.addGlobalEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});
+```
+
+### After
+
+```ts
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});
+```
+,
+### Before
+
+```ts
+Sentry.addGlobalEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});
+
+Sentry.addGlobalEventProcessor((event) => {
+  delete event.tags;
+  return event;
+});
+```
+
+### After
+
+```ts
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});
+
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  delete event.tags;
+  return event;
+});
+```
+,
+### Before
+
+```ts
+function processEvent(event) {
+  delete event.extra;
+  return event;
+}
+
+Sentry.addGlobalEventProcessor(processEvent);
+```
+
+### After
+
+```ts
+function processEvent(event) {
+  delete event.extra;
+  return event;
+}
+
+Sentry.getGlobalScope().addEventProcessor(processEvent);
+```
+,
+### Before
+
+```ts
+Sentry.addGlobalEventProcessor((event) => {
+  if (event.level === 'error') {
+    delete event.extra;
+  }
+  return event;
+});
+```
+
+### After
+
+```ts
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  if (event.level === 'error') {
+    delete event.extra;
+  }
+  return event;
+});
+```
+

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,4 @@
+Sentry.addGlobalEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,4 @@
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,9 @@
+Sentry.addGlobalEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});
+
+Sentry.addGlobalEventProcessor((event) => {
+  delete event.tags;
+  return event;
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,9 @@
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  delete event.extra;
+  return event;
+});
+
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  delete event.tags;
+  return event;
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture3.input.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture3.input.ts
@@ -1,0 +1,6 @@
+function processEvent(event) {
+  delete event.extra;
+  return event;
+}
+
+Sentry.addGlobalEventProcessor(processEvent);

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture3.output.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture3.output.ts
@@ -1,0 +1,6 @@
+function processEvent(event) {
+  delete event.extra;
+  return event;
+}
+
+Sentry.getGlobalScope().addEventProcessor(processEvent);

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture4.input.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture4.input.ts
@@ -1,0 +1,6 @@
+Sentry.addGlobalEventProcessor((event) => {
+  if (event.level === 'error') {
+    delete event.extra;
+  }
+  return event;
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture4.output.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/__testfixtures__/fixture4.output.ts
@@ -1,0 +1,6 @@
+Sentry.getGlobalScope().addEventProcessor((event) => {
+  if (event.level === 'error') {
+    delete event.extra;
+  }
+  return event;
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/cdmd_dist/index.cjs
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict"; Object.defineProperty(exports, "__esModule", { value: true }); Object.defineProperty(exports, "default", { enumerable: true, get: function () { return transform } }); function transform(file, api, options) { const j = api.jscodeshift; const root = j(file.source); let dirtyFlag = false; function replaceWithComments(path, newNode) { if (path.node.comments) { newNode.comments = path.node.comments } j(path).replaceWith(newNode) } root.find(j.CallExpression, { callee: { type: "MemberExpression", object: { name: "Sentry" }, property: { name: "addGlobalEventProcessor" } } }).forEach(path => { if (j.MemberExpression.check(path.value.callee)) { const newCallee = j.memberExpression(j.callExpression(j.memberExpression(j.identifier("Sentry"), j.identifier("getGlobalScope")), []), j.identifier("addEventProcessor")); replaceWithComments(path, j.callExpression(newCallee, path.node.arguments)); dirtyFlag = true } }); return dirtyFlag ? root.toSource() : undefined }

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/package.json
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "removal-of-addGlobalEventProcessor",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "akash-kumar-dev"
+}

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/src/index.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/src/index.ts
@@ -1,0 +1,70 @@
+import type {
+  API,
+  ASTNode,
+  ASTPath,
+  Block,
+  CommentBlock,
+  CommentLine,
+  FileInfo,
+  Line,
+  Node,
+  Options,
+} from 'jscodeshift';
+
+type CommentKind = Block | Line | CommentBlock | CommentLine;
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+  options ? : Options,
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Helper function to preserve comments when replacing nodes
+  function replaceWithComments(
+    path: ASTPath < ASTNode & { comments ? : CommentKind[] | null } > ,
+    newNode: Node,
+  ) {
+    // If the original node had comments, add them to the new node
+    if (path.node.comments) {
+      newNode.comments = path.node.comments;
+    }
+
+    // Replace the node
+    j(path).replaceWith(newNode);
+  }
+
+  // Find all calls to `Sentry.addGlobalEventProcessor`
+  root.find(j.CallExpression, {
+    callee: {
+      type: 'MemberExpression',
+      object: { name: 'Sentry' },
+      property: { name: 'addGlobalEventProcessor' },
+    },
+  }).forEach((path) => {
+    if (j.MemberExpression.check(path.value.callee)) {
+      // Replace `Sentry.addGlobalEventProcessor` with `Sentry.getGlobalScope().addEventProcessor`
+      const newCallee = j.memberExpression(
+        j.callExpression(
+          j.memberExpression(
+            j.identifier('Sentry'),
+            j.identifier('getGlobalScope'),
+          ),
+          [],
+        ),
+        j.identifier('addEventProcessor'),
+      );
+
+      // Use the helper function to replace the node while preserving comments
+      replaceWithComments(
+        path,
+        j.callExpression(newCallee, path.node.arguments),
+      );
+      dirtyFlag = true;
+    }
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/test/test.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/test/test.ts
@@ -1,0 +1,91 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('sentry/v1/replace-add-global-event-processor', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #4', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/tsconfig.json
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/vitest.config.ts
+++ b/packages/codemods/sentry/v8/removal-of-addGlobalEventProcessor/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/.codemodrc.json
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/.codemodrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "sentry/v8/removal-of-void-from-transport-return-types",
+  "description": "Codemod to remove void from Transport.send return types and ensure it returns TransportMakeRequestResponse in Sentry SDK.",
+  "version": "1.0.0",
+  "engine": "jscodeshift",
+  "private": false,
+  "applicability": {
+    "from": [["sentry", "<=", "7"]],
+    "to": [["sentry", ">=", "8"]]
+  },
+  "arguments": [],
+  "meta": {
+    "tags": ["sentry", "migration","codemod"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types"
+  }
+}

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/.gitignore
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/LICENSE
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/README.md
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/README.md
@@ -1,0 +1,34 @@
+This codemod removes the `void` return type from the `send` method of the `Transport` interface, ensuring that the method always returns a `TransportMakeRequestResponse` in the promise. This change aligns with the updated requirements in Sentry 8.x.
+
+## Example
+
+### Before
+
+```ts
+interface Transport {
+  send(event: Event): Promise < void | TransportMakeRequestResponse > ;
+}
+```
+
+### After
+
+```ts
+interface Transport {
+  send(event: Event): Promise < TransportMakeRequestResponse > ;
+}
+```
+,
+### Before
+
+```ts
+type TransportSend = (
+  event: Event,
+) => Promise < void | TransportMakeRequestResponse > ;
+```
+
+### After
+
+```ts
+type TransportSend = (event: Event) => Promise < TransportMakeRequestResponse > ;
+```
+

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,3 @@
+interface Transport {
+  send(event: Event): Promise < void | TransportMakeRequestResponse > ;
+}

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,3 @@
+interface Transport {
+  send(event: Event): Promise <TransportMakeRequestResponse> ;
+}

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,1 @@
+type TransportSend = (event: Event) => Promise<void | TransportMakeRequestResponse>;

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,1 @@
+type TransportSend = (event: Event) => Promise<TransportMakeRequestResponse>;

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/cdmd_dist/index.cjs
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api,options){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;function replaceWithComments(path,newNode){if(path.node.comments){newNode.comments=path.node.comments}j(path).replaceWith(newNode)}function transformPromiseType(node){if(j.TSTypeReference.check(node)&&j.Identifier.check(node.typeName)&&node.typeName.name==="Promise"){const typeParams=node.typeParameters;if(typeParams&&typeParams.params.length===1){const unionType=typeParams.params[0];if(j.TSUnionType.check(unionType)){const filteredTypes=unionType.types.filter(type=>!j.TSVoidKeyword.check(type));if(filteredTypes.length===1){typeParams.params[0]=filteredTypes[0];dirtyFlag=true}}}}}root.find(j.TSMethodSignature).forEach(path=>{const returnType=path.node.typeAnnotation?.typeAnnotation;if(returnType){transformPromiseType(returnType)}});root.find(j.TSTypeAliasDeclaration).forEach(path=>{const typeAnnotation=path.node.typeAnnotation;if(j.TSFunctionType.check(typeAnnotation)){const returnType=typeAnnotation.typeAnnotation?.typeAnnotation;if(returnType){transformPromiseType(returnType)}}});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/package.json
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "removal-of-void-from-transport-return-types",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "akash-kumar-dev"
+}

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/src/index.ts
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/src/index.ts
@@ -1,0 +1,82 @@
+import type {
+  API,
+  ASTNode,
+  ASTPath,
+  Block,
+  CommentBlock,
+  CommentLine,
+  FileInfo,
+  Line,
+  Node,
+  Options,
+} from 'jscodeshift';
+
+type CommentKind = Block | Line | CommentBlock | CommentLine;
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+  options ? : Options,
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Helper function to preserve comments when replacing nodes
+  function replaceWithComments(
+    path: ASTPath < ASTNode & { comments ? : CommentKind[] | null } > ,
+    newNode: Node,
+  ) {
+    // If the original node had comments, add them to the new node
+    if (path.node.comments) {
+      newNode.comments = path.node.comments;
+    }
+
+    // Replace the node
+    j(path).replaceWith(newNode);
+  }
+
+  // Function to transform Promise<void | TransportMakeRequestResponse> to Promise<TransportMakeRequestResponse>
+  function transformPromiseType(node: ASTNode) {
+    if (
+      j.TSTypeReference.check(node) &&
+      j.Identifier.check(node.typeName) &&
+      node.typeName.name === 'Promise'
+    ) {
+      const typeParams = node.typeParameters;
+      if (typeParams && typeParams.params.length === 1) {
+        const unionType = typeParams.params[0];
+        if (j.TSUnionType.check(unionType)) {
+          const filteredTypes = unionType.types.filter(
+            (type) => !j.TSVoidKeyword.check(type),
+          );
+          if (filteredTypes.length === 1) {
+            typeParams.params[0] = filteredTypes[0];
+            dirtyFlag = true;
+          }
+        }
+      }
+    }
+  }
+
+  // Transform interface method return types
+  root.find(j.TSMethodSignature).forEach((path: ASTPath < ASTNode > ) => {
+    const returnType = path.node.typeAnnotation?.typeAnnotation;
+    if (returnType) {
+      transformPromiseType(returnType);
+    }
+  });
+
+  // Transform type alias function return types
+  root.find(j.TSTypeAliasDeclaration).forEach((path: ASTPath < ASTNode > ) => {
+    const typeAnnotation = path.node.typeAnnotation;
+    if (j.TSFunctionType.check(typeAnnotation)) {
+      const returnType = typeAnnotation.typeAnnotation?.typeAnnotation;
+      if (returnType) {
+        transformPromiseType(returnType);
+      }
+    }
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/test/test.ts
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/test/test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('typescript/promise-void-to-transport-make-request-response', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/tsconfig.json
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/vitest.config.ts
+++ b/packages/codemods/sentry/v8/removal-of-void-from-transport-return-types/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/.codemodrc.json
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/.codemodrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "sentry/v8/remove-replay-package-and-update-integration",
+  "description": "Codemod to remove @sentry/replay package and replace new Replay() with Sentry.replayIntegration() for Sentry SDK compatibility.",
+  "version": "1.0.0",
+  "engine": "jscodeshift",
+  "private": false,
+  "applicability": {
+    "from": [["sentry", "<=", "7"]],
+    "to": [["sentry", ">=", "8"]]
+  },
+  "arguments": [],
+  "meta": {
+    "tags": ["sentry", "migration","codemod"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/sentry/v8/remove-replay-package-and-update-integration"
+  }
+}

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/LICENSE
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/README.md
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/README.md
@@ -1,0 +1,83 @@
+This codemod removes the import statement for the @sentry/replay package and replaces instances of new Replay() with Sentry.replayIntegration(), aligning with the latest Sentry SDK practices.
+
+- **Import Removal:** Eliminates the import statement for Replay from the @sentry/replay package.
+- **Integration Replacement:** Transforms all occurrences of new Replay() into Sentry.replayIntegration() to ensure compatibility with the latest Sentry SDK.
+
+## Example
+
+### Before
+
+```ts
+import { Replay } from '@sentry/replay';
+
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [new Replay()],
+});
+```
+
+### After
+
+```ts
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [Sentry.replayIntegration()],
+});
+```
+,
+### Before
+
+```ts
+import { Replay } from '@sentry/replay';
+
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    new Replay(),
+    // Other integrations
+  ],
+});
+```
+
+### After
+
+```ts
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    Sentry.replayIntegration(),
+    // Other integrations
+  ],
+});
+```
+,
+### Before
+
+```ts
+import { Replay } from '@sentry/replay';
+
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    new Replay({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+});
+```
+
+### After
+
+```ts
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+});
+```
+

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,6 @@
+import { Replay } from '@sentry/replay';
+
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [new Replay()],
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,4 @@
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [Sentry.replayIntegration()],
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,9 @@
+import { Replay } from '@sentry/replay';
+
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    new Replay(),
+    // Other integrations
+  ],
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,7 @@
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    Sentry.replayIntegration(),
+    // Other integrations
+  ],
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture3.input.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture3.input.ts
@@ -1,0 +1,11 @@
+import { Replay } from '@sentry/replay';
+
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    new Replay({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture3.output.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/__testfixtures__/fixture3.output.ts
@@ -1,0 +1,9 @@
+Sentry.init({
+  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/cdmd_dist/index.cjs
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api,options){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;function replaceWithComments(path,newNode){if(path.node.comments){newNode.comments=path.node.comments}j(path).replaceWith(newNode)}root.find(j.ImportDeclaration,{source:{value:"@sentry/replay"}}).forEach(path=>{j(path).remove();dirtyFlag=true});root.find(j.NewExpression,{callee:{name:"Replay"}}).forEach(path=>{const newCall=j.callExpression(j.memberExpression(j.identifier("Sentry"),j.identifier("replayIntegration")),path.node.arguments);replaceWithComments(path,newCall);dirtyFlag=true});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/package.json
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "remove-replay-package-and-update-integration",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "akash-kumar-dev"
+}

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/src/index.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/src/index.ts
@@ -1,0 +1,63 @@
+import type {
+  API,
+  ASTNode,
+  ASTPath,
+  Block,
+  CommentBlock,
+  CommentLine,
+  FileInfo,
+  Line,
+  Node,
+  Options,
+} from 'jscodeshift';
+
+type CommentKind = Block | Line | CommentBlock | CommentLine;
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+  options ? : Options,
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Helper function to preserve comments when replacing nodes
+  function replaceWithComments(
+    path: ASTPath < ASTNode & { comments ? : CommentKind[] | null } > ,
+    newNode: Node,
+  ) {
+    // If the original node had comments, add them to the new node
+    if (path.node.comments) {
+      newNode.comments = path.node.comments;
+    }
+
+    // Replace the node
+    j(path).replaceWith(newNode);
+  }
+
+  // Step 1: Remove the import statement for Replay
+  root.find(j.ImportDeclaration, {
+    source: { value: '@sentry/replay' },
+  }).forEach((path) => {
+    j(path).remove(); // Remove the entire import statement
+    dirtyFlag = true;
+  });
+
+  // Step 2: Replace new Replay() with Sentry.replayIntegration()
+  root.find(j.NewExpression, {
+    callee: { name: 'Replay' },
+  }).forEach((path) => {
+    const newCall = j.callExpression(
+      j.memberExpression(
+        j.identifier('Sentry'),
+        j.identifier('replayIntegration'),
+      ),
+      path.node.arguments, // Pass the original arguments if any
+    );
+    replaceWithComments(path, newCall);
+    dirtyFlag = true;
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/test/test.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/test/test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('sentry/1/replay-to-replay-integration', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/tsconfig.json
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/vitest.config.ts
+++ b/packages/codemods/sentry/v8/remove-replay-package-and-update-integration/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/.codemodrc.json
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/.codemodrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "sentry/v8/replace-span-status-from-http-code",
+  "description": "Codemod to replace spanStatusfromHttpCode with getSpanStatusFromHttpCode in Sentry 8.x for improved status handling.",
+  "version": "1.0.1",
+  "engine": "jscodeshift",
+  "private": false,
+  "applicability": {
+    "from": [["sentry", "<=", "7"]],
+    "to": [["sentry", ">=", "8"]]
+  },
+  "arguments": [],
+  "meta": {
+    "tags": ["sentry", "migration","codemod"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/sentry/v8/replace-span-status-from-http-code"
+  }
+}

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/LICENSE
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/README.md
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/README.md
@@ -1,0 +1,55 @@
+This codemod replaces spanStatusfromHttpCode with getSpanStatusFromHttpCode in Sentry 8.x. It transforms instances of spanStatusfromHttpCode to use the new getSpanStatusFromHttpCode function.
+
+
+## Example
+
+### Before
+
+```ts
+const spanStatus = spanStatusfromHttpCode(200);
+```
+
+### After
+
+```ts
+const spanStatus = getSpanStatusFromHttpCode(200);
+```
+,
+### Before
+
+```ts
+const status1 = spanStatusfromHttpCode(404);
+const status2 = spanStatusfromHttpCode(500);
+```
+
+### After
+
+```ts
+const status1 = getSpanStatusFromHttpCode(404);
+const status2 = getSpanStatusFromHttpCode(500);
+```
+,
+### Before
+
+```ts
+let currentStatus = spanStatusfromHttpCode(302);
+```
+
+### After
+
+```ts
+let currentStatus = getSpanStatusFromHttpCode(302);
+```
+,
+### Before
+
+```ts
+logSpanStatus(spanStatusfromHttpCode(201));
+```
+
+### After
+
+```ts
+logSpanStatus(getSpanStatusFromHttpCode(201));
+```
+

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,1 @@
+const spanStatus = spanStatusfromHttpCode(200);

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,1 @@
+const spanStatus = getSpanStatusFromHttpCode(200);

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,2 @@
+const status1 = spanStatusfromHttpCode(404);
+const status2 = spanStatusfromHttpCode(500);

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,2 @@
+const status1 = getSpanStatusFromHttpCode(404);
+const status2 = getSpanStatusFromHttpCode(500);

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture3.input.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture3.input.ts
@@ -1,0 +1,1 @@
+let currentStatus = spanStatusfromHttpCode(302);

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture3.output.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture3.output.ts
@@ -1,0 +1,1 @@
+let currentStatus = getSpanStatusFromHttpCode(302);

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture4.input.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture4.input.ts
@@ -1,0 +1,1 @@
+logSpanStatus(spanStatusfromHttpCode(201));

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture4.output.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/__testfixtures__/fixture4.output.ts
@@ -1,0 +1,1 @@
+logSpanStatus(getSpanStatusFromHttpCode(201));

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/cdmd_dist/index.cjs
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 akash-kumar-dev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api,options){const j=api.jscodeshift;const root=j(file.source);function replaceWithComments(path,newNode){if(path.node.comments){newNode.comments=path.node.comments}j(path).replaceWith(newNode)}root.find(j.CallExpression,{callee:{type:"Identifier",name:"spanStatusfromHttpCode"}}).forEach(path=>{const newCallee=j.identifier("getSpanStatusFromHttpCode");replaceWithComments(path.get("callee"),newCallee)});return root.toSource()}

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/package.json
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "replace-span-status-from-http-code",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "akash-kumar-dev"
+}

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/src/index.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/src/index.ts
@@ -1,0 +1,53 @@
+import type {
+  API,
+  ASTNode,
+  ASTPath,
+  Block,
+  CommentBlock,
+  CommentLine,
+  FileInfo,
+  Line,
+  Node,
+  Options,
+} from 'jscodeshift';
+
+type CommentKind = Block | Line | CommentBlock | CommentLine;
+
+export default function transform(
+  file: FileInfo,
+  api: API,
+  options ? : Options,
+): string | undefined {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  // Helper function to preserve comments when replacing nodes
+  function replaceWithComments(
+    path: ASTPath < ASTNode & { comments ? : CommentKind[] | null } > ,
+    newNode: Node,
+  ) {
+    // If the original node had comments, add them to the new node
+    if (path.node.comments) {
+      newNode.comments = path.node.comments;
+    }
+
+    // Replace the node
+    j(path).replaceWith(newNode);
+  }
+
+  // Find all call expressions
+  root.find(j.CallExpression, {
+    callee: {
+      type: 'Identifier',
+      name: 'spanStatusfromHttpCode',
+    },
+  }).forEach((path) => {
+    // Create a new Identifier with the name 'getSpanStatusFromHttpCode'
+    const newCallee = j.identifier('getSpanStatusFromHttpCode');
+
+    // Replace the old callee with the new one, preserving comments
+    replaceWithComments(path.get('callee'), newCallee);
+  });
+
+  return root.toSource();
+}

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/test/test.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/test/test.ts
@@ -1,0 +1,91 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('rename-span-status-from-http-code', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #4', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/tsconfig.json
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/sentry/v8/replace-span-status-from-http-code/vitest.config.ts
+++ b/packages/codemods/sentry/v8/replace-span-status-from-http-code/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});


### PR DESCRIPTION
## Sentry v7.x → Sentry  v8.x

### 📚 Description

- **Link to Official Upgrade Guide**: [Link](https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/)

#### Sentry/V8/Removal Severity Enum
- Registry [Link](https://codemod.com/registry/sentry-v8-removal-Severity-Enum)
-  [Codemod Studio Link](https://go.codemod.com/zYCUpF1)

#### Sentry/V8/Removal Sentry.ConfigureScope Method
- Registry [Link](https://codemod.com/registry/sentry-v8-Removal-Sentry-configureScope-method)
- [Codemod Studio Link](https://go.codemod.com/KavKUiF)

#### Sentry/V8/Replace Span Status From Http Code
- Registry [Link](https://codemod.com/registry/sentry-v8-replace-span-status-from-http-code): [Link](https://codemod.com/registry/sentry-v8-replace-span-status-from-http-code)
- [Codemod Studio Link](https://go.codemod.com/yK5xQD9)

#### Sentry/V8/Removal Of AddGlobalEventProcessor
- Registry [Link](https://codemod.com/registry/sentry-v8-removal-of-addGlobalEventProcessor)
- [Codemod Studio Link](https://go.codemod.com/l2FucZz)

#### Sentry/V8/Remove Replay Package And Update Integration
- Registry Link: [Link](https://codemod.com/registry/sentry-v8-remove-replay-package-and-update-integration)
- [Codemod Studio Link](https://go.codemod.com/X9PRS06)

#### Sentry/V8/Removal Of Void From Transport Return Types
- Registry [Link](https://codemod.com/registry/sentry-v8-removal-of-void-from-transport-return-types)
- [Codemod Studio Link](https://go.codemod.com/A6ZiBDm)](https://go.codemod.com/A6ZiBDm)

#### Sentry/V8/Migration Recipe
- Registry [Link](https://codemod.com/registry/sentry-v8-migration-recipe)
