### PR TITLE
Refactor Imports from @next/font to next/font in Next15

### DIFF
--- a/packages/codemods/next/15/next-font/.codemodrc.json
+++ b/packages/codemods/next/15/next-font/.codemodrc.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "Next/15/Refactor-Imports-from-@next/font-to-next/font",
+  "version": "1.0.0",
+  "engine": "jscodeshift",
+  "private": false,
+  "arguments": [],
+  "meta": {
+    "tags": [
+      "Next"
+    ]
+  }
+}

--- a/packages/codemods/next/15/next-font/.gitignore
+++ b/packages/codemods/next/15/next-font/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/next/15/next-font/LICENSE
+++ b/packages/codemods/next/15/next-font/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 nishant2253
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/next/15/next-font/README.md
+++ b/packages/codemods/next/15/next-font/README.md
@@ -1,0 +1,23 @@
+Refactor Imports from @next/font to next/font
+
+This codemod refactors import statements in your code to replace @next/font with next/font, aligning with the latest Next.js module structure.
+
+- Find Import Declarations: Identifies all ImportDeclaration nodes in the code.
+
+- Check Import Path: Ensures that the import path starts with @next/font.
+
+- Replace Import Path: Updates the import path to use next/font instead of @next/font.
+
+### Before
+
+```js
+// Before
+import { Inter } from "@next/font/google";
+```
+
+### After
+
+```js
+// After
+import { Inter } from "next/font/google";
+```

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,1 @@
+import { Inter } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,1 @@
+import { Inter } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture10.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture10.input.ts
@@ -1,0 +1,1 @@
+import { Georgia } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture10.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture10.output.ts
@@ -1,0 +1,1 @@
+import { Georgia } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture11.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture11.input.ts
@@ -1,0 +1,1 @@
+import { Tahoma } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture11.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture11.output.ts
@@ -1,0 +1,1 @@
+import { Tahoma } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture12.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture12.input.ts
@@ -1,0 +1,1 @@
+import { ComicSans } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture12.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture12.output.ts
@@ -1,0 +1,1 @@
+import { ComicSans } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,1 @@
+import { Roboto } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,1 @@
+import { Roboto } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture3.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture3.input.ts
@@ -1,0 +1,1 @@
+import { OpenSans } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture3.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture3.output.ts
@@ -1,0 +1,1 @@
+import { OpenSans } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture4.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture4.input.ts
@@ -1,0 +1,1 @@
+import { Lato } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture4.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture4.output.ts
@@ -1,0 +1,1 @@
+import { Lato } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture5.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture5.input.ts
@@ -1,0 +1,1 @@
+import { Montserrat } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture5.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture5.output.ts
@@ -1,0 +1,1 @@
+import { Montserrat } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture6.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture6.input.ts
@@ -1,0 +1,1 @@
+import { Arial } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture6.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture6.output.ts
@@ -1,0 +1,1 @@
+import { Arial } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture7.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture7.input.ts
@@ -1,0 +1,1 @@
+import { TimesNewRoman } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture7.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture7.output.ts
@@ -1,0 +1,1 @@
+import { TimesNewRoman } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture8.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture8.input.ts
@@ -1,0 +1,1 @@
+import { Verdana } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture8.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture8.output.ts
@@ -1,0 +1,1 @@
+import { Verdana } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture9.input.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture9.input.ts
@@ -1,0 +1,1 @@
+import { CourierNew } from '@next/font/google';

--- a/packages/codemods/next/15/next-font/__testfixtures__/fixture9.output.ts
+++ b/packages/codemods/next/15/next-font/__testfixtures__/fixture9.output.ts
@@ -1,0 +1,1 @@
+import { CourierNew } from 'next/font/google';

--- a/packages/codemods/next/15/next-font/cdmd_dist/index.cjs
+++ b/packages/codemods/next/15/next-font/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 nishant2253
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api,options){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;root.find(j.ImportDeclaration,{source:{value:"@next/font/google"}}).forEach(path=>{path.node.source.value="next/font/google";dirtyFlag=true});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/next/15/next-font/package.json
+++ b/packages/codemods/next/15/next-font/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "Next/15/Refactor-Imports-from-@next/font-to-next/font",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "nishant2253"
+}

--- a/packages/codemods/next/15/next-font/src/index.ts
+++ b/packages/codemods/next/15/next-font/src/index.ts
@@ -1,0 +1,15 @@
+export default function transform(file, api, options) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Find the import declaration with the specific source
+  root.find(j.ImportDeclaration, { source: { value: '@next/font/google' } })
+    .forEach(path => {
+      // Update the source value
+      path.node.source.value = 'next/font/google';
+      dirtyFlag = true;
+    });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/next/15/next-font/test/test.ts
+++ b/packages/codemods/next/15/next-font/test/test.ts
@@ -1,0 +1,227 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('next/10/update-google-font-import-path', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #4', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #5', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #6', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture6.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture6.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #7', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture7.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture7.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #8', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture8.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture8.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #9', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture9.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture9.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #10', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture10.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture10.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #11', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture11.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture11.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #12', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture12.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture12.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/next/15/next-font/tsconfig.json
+++ b/packages/codemods/next/15/next-font/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/next/15/next-font/vitest.config.ts
+++ b/packages/codemods/next/15/next-font/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});

