### PR TITLE
React-i18n Migration from ## **v22.x.x to v23.0.0**  codemods

### DIFF
--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/.codemodrc.json
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/.codemodrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "add-namespace-type-annotation",
+  "version": "1.0.0",
+  "engine": "jscodeshift",
+  "private": false,
+  "arguments": [],
+  "meta": {
+    "tags": [
+      "react-i18n",
+      "breaking changes",
+      "v22.x.x to v23.0.0",
+      "InterpolationOptions type",
+      "Namespace"
+    ],
+    "git": "https://github.com/codemod-com/codemod/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod"
+  }
+}

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/.gitignore
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/LICENSE
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 dfordp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/README.md
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/README.md
@@ -1,0 +1,20 @@
+Modification of the InterpolationOptions type. In version 23.0.0, the ns property within InterpolationOptions is now constrained to be of type Namespace instead of being a string or a readonly string[]. This change requires you to adjust your code accordingly.
+
+## Example
+
+### Before
+
+```ts
+function translateWithNs(key, ns) {
+  return i18n.t(key, { ns });
+}
+```
+
+### After
+
+```ts
+function translateWithNs(key, ns: Namespace) {
+  return i18n.t(key, { ns });
+}
+```
+

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,3 @@
+function translateWithNs(key, ns) {
+  return i18n.t(key, { ns });
+}

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,3 @@
+function translateWithNs(key, ns: Namespace) {
+  return i18n.t(key, { ns });
+}

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/cdmd_dist/index.cjs
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 dfordp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;root.find(j.FunctionDeclaration).forEach(path=>{const{node}=path;if(node.id&&node.id.name==="translateWithNs"){const nsParam=node.params.find(param=>param.name==="ns");if(nsParam&&!nsParam.typeAnnotation){nsParam.typeAnnotation=j.typeAnnotation(j.genericTypeAnnotation(j.identifier("Namespace"),null));dirtyFlag=true}}});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/package.json
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "add-namespace-type-annotation",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "dfordp"
+}

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/src/index.ts
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/src/index.ts
@@ -1,0 +1,22 @@
+export default function transform(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Find all function declarations
+  root.find(j.FunctionDeclaration).forEach(path => {
+    const { node } = path;
+    // Check if the function name is 'translateWithNs'
+    if (node.id && node.id.name === 'translateWithNs') {
+      // Find the parameter named 'ns'
+      const nsParam = node.params.find(param => param.name === 'ns');
+      if (nsParam && !nsParam.typeAnnotation) {
+        // Add type annotation to 'ns' parameter
+        nsParam.typeAnnotation = j.typeAnnotation(j.genericTypeAnnotation(j.identifier('Namespace'), null));
+        dirtyFlag = true;
+      }
+    }
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/test/test.ts
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/test/test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('add-namespace-type-annotation', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/tsconfig.json
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/vitest.config.ts
+++ b/packages/codemods/i18n/v23.0.0/add-namespace-type-annotation-codemod/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/.codemodrc.json
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/.codemodrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "i18n-remove-options",
+  "version": "1.0.0",
+  "engine": "jscodeshift",
+  "private": false,
+  "arguments": [],
+  "meta": {
+    "tags": [
+      "react-i18n",
+      "breaking changes",
+      "v22.x.x to v23.0.0",
+      "Removing NormalizeByTypeOptions type."
+    ],
+    "git": "https://github.com/codemod-com/codemod/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode"
+  }
+}

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/.gitignore
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/LICENSE
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 dfordp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/README.md
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/README.md
@@ -1,0 +1,49 @@
+Modification of the InterpolationOptions type. In version 23.0.0, the ns property within InterpolationOptions is now constrained to be of type Namespace instead of being a string or a readonly string[]. This change requires you to adjust your code accordingly.
+
+## Example
+
+### Before
+
+```ts
+const options = {
+  interpolation: {
+    escapeValue: false,
+  },
+};
+
+i18n.init({
+  lng: 'en',
+  backend: {
+    loadPath: '/locales/{{lng}}/{{ns}}.json',
+  },
+  normalize: (type, value) => {
+    switch (type) {
+      case 'translation':
+        return value.toUpperCase(); // Custom normalization for translations
+      default:
+        return value;
+    }
+  },
+  options,
+});
+```
+
+### After
+
+```ts
+i18n.init({
+  lng: 'en',
+  backend: {
+    loadPath: '/locales/{{lng}}/{{ns}}.json',
+  },
+  normalize: (type, value) => {
+    switch (type) {
+      case 'translation':
+        return value.toUpperCase(); // Custom normalization for translations
+      default:
+        return value;
+    }
+  },
+});
+```
+

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,21 @@
+const options = {
+  interpolation: {
+    escapeValue: false,
+  },
+};
+
+i18n.init({
+  lng: 'en',
+  backend: {
+    loadPath: '/locales/{{lng}}/{{ns}}.json',
+  },
+  normalize: (type, value) => {
+    switch (type) {
+      case 'translation':
+        return value.toUpperCase(); // Custom normalization for translations
+      default:
+        return value;
+    }
+  },
+  options,
+});

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,14 @@
+i18n.init({
+  lng: 'en',
+  backend: {
+    loadPath: '/locales/{{lng}}/{{ns}}.json',
+  },
+  normalize: (type, value) => {
+    switch (type) {
+      case 'translation':
+        return value.toUpperCase(); // Custom normalization for translations
+      default:
+        return value;
+    }
+  },
+});

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/cdmd_dist/index.cjs
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 dfordp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;root.find(j.VariableDeclaration).forEach(path=>{const declaration=path.node.declarations[0];if(j.Identifier.check(declaration.id)&&declaration.id.name==="options"){j(path).remove();dirtyFlag=true}});root.find(j.CallExpression,{callee:{object:{name:"i18n"},property:{name:"init"}}}).forEach(path=>{const args=path.node.arguments;if(args.length>0&&j.ObjectExpression.check(args[0])){const properties=args[0].properties;const newProperties=properties.filter(prop=>{if(j.Property.check(prop)&&j.Identifier.check(prop.key)&&prop.key.name==="options"){dirtyFlag=true;return false}return true});args[0].properties=newProperties}});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/package.json
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "i18n-remove-options",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "dfordp"
+}

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/src/index.ts
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/src/index.ts
@@ -1,0 +1,42 @@
+export default function transform(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Find the variable declaration for `options`
+  root.find(j.VariableDeclaration).forEach((path) => {
+    const declaration = path.node.declarations[0];
+    if (
+      j.Identifier.check(declaration.id) &&
+      declaration.id.name === 'options'
+    ) {
+      // Remove the variable declaration
+      j(path).remove();
+      dirtyFlag = true;
+    }
+  });
+
+  // Find the i18n.init call and remove the `options` property
+  root.find(j.CallExpression, {
+    callee: { object: { name: 'i18n' }, property: { name: 'init' } },
+  }).forEach((path) => {
+    const args = path.node.arguments;
+    if (args.length > 0 && j.ObjectExpression.check(args[0])) {
+      const properties = args[0].properties;
+      const newProperties = properties.filter((prop) => {
+        if (
+          j.Property.check(prop) &&
+          j.Identifier.check(prop.key) &&
+          prop.key.name === 'options'
+        ) {
+          dirtyFlag = true;
+          return false;
+        }
+        return true;
+      });
+      args[0].properties = newProperties;
+    }
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/test/test.ts
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/test/test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('i18n/remove-options', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/tsconfig.json
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/vitest.config.ts
+++ b/packages/codemods/i18n/v23.0.0/i18n-remove-options-codemode/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/.codemodrc.json
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/.codemodrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "i18next-replace-keyswithseparator-with-joinkeys",
+  "version": "1.0.0",
+  "engine": "jscodeshift",
+  "private": false,
+  "arguments": [],
+  "meta": {
+    "tags": [
+      "react-i18n",
+      "breaking changes",
+      "v22.x.x to v23.0.0",
+      "keyswithseparator",
+      "joinkeys"
+    ],
+    "git": "https://github.com/codemod-com/codemod/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod"
+  }
+}

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/.gitignore
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/LICENSE
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 dfordp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/README.md
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/README.md
@@ -1,0 +1,24 @@
+Renaming types or functions can be part of an effort to clarify the library's API, deprecate old functionality, or introduce new features. In this case, KeysWithSeparator has been renamed to JoinKeys. This means wherever KeysWithSeparator was used in the codebase, it needs to be replaced with JoinKeys.
+
+## Example
+
+### Before
+
+```ts
+import { KeysWithSeparator } from 'i18next';
+
+const myTranslationFunction = (key: KeysWithSeparator < string > ) => {
+  // Function body remains the same
+};
+```
+
+### After
+
+```ts
+import { JoinKeys } from 'i18next';
+
+const myTranslationFunction = (key: JoinKeys < string > ) => {
+  // Function body remains the same
+};
+```
+

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,5 @@
+import { KeysWithSeparator } from 'i18next';
+
+const myTranslationFunction = (key: KeysWithSeparator < string > ) => {
+  // Function body remains the same
+};

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,5 @@
+import { JoinKeys } from 'i18next';
+
+const myTranslationFunction = (key: JoinKeys < string > ) => {
+  // Function body remains the same
+};

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/cdmd_dist/index.cjs
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 dfordp
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;root.find(j.ImportDeclaration,{source:{value:"i18next"}}).find(j.ImportSpecifier,{imported:{name:"KeysWithSeparator"}}).forEach(path=>{path.replace(j.importSpecifier(j.identifier("JoinKeys")));dirtyFlag=true});root.find(j.TSTypeReference,{typeName:{type:"Identifier",name:"KeysWithSeparator"}}).forEach(path=>{path.replace(j.tsTypeReference(j.identifier("JoinKeys"),path.node.typeParameters));dirtyFlag=true});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/package.json
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "i18next-replace-keyswithseparator-with-joinkeys",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "dfordp"
+}

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/src/index.ts
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/src/index.ts
@@ -1,0 +1,22 @@
+export default function transform(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Replace import { KeysWithSeparator } with { JoinKeys }
+  root.find(j.ImportDeclaration, { source: { value: 'i18next' } })
+    .find(j.ImportSpecifier, { imported: { name: 'KeysWithSeparator' } })
+    .forEach(path => {
+      path.replace(j.importSpecifier(j.identifier('JoinKeys')));
+      dirtyFlag = true;
+    });
+
+  // Replace type KeysWithSeparator<string> with JoinKeys<string>
+  root.find(j.TSTypeReference, { typeName: { type: 'Identifier', name: 'KeysWithSeparator' } })
+    .forEach(path => {
+      path.replace(j.tsTypeReference(j.identifier('JoinKeys'), path.node.typeParameters));
+      dirtyFlag = true;
+    });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/test/test.ts
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/test/test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('i18next/replace-keyswithseparator-with-joinkeys', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/tsconfig.json
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/vitest.config.ts
+++ b/packages/codemods/i18n/v23.0.0/i18next-replace-keyswithseparator-with-joinkeys-codemod/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});


### PR DESCRIPTION
### Reacti18next

## **v22.x.x to v23.0.0**

- **Link to Official Upgrade Guide**: [https://www.i18next.com/misc/migration-guide#v22.x.x-to-v23.0.0]

### add-namespace type anotation

- Modification of the `InterpolationOptions` type. In version 23.0.0, the `ns` property within `InterpolationOptions` is now constrained to be of type `Namespace` instead of being a `string` or a `readonly string[]`. This change requires you to adjust your code accordingly.

### Additional Details

- ns property from InterpolationOptions type will be constrained to Namespace rather than string or readonly string[].
- https://go.codemod.com/jkx2fNh

---

### i18next_replace-keyswithseparator-with-joinkeys

- Renaming types or functions can be part of an effort to clarify the library's API, deprecate old functionality, or introduce new features. In this case, `KeysWithSeparator` has been renamed to `JoinKeys`. This means wherever `KeysWithSeparator` was used in the codebase, it needs to be replaced with `JoinKeys`.

### Additional Details

- Renaming KeysWithSeparator type to JoinKeys, and it will no longer be exposed.
- https://go.codemod.com/lzNvyAE

### i18n_remove-options

- This migration simplifies the configuration but requires reviewing your existing normalization logic to ensure it still meets your needs without the explicit type-based customization previously available through `NormalizeByTypeOptions`.

### Additional Details

- Removing NormalizeByTypeOptions type.
- https://go.codemod.com/LbkZwAe