--- a/packages/codemods/react/render-to-readable-stream/.codemodrc.json
+++ b/packages/codemods/react/render-to-readable-stream/.codemodrc.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "render-to-readable-stream-args-refactor",
+  "version": "1.0.0",
+  "engine": "jscodeshift",
+  "private": false,
+  "arguments": [],
+  "meta": {}
+}

--- a/packages/codemods/react/render-to-readable-stream/LICENSE
+++ b/packages/codemods/react/render-to-readable-stream/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 nishant2253
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/react/render-to-readable-stream/README.md
+++ b/packages/codemods/react/render-to-readable-stream/README.md
@@ -1,0 +1,26 @@
+### Codemod Description:
+
+    Purpose: Refactor renderToReadableStream call expressions to use a combined object argument.
+    Changes Made:
+      -  Finds Call Expressions: Identifies calls to renderToReadableStream in the code.
+      -  Argument Check: Ensures the function calls have exactly three arguments, with the second and third being identifiers.
+      -  Create Object Argument: Combines the second and third arguments into a new object argument with properties onError,    context, and a default identifierPrefix.
+      -  Replace Arguments: Updates the function call to use the new object argument.
+
+This codemod simplifies the argument structure for renderToReadableStream, aligning it with new conventions or improving readability and maintainability.
+
+### Before
+
+```ts
+renderToReadableStream(widget, onErrorCallback, appContextData);
+```
+
+### After
+
+```ts
+renderToReadableStream(widget, {
+  onError: onErrorCallback,
+  context: appContextData,
+  identifierPrefix: prefix,
+});
+```

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(widget, onErrorCallback, appContextData);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(widget, {
+  onError: onErrorCallback,
+  context: appContextData,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture2.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture2.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(widget, handleFailure, appData);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture2.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture2.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(widget, {
+  onError: handleFailure,
+  context: appData,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture3.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture3.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(component, handleFailure, userData);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture3.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture3.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(component, {
+  onError: handleFailure,
+  context: userData,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture4.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture4.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(view, handleFailure, sessionContext);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture4.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture4.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(view, {
+  onError: handleFailure,
+  context: sessionContext,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture5.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture5.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(template, handleException, requestContext);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture5.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture5.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(template, {
+  onError: handleException,
+  context: requestContext,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture6.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture6.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(page, handleError, userSession);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture6.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture6.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(page, {
+  onError: handleError,
+  context: userSession,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture7.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture7.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(document, handleException, appContext);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture7.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture7.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(document, {
+  onError: handleException,
+  context: appContext,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture8.input.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture8.input.ts
@@ -1,0 +1,1 @@
+renderToReadableStream(element, handleError, globalContext);

--- a/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture8.output.ts
+++ b/packages/codemods/react/render-to-readable-stream/__testfixtures__/fixture8.output.ts
@@ -1,0 +1,5 @@
+renderToReadableStream(element, {
+  onError: handleError,
+  context: globalContext,
+  identifierPrefix: prefix,
+});

--- a/packages/codemods/react/render-to-readable-stream/cdmd_dist/index.cjs
+++ b/packages/codemods/react/render-to-readable-stream/cdmd_dist/index.cjs
@@ -1,0 +1,13 @@
+/*! @license
+The MIT License (MIT)
+
+Copyright (c) 2024 nishant2253
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+"use strict";Object.defineProperty(exports,"__esModule",{value:true});Object.defineProperty(exports,"default",{enumerable:true,get:function(){return transform}});function transform(file,api){const j=api.jscodeshift;const root=j(file.source);let dirtyFlag=false;root.find(j.CallExpression,{callee:{type:"Identifier",name:"renderToReadableStream"}}).forEach(path=>{const args=path.value.arguments;if(args.length===3){const[widget,onErrorCallback,appContextData]=args;if(j.Identifier.check(onErrorCallback)&&j.Identifier.check(appContextData)){const newObjectArg=j.objectExpression([j.property.from({kind:"init",key:j.identifier("onError"),value:onErrorCallback,shorthand:false}),j.property.from({kind:"init",key:j.identifier("context"),value:appContextData,shorthand:false}),j.property.from({kind:"init",key:j.identifier("identifierPrefix"),value:j.identifier("prefix"),shorthand:true})]);path.value.arguments=[widget,newObjectArg];dirtyFlag=true}}});return dirtyFlag?root.toSource():undefined}

--- a/packages/codemods/react/render-to-readable-stream/package.json
+++ b/packages/codemods/react/render-to-readable-stream/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "render-to-readable-stream-args-refactor",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "20.9.0",
+    "typescript": "^5.2.2",
+    "vitest": "^1.0.1",
+    "@codemod.com/codemod-utils": "*",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest watch"
+  },
+  "files": [
+    "README.md",
+    ".codemodrc.json",
+    "/dist/index.cjs"
+  ],
+  "type": "module",
+  "author": "nishant2253"
+}

--- a/packages/codemods/react/render-to-readable-stream/src/index.ts
+++ b/packages/codemods/react/render-to-readable-stream/src/index.ts
@@ -1,0 +1,54 @@
+export default function transform(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirtyFlag = false;
+
+  // Find all call expressions to renderToReadableStream
+  root.find(j.CallExpression, {
+    callee: {
+      type: 'Identifier',
+      name: 'renderToReadableStream',
+    },
+  }).forEach((path) => {
+    const args = path.value.arguments;
+
+    // Ensure there are exactly three arguments
+    if (args.length === 3) {
+      const [widget, onErrorCallback, appContextData] = args;
+
+      // Check if the second and third arguments are identifiers
+      if (
+        j.Identifier.check(onErrorCallback) &&
+        j.Identifier.check(appContextData)
+      ) {
+        // Create the new object argument
+        const newObjectArg = j.objectExpression([
+          j.property.from({
+            kind: 'init',
+            key: j.identifier('onError'),
+            value: onErrorCallback,
+            shorthand: false,
+          }),
+          j.property.from({
+            kind: 'init',
+            key: j.identifier('context'),
+            value: appContextData,
+            shorthand: false,
+          }),
+          j.property.from({
+            kind: 'init',
+            key: j.identifier('identifierPrefix'),
+            value: j.identifier('prefix'),
+            shorthand: true,
+          }),
+        ]);
+
+        // Replace the arguments in the call expression
+        path.value.arguments = [widget, newObjectArg];
+        dirtyFlag = true;
+      }
+    }
+  });
+
+  return dirtyFlag ? root.toSource() : undefined;
+}

--- a/packages/codemods/react/render-to-readable-stream/test/test.ts
+++ b/packages/codemods/react/render-to-readable-stream/test/test.ts
@@ -1,0 +1,159 @@
+import { describe, it } from 'vitest';
+import jscodeshift, { type API } from 'jscodeshift';
+import transform from '../src/index.js';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const buildApi = (parser: string | undefined): API => ({
+  j: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  jscodeshift: parser ? jscodeshift.withParser(parser) : jscodeshift,
+  stats: () => {
+    console.error(
+      'The stats function was called, which is not supported on purpose',
+    );
+  },
+  report: () => {
+    console.error(
+      'The report function was called, which is not supported on purpose',
+    );
+  },
+});
+
+describe('render-to-readable-stream-args-refactor', () => {
+  it('test #1', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture1.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #2', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture2.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #3', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture3.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #4', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture4.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #5', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture5.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #6', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture6.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture6.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #7', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture7.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture7.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+
+  it('test #8', async () => {
+    const INPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture8.input.ts'), 'utf-8');
+    const OUTPUT = await readFile(join(__dirname, '..', '__testfixtures__/fixture8.output.ts'), 'utf-8');
+
+    const actualOutput = transform({
+        path: 'index.js',
+        source: INPUT,
+      },
+      buildApi('tsx'), {}
+    );
+
+    assert.deepEqual(
+      actualOutput?.replace(/W/gm, ''),
+      OUTPUT.replace(/W/gm, ''),
+    );
+  });
+});

--- a/packages/codemods/react/render-to-readable-stream/tsconfig.json
+++ b/packages/codemods/react/render-to-readable-stream/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "target": "ESNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "useDefineForClassFields": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "preserveWatchOutput": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "incremental": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/react/render-to-readable-stream/vitest.config.ts
+++ b/packages/codemods/react/render-to-readable-stream/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, '**/test/*.ts'],
+  },
+});


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

This codemod refactors import statements in your code to replace `@next/font` with `next/font`, aligning with the latest Next.js module structure. It identifies and updates import paths from `@next/font` to `next/font` to ensure compatibility with the updated Next.js API.

#### 🧪 Test Plan
Test the codemod by running it against the specified repository and Next.js  folder to ensure that import statements are correctly updated from `@next/font` to `next/font`. Verify that the refactored import paths work as expected and that there are no import errors in the application.

1. Apply the codemod to the repository available at (https://github.com/saleor/storefront)
2. Confirm that all occurrences of `@next/font` are replaced with `next/font`.
3. Test the application to ensure that it functions correctly with the updated import paths.
- All the other test cases are runned in the codemod studio and present in **/codemod/packages/codemods/next/15/next-font/_textfixtures_/**

#### 📄 Documentation to Update

If applicable, update the documentation to reflect the changes in import paths. This may include README files or other developer guides that reference `@next/font`.

