### PR TITLE
Added Codemods for Svelte from v4 to v5

### DIFF
--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/.codemodrc.json
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/.codemodrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "version": "1.0.2",
+  "private": false,
+  "name": "svelte/5/components-as-functions-destroyfunction",
+  "engine": "jscodeshift",
+  "applicability": {
+    "from": [["svelte", ">=", "4.0.0"], ["svelte", "<", "5.0.0"]],
+    "to": [["svelte", ">=", "5.0.0"]]
+  },
+  "meta": {
+    "tags": ["svelte", "5", "migration"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/svelte/5/components-as-functions-destroyfunction"
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue", "**/*.svelte"]
+}

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/.gitignore
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/LICENSE
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Codemod Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/README.md
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/README.md
@@ -1,0 +1,31 @@
+This codemod updates Svelte component instantiation and event handling for Svelte 5:
+
+- Converts `new Component({ target })` to `mount(Component, { target })`.
+- Replaces `$destroy` method calls with `unmount`.
+- Ensures compatibility with Svelte 5's function-based components and new event handling.
+
+## Before
+
+```jsx
+import App from './App.svelte';
+
+const app = new App({
+    target: document.getElementById('app'),
+    props: { foo: 'bar' },
+});
+app.$destroy();
+```
+
+## After
+
+```jsx
+import { unmount } from 'svelte';
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, {
+    target: document.getElementById('app'),
+    props: { foo: 'bar' },
+});
+unmount(app);
+```

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,7 @@
+import App from './App.svelte';
+
+const app = new App({
+    target: document.getElementById('app'),
+    props: { foo: 'bar' },
+});
+app.$destroy();

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,9 @@
+import { unmount } from 'svelte';
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, {
+    target: document.getElementById('app'),
+    props: { foo: 'bar' },
+});
+unmount(app);

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/package.json
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@codemod/svelte-5-components-as-functions-destroyfunction",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10",
+    "vitest": "^1.0.1",
+    "@vitest/coverage-v8": "^1.0.1"
+  },
+  "scripts": {},
+  "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],
+  "type": "module"
+}

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/src/index.ts
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/src/index.ts
@@ -1,0 +1,209 @@
+import type {
+  API,
+  ArrowFunctionExpression,
+  FileInfo,
+  Options,
+} from "jscodeshift";
+
+export default function transform(
+    file: FileInfo,
+    api: API,
+    options?: Options,
+  ): string | undefined {
+    const j = api.jscodeshift;
+    const source = file.source;
+
+    // Regular expression to find the content inside <script> tags
+    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
+
+    // Variable to hold the transformed source
+    let transformedSource = source;
+    let scriptFound = false;
+
+    // Function to perform the transformation logic
+    function transformCode(code) {
+        const root = j(code);
+
+        // Add 'mount' and 'unmount' imports if they are not present
+        function addSvelteImports() {
+            let needsUnmount = false;
+
+            // Check if any $destroy calls are present
+            root.find(j.CallExpression, {
+                callee: {
+                    type: 'MemberExpression',
+                    property: {
+                        type: 'Identifier',
+                        name: '$destroy',
+                    },
+                },
+            }).forEach(() => {
+                needsUnmount = true;
+            });
+
+            const svelteImport = root.find(j.ImportDeclaration, {
+                source: { value: 'svelte' },
+            });
+
+            const mountSpecifier = svelteImport
+                .find(j.ImportSpecifier)
+                .filter((specifier) => specifier.node.imported.name === 'mount');
+            const unmountSpecifier = svelteImport
+                .find(j.ImportSpecifier)
+                .filter((specifier) => specifier.node.imported.name === 'unmount');
+
+            if (mountSpecifier.length === 0) {
+                if (svelteImport.length > 0) {
+                    svelteImport
+                        .get(0)
+                        .node.specifiers.push(
+                            j.importSpecifier(j.identifier('mount')),
+                        );
+                } else {
+                    const importStatement = j.importDeclaration(
+                        [j.importSpecifier(j.identifier('mount'))],
+                        j.literal('svelte'),
+                    );
+                    root.find(j.ImportDeclaration)
+                        .at(0)
+                        .insertBefore(importStatement);
+                }
+            }
+
+            if (needsUnmount && unmountSpecifier.length === 0) {
+                if (svelteImport.length > 0) {
+                    svelteImport
+                        .get(0)
+                        .node.specifiers.push(
+                            j.importSpecifier(j.identifier('unmount')),
+                        );
+                } else {
+                    const importStatement = j.importDeclaration(
+                        [j.importSpecifier(j.identifier('unmount'))],
+                        j.literal('svelte'),
+                    );
+                    root.find(j.ImportDeclaration)
+                        .at(0)
+                        .insertBefore(importStatement);
+                }
+            }
+        }
+
+        // Find instantiations of Svelte components and replace them
+        root.find(j.NewExpression, {
+            callee: {
+                type: 'Identifier',
+            },
+        }).forEach((path) => {
+            const componentName = path.node.callee.name;
+
+            // Check if the instantiation is for a Svelte component (imported from .svelte)
+            const importDeclaration = root.find(j.ImportDeclaration, {
+                specifiers: [{ local: { name: componentName } }],
+                source: { value: (val) => val.endsWith('.svelte') },
+            });
+
+            if (importDeclaration.length > 0) {
+                // Replace `new Component({ target })` with `mount(Component, { target })`
+                j(path).replaceWith(
+                    j.callExpression(j.identifier('mount'), [
+                        j.identifier(componentName),
+                        ...path.node.arguments,
+                    ]),
+                );
+                addSvelteImports();
+            }
+        });
+
+        // Find and replace $destroy method calls with unmount
+        root.find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                property: {
+                    type: 'Identifier',
+                    name: '$destroy',
+                },
+            },
+        }).forEach((path) => {
+            const appVarName = path.node.callee.object.name;
+
+            // Replace `$destroy()` with `unmount(appVarName)`
+            j(path).replaceWith(
+                j.callExpression(j.identifier('unmount'), [
+                    j.identifier(appVarName),
+                ]),
+            );
+        });
+
+        // Find and replace $on method calls with events property
+        root.find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                property: {
+                    type: 'Identifier',
+                    name: '$on',
+                },
+            },
+        }).forEach((path) => {
+            const componentName = path.node.callee.object.name;
+            const eventName = path.node.arguments[0];
+            const callback = path.node.arguments[1];
+
+            // Add events property to the mount options
+            root.find(j.CallExpression, {
+                callee: {
+                    type: 'Identifier',
+                    name: 'mount',
+                },
+            }).forEach((mountPath) => {
+                const optionsArg = mountPath.node.arguments[1];
+                if (optionsArg && optionsArg.type === 'ObjectExpression') {
+                    const eventsProperty = optionsArg.properties.find(
+                        (prop) => prop.key.name === 'events',
+                    );
+                    if (eventsProperty) {
+                        eventsProperty.value.properties.push(
+                            j.property('init', eventName, callback),
+                        );
+                    } else {
+                        optionsArg.properties.push(
+                            j.property(
+                                'init',
+                                j.identifier('events'),
+                                j.objectExpression([
+                                    j.property('init', eventName, callback),
+                                ]),
+                            ),
+                        );
+                    }
+                }
+            });
+
+            // Remove the $on call
+            j(path).remove();
+        });
+
+        return root.toSource();
+    }
+
+    // Handle JavaScript inside <script> tags and directly in JavaScript files
+    if (file.path.endsWith('.svelte')) {
+        transformedSource = transformedSource.replace(scriptTagRegex, (match, scriptContent) => {
+            scriptFound = true;
+            // Transform the extracted JavaScript content from <script> tags
+            const transformedScriptContent = transformCode(scriptContent);
+            // Replace the original <script> content with the transformed content
+            return `<script>\n${transformedScriptContent}\n</script>`;
+        });
+
+        // If no <script> tags were found, assume it's a script-less Svelte file
+        if (!scriptFound) {
+            transformedSource = transformCode(source);
+        }
+    } else {
+        // Directly transform JavaScript files
+        transformedSource = transformCode(source);
+    }
+
+    return transformedSource;
+}

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/src/index.ts
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/src/index.ts
@@ -1,209 +1,203 @@
 import type {
-  API,
-  ArrowFunctionExpression,
-  FileInfo,
-  Options,
-} from "jscodeshift";
-
-export default function transform(
+    API,
+    ArrowFunctionExpression,
+    FileInfo,
+    Options,
+  } from "jscodeshift";
+  
+  export default function transform(
     file: FileInfo,
     api: API,
     options?: Options,
   ): string | undefined {
     const j = api.jscodeshift;
     const source = file.source;
-
-    // Regular expression to find the content inside <script> tags
-    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
-
+  
+    // Regular expression to find the content inside <script> tags and capture the entire opening tag
+    const scriptTagRegex = /(<script[^>]*>)([\s\S]*?)(<\/script>)/gm;
+  
     // Variable to hold the transformed source
     let transformedSource = source;
     let scriptFound = false;
-
+  
     // Function to perform the transformation logic
     function transformCode(code) {
-        const root = j(code);
-
-        // Add 'mount' and 'unmount' imports if they are not present
-        function addSvelteImports() {
-            let needsUnmount = false;
-
-            // Check if any $destroy calls are present
-            root.find(j.CallExpression, {
-                callee: {
-                    type: 'MemberExpression',
-                    property: {
-                        type: 'Identifier',
-                        name: '$destroy',
-                    },
-                },
-            }).forEach(() => {
-                needsUnmount = true;
-            });
-
-            const svelteImport = root.find(j.ImportDeclaration, {
-                source: { value: 'svelte' },
-            });
-
-            const mountSpecifier = svelteImport
-                .find(j.ImportSpecifier)
-                .filter((specifier) => specifier.node.imported.name === 'mount');
-            const unmountSpecifier = svelteImport
-                .find(j.ImportSpecifier)
-                .filter((specifier) => specifier.node.imported.name === 'unmount');
-
-            if (mountSpecifier.length === 0) {
-                if (svelteImport.length > 0) {
-                    svelteImport
-                        .get(0)
-                        .node.specifiers.push(
-                            j.importSpecifier(j.identifier('mount')),
-                        );
-                } else {
-                    const importStatement = j.importDeclaration(
-                        [j.importSpecifier(j.identifier('mount'))],
-                        j.literal('svelte'),
-                    );
-                    root.find(j.ImportDeclaration)
-                        .at(0)
-                        .insertBefore(importStatement);
-                }
-            }
-
-            if (needsUnmount && unmountSpecifier.length === 0) {
-                if (svelteImport.length > 0) {
-                    svelteImport
-                        .get(0)
-                        .node.specifiers.push(
-                            j.importSpecifier(j.identifier('unmount')),
-                        );
-                } else {
-                    const importStatement = j.importDeclaration(
-                        [j.importSpecifier(j.identifier('unmount'))],
-                        j.literal('svelte'),
-                    );
-                    root.find(j.ImportDeclaration)
-                        .at(0)
-                        .insertBefore(importStatement);
-                }
-            }
-        }
-
-        // Find instantiations of Svelte components and replace them
-        root.find(j.NewExpression, {
-            callee: {
-                type: 'Identifier',
-            },
-        }).forEach((path) => {
-            const componentName = path.node.callee.name;
-
-            // Check if the instantiation is for a Svelte component (imported from .svelte)
-            const importDeclaration = root.find(j.ImportDeclaration, {
-                specifiers: [{ local: { name: componentName } }],
-                source: { value: (val) => val.endsWith('.svelte') },
-            });
-
-            if (importDeclaration.length > 0) {
-                // Replace `new Component({ target })` with `mount(Component, { target })`
-                j(path).replaceWith(
-                    j.callExpression(j.identifier('mount'), [
-                        j.identifier(componentName),
-                        ...path.node.arguments,
-                    ]),
-                );
-                addSvelteImports();
-            }
-        });
-
-        // Find and replace $destroy method calls with unmount
+      const root = j(code);
+  
+      // Add 'mount' and 'unmount' imports if they are not present
+      function addSvelteImports() {
+        let needsUnmount = false;
+  
+        // Check if any $destroy calls are present
         root.find(j.CallExpression, {
-            callee: {
-                type: 'MemberExpression',
-                property: {
-                    type: 'Identifier',
-                    name: '$destroy',
-                },
+          callee: {
+            type: "MemberExpression",
+            property: {
+              type: "Identifier",
+              name: "$destroy",
             },
-        }).forEach((path) => {
-            const appVarName = path.node.callee.object.name;
-
-            // Replace `$destroy()` with `unmount(appVarName)`
-            j(path).replaceWith(
-                j.callExpression(j.identifier('unmount'), [
-                    j.identifier(appVarName),
-                ]),
+          },
+        }).forEach(() => {
+          needsUnmount = true;
+        });
+  
+        const svelteImport = root.find(j.ImportDeclaration, {
+          source: { value: "svelte" },
+        });
+  
+        const mountSpecifier = svelteImport
+          .find(j.ImportSpecifier)
+          .filter((specifier) => specifier.node.imported.name === "mount");
+        const unmountSpecifier = svelteImport
+          .find(j.ImportSpecifier)
+          .filter((specifier) => specifier.node.imported.name === "unmount");
+  
+        if (mountSpecifier.length === 0) {
+          if (svelteImport.length > 0) {
+            svelteImport.get(0).node.specifiers.push(
+              j.importSpecifier(j.identifier("mount"))
             );
-        });
-
-        // Find and replace $on method calls with events property
-        root.find(j.CallExpression, {
-            callee: {
-                type: 'MemberExpression',
-                property: {
-                    type: 'Identifier',
-                    name: '$on',
-                },
-            },
-        }).forEach((path) => {
-            const componentName = path.node.callee.object.name;
-            const eventName = path.node.arguments[0];
-            const callback = path.node.arguments[1];
-
-            // Add events property to the mount options
-            root.find(j.CallExpression, {
-                callee: {
-                    type: 'Identifier',
-                    name: 'mount',
-                },
-            }).forEach((mountPath) => {
-                const optionsArg = mountPath.node.arguments[1];
-                if (optionsArg && optionsArg.type === 'ObjectExpression') {
-                    const eventsProperty = optionsArg.properties.find(
-                        (prop) => prop.key.name === 'events',
-                    );
-                    if (eventsProperty) {
-                        eventsProperty.value.properties.push(
-                            j.property('init', eventName, callback),
-                        );
-                    } else {
-                        optionsArg.properties.push(
-                            j.property(
-                                'init',
-                                j.identifier('events'),
-                                j.objectExpression([
-                                    j.property('init', eventName, callback),
-                                ]),
-                            ),
-                        );
-                    }
-                }
-            });
-
-            // Remove the $on call
-            j(path).remove();
-        });
-
-        return root.toSource();
-    }
-
-    // Handle JavaScript inside <script> tags and directly in JavaScript files
-    if (file.path.endsWith('.svelte')) {
-        transformedSource = transformedSource.replace(scriptTagRegex, (match, scriptContent) => {
-            scriptFound = true;
-            // Transform the extracted JavaScript content from <script> tags
-            const transformedScriptContent = transformCode(scriptContent);
-            // Replace the original <script> content with the transformed content
-            return `<script>\n${transformedScriptContent}\n</script>`;
-        });
-
-        // If no <script> tags were found, assume it's a script-less Svelte file
-        if (!scriptFound) {
-            transformedSource = transformCode(source);
+          } else {
+            const importStatement = j.importDeclaration(
+              [j.importSpecifier(j.identifier("mount"))],
+              j.literal("svelte")
+            );
+            root.find(j.ImportDeclaration).at(0).insertBefore(importStatement);
+          }
         }
-    } else {
-        // Directly transform JavaScript files
-        transformedSource = transformCode(source);
+  
+        if (needsUnmount && unmountSpecifier.length === 0) {
+          if (svelteImport.length > 0) {
+            svelteImport.get(0).node.specifiers.push(
+              j.importSpecifier(j.identifier("unmount"))
+            );
+          } else {
+            const importStatement = j.importDeclaration(
+              [j.importSpecifier(j.identifier("unmount"))],
+              j.literal("svelte")
+            );
+            root.find(j.ImportDeclaration).at(0).insertBefore(importStatement);
+          }
+        }
+      }
+  
+      // Find instantiations of Svelte components and replace them
+      root.find(j.NewExpression, {
+        callee: {
+          type: "Identifier",
+        },
+      }).forEach((path) => {
+        const componentName = path.node.callee.name;
+  
+        // Check if the instantiation is for a Svelte component (imported from .svelte)
+        const importDeclaration = root.find(j.ImportDeclaration, {
+          specifiers: [{ local: { name: componentName } }],
+          source: { value: (val) => val.endsWith(".svelte") },
+        });
+  
+        if (importDeclaration.length > 0) {
+          // Replace `new Component({ target })` with `mount(Component, { target })`
+          j(path).replaceWith(
+            j.callExpression(j.identifier("mount"), [
+              j.identifier(componentName),
+              ...path.node.arguments,
+            ])
+          );
+          addSvelteImports();
+        }
+      });
+  
+      // Find and replace $destroy method calls with unmount
+      root.find(j.CallExpression, {
+        callee: {
+          type: "MemberExpression",
+          property: {
+            type: "Identifier",
+            name: "$destroy",
+          },
+        },
+      }).forEach((path) => {
+        const appVarName = path.node.callee.object.name;
+  
+        // Replace `$destroy()` with `unmount(appVarName)`
+        j(path).replaceWith(
+          j.callExpression(j.identifier("unmount"), [j.identifier(appVarName)])
+        );
+      });
+  
+      // Find and replace $on method calls with events property
+      root.find(j.CallExpression, {
+        callee: {
+          type: "MemberExpression",
+          property: {
+            type: "Identifier",
+            name: "$on",
+          },
+        },
+      }).forEach((path) => {
+        const componentName = path.node.callee.object.name;
+        const eventName = path.node.arguments[0];
+        const callback = path.node.arguments[1];
+  
+        // Add events property to the mount options
+        root.find(j.CallExpression, {
+          callee: {
+            type: "Identifier",
+            name: "mount",
+          },
+        }).forEach((mountPath) => {
+          const optionsArg = mountPath.node.arguments[1];
+          if (optionsArg && optionsArg.type === "ObjectExpression") {
+            const eventsProperty = optionsArg.properties.find(
+              (prop) => prop.key.name === "events"
+            );
+            if (eventsProperty) {
+              eventsProperty.value.properties.push(
+                j.property("init", eventName, callback)
+              );
+            } else {
+              optionsArg.properties.push(
+                j.property(
+                  "init",
+                  j.identifier("events"),
+                  j.objectExpression([
+                    j.property("init", eventName, callback),
+                  ])
+                )
+              );
+            }
+          }
+        });
+  
+        // Remove the $on call
+        j(path).remove();
+      });
+  
+      return root.toSource();
     }
-
+  
+    // Handle JavaScript inside <script> tags and directly in JavaScript files
+    if (file.path.endsWith(".svelte")) {
+      transformedSource = transformedSource.replace(
+        scriptTagRegex,
+        (match, openingTag, scriptContent, closingTag) => {
+          scriptFound = true;
+          // Transform the extracted JavaScript content from <script> tags
+          const transformedScriptContent = transformCode(scriptContent);
+          // Replace the original <script> content with the transformed content, preserving the original opening tag
+          return `${openingTag}\n${transformedScriptContent}\n${closingTag}`;
+        }
+      );
+  
+      // If no <script> tags were found, assume it's a script-less Svelte file
+      if (!scriptFound) {
+        transformedSource = transformCode(source);
+      }
+    } else {
+      // Directly transform JavaScript files
+      transformedSource = transformCode(source);
+    }
+  
     return transformedSource;
-}
+  }
+  

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/tsconfig.json
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES6",
+    "allowJs": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/svelte/5/components-as-functions-destroyfunction/vitest.config.ts
+++ b/packages/codemods/svelte/5/components-as-functions-destroyfunction/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, "**/test/*.ts"],
+  },
+});

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/.codemodrc.json
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/.codemodrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "version": "1.0.2",
+  "private": false,
+  "name": "svelte/5/components-as-functions-onfunction",
+  "engine": "jscodeshift",
+  "applicability": {
+    "from": [["svelte", ">=", "4.0.0"], ["svelte", "<", "5.0.0"]],
+    "to": [["svelte", ">=", "5.0.0"]]
+  },
+  "meta": {
+    "tags": ["svelte", "5", "migration"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/svelte/5/components-as-functions-onfunction"
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue", "**/*.svelte"]
+}

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/.gitignore
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/LICENSE
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Codemod Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/README.md
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/README.md
@@ -1,0 +1,28 @@
+This codemod updates Svelte component instantiation and event handling for Svelte 5:
+
+- Converts `new Component({ target })` to `mount(Component, { target })`.
+- Adds the `mount` import from `svelte` if not present.
+- Replaces `$on` method calls with the `events` property in the mount options.
+
+This ensures compatibility with Svelte 5's function-based components and new event handling.
+
+## Before
+
+```jsx
+import App from './App.svelte';
+
+const app = new App({ target: document.getElementById('app') });
+app.$on('event', callback);
+```
+
+## After
+
+```jsx
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, {
+    target: document.getElementById('app'),
+    events: { event: callback },
+});
+```

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,4 @@
+import App from './App.svelte';
+
+const app = new App({ target: document.getElementById('app') });
+app.$on('event', callback);

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,7 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, {
+    target: document.getElementById('app'),
+    events: { event: callback },
+});

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/package.json
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@codemod/svelte-5-components-as-functions-onfunction",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10",
+    "vitest": "^1.0.1",
+    "@vitest/coverage-v8": "^1.0.1"
+  },
+  "scripts": {},
+  "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],
+  "type": "module"
+}

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/src/index.ts
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/src/index.ts
@@ -1,153 +1,148 @@
 import type {
-  API,
-  ArrowFunctionExpression,
-  FileInfo,
-  Options,
-} from "jscodeshift";
-
-export default function transform(
+    API,
+    ArrowFunctionExpression,
+    FileInfo,
+    Options,
+  } from "jscodeshift";
+  
+  export default function transform(
     file: FileInfo,
     api: API,
     options?: Options,
   ): string | undefined {
     const j = api.jscodeshift;
     const source = file.source;
-
-    // Regular expression to find the content inside <script> tags
-    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
-
+  
+    // Regular expression to find the content inside <script> tags and capture the entire opening tag
+    const scriptTagRegex = /(<script[^>]*>)([\s\S]*?)(<\/script>)/gm;
+  
     // Variable to hold the transformed source
     let transformedSource = source;
     let scriptFound = false;
-
+  
     // Function to perform the transformation logic
     function transformCode(code) {
-        const root = j(code);
-
-        // Add 'mount' import if it's not present
-        function addMountImport() {
-            const svelteImport = root.find(j.ImportDeclaration, {
-                source: { value: 'svelte' },
-            });
-
-            if (svelteImport.length > 0) {
-                const mountSpecifier = svelteImport
-                    .find(j.ImportSpecifier)
-                    .filter(
-                        (specifier) => specifier.node.imported.name === 'mount',
-                    );
-
-                if (mountSpecifier.length === 0) {
-                    svelteImport
-                        .get(0)
-                        .node.specifiers.push(
-                            j.importSpecifier(j.identifier('mount')),
-                        );
-                }
-            } else {
-                const importStatement = j.importDeclaration(
-                    [j.importSpecifier(j.identifier('mount'))],
-                    j.literal('svelte'),
-                );
-                root.find(j.ImportDeclaration)
-                    .at(0)
-                    .insertBefore(importStatement);
-            }
+      const root = j(code);
+  
+      // Add 'mount' import if it's not present
+      function addMountImport() {
+        const svelteImport = root.find(j.ImportDeclaration, {
+          source: { value: "svelte" },
+        });
+  
+        if (svelteImport.length > 0) {
+          const mountSpecifier = svelteImport
+            .find(j.ImportSpecifier)
+            .filter((specifier) => specifier.node.imported.name === "mount");
+  
+          if (mountSpecifier.length === 0) {
+            svelteImport
+              .get(0)
+              .node.specifiers.push(j.importSpecifier(j.identifier("mount")));
+          }
+        } else {
+          const importStatement = j.importDeclaration(
+            [j.importSpecifier(j.identifier("mount"))],
+            j.literal("svelte")
+          );
+          root.find(j.ImportDeclaration).at(0).insertBefore(importStatement);
         }
-
-        // Find instantiations of Svelte components and replace them
-        root.find(j.NewExpression, {
-            callee: {
-                type: 'Identifier',
-            },
-        }).forEach((path) => {
-            const componentName = path.node.callee.name;
-
-            // Check if the instantiation is for a Svelte component (imported from .svelte)
-            const importDeclaration = root.find(j.ImportDeclaration, {
-                specifiers: [{ local: { name: componentName } }],
-                source: { value: (val) => val.endsWith('.svelte') },
-            });
-
-            if (importDeclaration.length > 0) {
-                // Replace `new Component({ target })` with `mount(Component, { target })`
-                j(path).replaceWith(
-                    j.callExpression(j.identifier('mount'), [
-                        j.identifier(componentName),
-                        ...path.node.arguments,
-                    ]),
-                );
-                addMountImport();
-            }
+      }
+  
+      // Find instantiations of Svelte components and replace them
+      root.find(j.NewExpression, {
+        callee: {
+          type: "Identifier",
+        },
+      }).forEach((path) => {
+        const componentName = path.node.callee.name;
+  
+        // Check if the instantiation is for a Svelte component (imported from .svelte)
+        const importDeclaration = root.find(j.ImportDeclaration, {
+          specifiers: [{ local: { name: componentName } }],
+          source: { value: (val) => val.endsWith(".svelte") },
         });
-
-        // Find and replace $on method calls with events property
+  
+        if (importDeclaration.length > 0) {
+          // Replace `new Component({ target })` with `mount(Component, { target })`
+          j(path).replaceWith(
+            j.callExpression(j.identifier("mount"), [
+              j.identifier(componentName),
+              ...path.node.arguments,
+            ])
+          );
+          addMountImport();
+        }
+      });
+  
+      // Find and replace $on method calls with events property
+      root.find(j.CallExpression, {
+        callee: {
+          type: "MemberExpression",
+          property: {
+            type: "Identifier",
+            name: "$on",
+          },
+        },
+      }).forEach((path) => {
+        const componentName = path.node.callee.object.name;
+        const eventName = path.node.arguments[0];
+        const callback = path.node.arguments[1];
+  
+        // Add events property to the mount options
         root.find(j.CallExpression, {
-            callee: {
-                type: 'MemberExpression',
-                property: {
-                    type: 'Identifier',
-                    name: '$on',
-                },
-            },
-        }).forEach((path) => {
-            const componentName = path.node.callee.object.name;
-            const eventName = path.node.arguments[0];
-            const callback = path.node.arguments[1];
-
-            // Add events property to the mount options
-            root.find(j.CallExpression, {
-                callee: {
-                    type: 'Identifier',
-                    name: 'mount',
-                },
-            }).forEach((mountPath) => {
-                const optionsArg = mountPath.node.arguments[1];
-                if (optionsArg && optionsArg.type === 'ObjectExpression') {
-                    const eventsProperty = optionsArg.properties.find(
-                        (prop) => prop.key.name === 'events',
-                    );
-                    if (eventsProperty) {
-                        eventsProperty.value.properties.push(
-                            j.property('init', eventName, callback),
-                        );
-                    } else {
-                        optionsArg.properties.push(
-                            j.property(
-                                'init',
-                                j.identifier('events'),
-                                j.objectExpression([
-                                    j.property('init', eventName, callback),
-                                ]),
-                            ),
-                        );
-                    }
-                }
-            });
-
-            // Remove the $on call
-            j(path).remove();
+          callee: {
+            type: "Identifier",
+            name: "mount",
+          },
+        }).forEach((mountPath) => {
+          const optionsArg = mountPath.node.arguments[1];
+          if (optionsArg && optionsArg.type === "ObjectExpression") {
+            const eventsProperty = optionsArg.properties.find(
+              (prop) => prop.key.name === "events"
+            );
+            if (eventsProperty) {
+              eventsProperty.value.properties.push(
+                j.property("init", eventName, callback)
+              );
+            } else {
+              optionsArg.properties.push(
+                j.property(
+                  "init",
+                  j.identifier("events"),
+                  j.objectExpression([
+                    j.property("init", eventName, callback),
+                  ])
+                )
+              );
+            }
+          }
         });
-
-        return root.toSource();
+  
+        // Remove the $on call
+        j(path).remove();
+      });
+  
+      return root.toSource();
     }
-
+  
     // First, handle the case with <script> tags
     transformedSource = transformedSource.replace(
-        scriptTagRegex,
-        (match, scriptContent) => {
-            scriptFound = true;
-            // Transform the extracted JavaScript content from <script> tags
-            const transformedScriptContent = transformCode(scriptContent);
-            // Replace the original <script> content with the transformed content
-            return `<script>\n${transformedScriptContent}\n</script>`;
-        },
+      scriptTagRegex,
+      (match, openingTag, scriptContent, closingTag) => {
+        scriptFound = true;
+        // Transform the extracted JavaScript content from <script> tags
+        const transformedScriptContent = transformCode(scriptContent);
+        // Replace the original <script> content with the transformed content, preserving the original opening tag
+        return `${openingTag}\n${transformedScriptContent}\n${closingTag}`;
+      }
     );
-
+  
     // If no <script> tags were found, assume the code is JavaScript directly in the .svelte file
     if (!scriptFound) {
-        transformedSource = transformCode(source);
+      transformedSource = transformCode(source);
     }
-
+  
     return transformedSource;
-}
+  }
+  

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/src/index.ts
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/src/index.ts
@@ -1,0 +1,153 @@
+import type {
+  API,
+  ArrowFunctionExpression,
+  FileInfo,
+  Options,
+} from "jscodeshift";
+
+export default function transform(
+    file: FileInfo,
+    api: API,
+    options?: Options,
+  ): string | undefined {
+    const j = api.jscodeshift;
+    const source = file.source;
+
+    // Regular expression to find the content inside <script> tags
+    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
+
+    // Variable to hold the transformed source
+    let transformedSource = source;
+    let scriptFound = false;
+
+    // Function to perform the transformation logic
+    function transformCode(code) {
+        const root = j(code);
+
+        // Add 'mount' import if it's not present
+        function addMountImport() {
+            const svelteImport = root.find(j.ImportDeclaration, {
+                source: { value: 'svelte' },
+            });
+
+            if (svelteImport.length > 0) {
+                const mountSpecifier = svelteImport
+                    .find(j.ImportSpecifier)
+                    .filter(
+                        (specifier) => specifier.node.imported.name === 'mount',
+                    );
+
+                if (mountSpecifier.length === 0) {
+                    svelteImport
+                        .get(0)
+                        .node.specifiers.push(
+                            j.importSpecifier(j.identifier('mount')),
+                        );
+                }
+            } else {
+                const importStatement = j.importDeclaration(
+                    [j.importSpecifier(j.identifier('mount'))],
+                    j.literal('svelte'),
+                );
+                root.find(j.ImportDeclaration)
+                    .at(0)
+                    .insertBefore(importStatement);
+            }
+        }
+
+        // Find instantiations of Svelte components and replace them
+        root.find(j.NewExpression, {
+            callee: {
+                type: 'Identifier',
+            },
+        }).forEach((path) => {
+            const componentName = path.node.callee.name;
+
+            // Check if the instantiation is for a Svelte component (imported from .svelte)
+            const importDeclaration = root.find(j.ImportDeclaration, {
+                specifiers: [{ local: { name: componentName } }],
+                source: { value: (val) => val.endsWith('.svelte') },
+            });
+
+            if (importDeclaration.length > 0) {
+                // Replace `new Component({ target })` with `mount(Component, { target })`
+                j(path).replaceWith(
+                    j.callExpression(j.identifier('mount'), [
+                        j.identifier(componentName),
+                        ...path.node.arguments,
+                    ]),
+                );
+                addMountImport();
+            }
+        });
+
+        // Find and replace $on method calls with events property
+        root.find(j.CallExpression, {
+            callee: {
+                type: 'MemberExpression',
+                property: {
+                    type: 'Identifier',
+                    name: '$on',
+                },
+            },
+        }).forEach((path) => {
+            const componentName = path.node.callee.object.name;
+            const eventName = path.node.arguments[0];
+            const callback = path.node.arguments[1];
+
+            // Add events property to the mount options
+            root.find(j.CallExpression, {
+                callee: {
+                    type: 'Identifier',
+                    name: 'mount',
+                },
+            }).forEach((mountPath) => {
+                const optionsArg = mountPath.node.arguments[1];
+                if (optionsArg && optionsArg.type === 'ObjectExpression') {
+                    const eventsProperty = optionsArg.properties.find(
+                        (prop) => prop.key.name === 'events',
+                    );
+                    if (eventsProperty) {
+                        eventsProperty.value.properties.push(
+                            j.property('init', eventName, callback),
+                        );
+                    } else {
+                        optionsArg.properties.push(
+                            j.property(
+                                'init',
+                                j.identifier('events'),
+                                j.objectExpression([
+                                    j.property('init', eventName, callback),
+                                ]),
+                            ),
+                        );
+                    }
+                }
+            });
+
+            // Remove the $on call
+            j(path).remove();
+        });
+
+        return root.toSource();
+    }
+
+    // First, handle the case with <script> tags
+    transformedSource = transformedSource.replace(
+        scriptTagRegex,
+        (match, scriptContent) => {
+            scriptFound = true;
+            // Transform the extracted JavaScript content from <script> tags
+            const transformedScriptContent = transformCode(scriptContent);
+            // Replace the original <script> content with the transformed content
+            return `<script>\n${transformedScriptContent}\n</script>`;
+        },
+    );
+
+    // If no <script> tags were found, assume the code is JavaScript directly in the .svelte file
+    if (!scriptFound) {
+        transformedSource = transformCode(source);
+    }
+
+    return transformedSource;
+}

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/tsconfig.json
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES6",
+    "allowJs": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/svelte/5/components-as-functions-onfunction/vitest.config.ts
+++ b/packages/codemods/svelte/5/components-as-functions-onfunction/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, "**/test/*.ts"],
+  },
+});

--- a/packages/codemods/svelte/5/components-as-functions/.codemodrc.json
+++ b/packages/codemods/svelte/5/components-as-functions/.codemodrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "version": "1.0.2",
+  "private": false,
+  "name": "svelte/5/components-as-functions",
+  "engine": "jscodeshift",
+  "applicability": {
+    "from": [["svelte", ">=", "4.0.0"], ["svelte", "<", "5.0.0"]],
+    "to": [["svelte", ">=", "5.0.0"]]
+  },
+  "meta": {
+    "tags": ["svelte", "5", "migration"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/svelte/5/components-as-functions"
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue", "**/*.svelte"]
+}

--- a/packages/codemods/svelte/5/components-as-functions/.gitignore
+++ b/packages/codemods/svelte/5/components-as-functions/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/svelte/5/components-as-functions/LICENSE
+++ b/packages/codemods/svelte/5/components-as-functions/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Codemod Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/svelte/5/components-as-functions/README.md
+++ b/packages/codemods/svelte/5/components-as-functions/README.md
@@ -1,0 +1,25 @@
+In Svelte 3 and 4, components were classes, while in Svelte 5, components are functions. This codemod updates the instantiation of Svelte components to use `mount` or `hydrate` (imported from svelte), ensuring compatibility with Svelte 5's new functional component model.
+
+## Before
+
+```jsx
+import App from './App.svelte';
+
+const app = new App({ target: document.getElementById('app') });
+
+export default app;
+
+```
+
+## After
+
+```jsx
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, { target: document.getElementById('app') });
+
+export default app;
+
+
+```

--- a/packages/codemods/svelte/5/components-as-functions/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/svelte/5/components-as-functions/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,5 @@
+import App from './App.svelte';
+
+const app = new App({ target: document.getElementById('app') });
+
+export default app;

--- a/packages/codemods/svelte/5/components-as-functions/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/svelte/5/components-as-functions/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,6 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+const app = mount(App, { target: document.getElementById('app') });
+
+export default app;

--- a/packages/codemods/svelte/5/components-as-functions/package.json
+++ b/packages/codemods/svelte/5/components-as-functions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@codemod/svelte-5-components-as-functions",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10",
+    "vitest": "^1.0.1",
+    "@vitest/coverage-v8": "^1.0.1"
+  },
+  "scripts": {},
+  "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],
+  "type": "module"
+}

--- a/packages/codemods/svelte/5/components-as-functions/src/index.ts
+++ b/packages/codemods/svelte/5/components-as-functions/src/index.ts
@@ -1,20 +1,20 @@
 import type {
-  API,
-  ArrowFunctionExpression,
-  FileInfo,
-  Options,
-} from "jscodeshift";
+    API,
+    ArrowFunctionExpression,
+    FileInfo,
+    Options,
+} from 'jscodeshift';
 
 export default function transform(
     file: FileInfo,
     api: API,
     options?: Options,
-  ): string | undefined {
+): string | undefined {
     const j = api.jscodeshift;
     const source = file.source;
 
-    // Regular expression to find the content inside <script> tags
-    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
+    // Regular expression to find the content inside <script> tags and capture the entire opening tag
+    const scriptTagRegex = /(<script[^>]*>)([\s\S]*?)(<\/script>)/gm;
 
     // Variable to hold the transformed source
     let transformedSource = source;
@@ -88,12 +88,12 @@ export default function transform(
     // First, handle the case with <script> tags
     transformedSource = transformedSource.replace(
         scriptTagRegex,
-        (match, scriptContent) => {
+        (match, openingTag, scriptContent, closingTag) => {
             scriptFound = true;
             // Transform the extracted JavaScript content from <script> tags
             const transformedScriptContent = transformCode(scriptContent);
-            // Replace the original <script> content with the transformed content
-            return `<script>\n${transformedScriptContent}\n</script>`;
+            // Replace the original <script> content with the transformed content, preserving the original opening tag
+            return `${openingTag}\n${transformedScriptContent}\n${closingTag}`;
         },
     );
 

--- a/packages/codemods/svelte/5/components-as-functions/src/index.ts
+++ b/packages/codemods/svelte/5/components-as-functions/src/index.ts
@@ -1,0 +1,106 @@
+import type {
+  API,
+  ArrowFunctionExpression,
+  FileInfo,
+  Options,
+} from "jscodeshift";
+
+export default function transform(
+    file: FileInfo,
+    api: API,
+    options?: Options,
+  ): string | undefined {
+    const j = api.jscodeshift;
+    const source = file.source;
+
+    // Regular expression to find the content inside <script> tags
+    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
+
+    // Variable to hold the transformed source
+    let transformedSource = source;
+    let scriptFound = false;
+
+    // Function to perform the transformation logic
+    function transformCode(code) {
+        const root = j(code);
+
+        // Function to add 'mount' import from 'svelte'
+        function addMountImport() {
+            const svelteImport = root.find(j.ImportDeclaration, {
+                source: { value: 'svelte' },
+            });
+
+            if (svelteImport.length > 0) {
+                const mountSpecifier = svelteImport
+                    .find(j.ImportSpecifier)
+                    .filter(
+                        (specifier) => specifier.node.imported.name === 'mount',
+                    );
+
+                if (mountSpecifier.length === 0) {
+                    svelteImport
+                        .get(0)
+                        .node.specifiers.push(
+                            j.importSpecifier(j.identifier('mount')),
+                        );
+                }
+            } else {
+                const importStatement = j.importDeclaration(
+                    [j.importSpecifier(j.identifier('mount'))],
+                    j.literal('svelte'),
+                );
+                root.find(j.ImportDeclaration)
+                    .at(0)
+                    .insertBefore(importStatement);
+            }
+        }
+
+        // Find instantiations of Svelte components and replace them
+        root.find(j.NewExpression, {
+            callee: {
+                type: 'Identifier',
+            },
+        }).forEach((path) => {
+            const componentName = path.node.callee.name;
+
+            // Check if the instantiation is for a Svelte component (imported from .svelte)
+            const importDeclaration = root.find(j.ImportDeclaration, {
+                specifiers: [{ local: { name: componentName } }],
+                source: { value: (val) => val.endsWith('.svelte') },
+            });
+
+            if (importDeclaration.length > 0) {
+                // Replace `new Component({ target })` with `mount(Component, { target })`
+                j(path).replaceWith(
+                    j.callExpression(j.identifier('mount'), [
+                        j.identifier(componentName),
+                        ...path.node.arguments,
+                    ]),
+                );
+                addMountImport();
+            }
+        });
+
+        // Return the transformed code
+        return root.toSource();
+    }
+
+    // First, handle the case with <script> tags
+    transformedSource = transformedSource.replace(
+        scriptTagRegex,
+        (match, scriptContent) => {
+            scriptFound = true;
+            // Transform the extracted JavaScript content from <script> tags
+            const transformedScriptContent = transformCode(scriptContent);
+            // Replace the original <script> content with the transformed content
+            return `<script>\n${transformedScriptContent}\n</script>`;
+        },
+    );
+
+    // If no <script> tags were found, assume the code is JavaScript directly in the .svelte file
+    if (!scriptFound) {
+        transformedSource = transformCode(source);
+    }
+
+    return transformedSource;
+}

--- a/packages/codemods/svelte/5/components-as-functions/tsconfig.json
+++ b/packages/codemods/svelte/5/components-as-functions/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES6",
+    "allowJs": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/svelte/5/components-as-functions/vitest.config.ts
+++ b/packages/codemods/svelte/5/components-as-functions/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, "**/test/*.ts"],
+  },
+});

--- a/packages/codemods/svelte/5/is-where-scoping/.codemodrc.json
+++ b/packages/codemods/svelte/5/is-where-scoping/.codemodrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "version": "1.0.2",
+  "private": false,
+  "name": "svelte/5/is-where-scoping",
+  "engine": "jscodeshift",
+  "applicability": {
+    "from": [["svelte", ">=", "4.0.0"], ["svelte", "<", "5.0.0"]],
+    "to": [["svelte", ">=", "5.0.0"]]
+  },
+  "meta": {
+    "tags": ["svelte", "5", "migration"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/svelte/5/is-where-scoping"
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue", "**/*.svelte"]
+}

--- a/packages/codemods/svelte/5/is-where-scoping/.gitignore
+++ b/packages/codemods/svelte/5/is-where-scoping/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/svelte/5/is-where-scoping/LICENSE
+++ b/packages/codemods/svelte/5/is-where-scoping/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Codemod Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/svelte/5/is-where-scoping/README.md
+++ b/packages/codemods/svelte/5/is-where-scoping/README.md
@@ -1,0 +1,22 @@
+This codemod updates CSS handling in your project:
+
+- Transforms Tailwind `@apply` directives and CSS selectors by adding `:global()` inside `:is(...)` and `:where(...)` selectors.
+- Applies changes to CSS within `<style>` tags in Svelte files.
+- Ensures global scope is properly applied to Tailwind utilities and complex selectors.
+
+
+## Before
+
+```jsx
+main {
+	@apply bg-blue-100 dark:bg-blue-900;
+}
+```
+
+## After
+
+```jsx
+main :global {
+	@apply bg-blue-100 dark:bg-blue-900
+}
+```

--- a/packages/codemods/svelte/5/is-where-scoping/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/svelte/5/is-where-scoping/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,3 @@
+main {
+	@apply bg-blue-100 dark:bg-blue-900;
+}

--- a/packages/codemods/svelte/5/is-where-scoping/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/svelte/5/is-where-scoping/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,3 @@
+main :global {
+	@apply bg-blue-100 dark:bg-blue-900
+}

--- a/packages/codemods/svelte/5/is-where-scoping/package.json
+++ b/packages/codemods/svelte/5/is-where-scoping/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@codemod/svelte-5-is-where-scoping",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10",
+    "vitest": "^1.0.1",
+    "@vitest/coverage-v8": "^1.0.1"
+  },
+  "scripts": {},
+  "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],
+  "type": "module"
+}

--- a/packages/codemods/svelte/5/is-where-scoping/src/index.ts
+++ b/packages/codemods/svelte/5/is-where-scoping/src/index.ts
@@ -13,8 +13,8 @@ export default function transform(
     const j = api.jscodeshift;
     const source = file.source;
 
-    // Regular expression to find content inside <style> tags
-    const styleTagRegex = /<style[^>]*>([\s\S]*?)<\/style>/gm;
+    // Regular expression to find content inside <style> tags and capture the entire opening tag
+    const styleTagRegex = /(<style[^>]*>)([\s\S]*?)(<\/style>)/gm;
 
     // Function to perform the transformation logic
     function transformCss(css) {
@@ -67,11 +67,11 @@ export default function transform(
         // Process CSS inside <style> tags
         const transformedSource = source.replace(
             styleTagRegex,
-            (match, styleContent) => {
+            (match, openingTag, styleContent, closingTag) => {
                 // Transform the extracted CSS content from <style> tags
                 const transformedStyleContent = transformCss(styleContent);
-                // Replace the original <style> content with the transformed content
-                return `<style>\n${transformedStyleContent}\n</style>`;
+                // Replace the original <style> content with the transformed content, preserving the original opening tag
+                return `${openingTag}\n${transformedStyleContent}\n${closingTag}`;
             },
         );
 

--- a/packages/codemods/svelte/5/is-where-scoping/src/index.ts
+++ b/packages/codemods/svelte/5/is-where-scoping/src/index.ts
@@ -1,0 +1,83 @@
+import type {
+    API,
+    ArrowFunctionExpression,
+    FileInfo,
+    Options,
+} from 'jscodeshift';
+
+export default function transform(
+    file: FileInfo,
+    api: API,
+    options?: Options,
+): string | undefined {
+    const j = api.jscodeshift;
+    const source = file.source;
+
+    // Regular expression to find content inside <style> tags
+    const styleTagRegex = /<style[^>]*>([\s\S]*?)<\/style>/gm;
+
+    // Function to perform the transformation logic
+    function transformCss(css) {
+        // Helper function to add :global(...) inside :is(...) or :where(...) selectors
+        const addGlobalInside = (selector) => {
+            return selector.replace(
+                /:is\(([^)]+)\)|:where\(([^)]+)\)/g,
+                (match, p1, p2) => {
+                    const innerSelector = p1 || p2; // Capture inside of :is(...) or :where(...)
+                    return match.replace(
+                        innerSelector,
+                        `:global(${innerSelector})`,
+                    );
+                },
+            );
+        };
+
+        // Regular expression to match Tailwind @apply directives
+        const applyDirectiveRegex = /([^{]*?)\s*\{\s*@apply\s+([^;]+);?\s*}/g;
+
+        // Transform :is(...) and :where(...) selectors by adding :global inside
+        let transformedCss = css.replace(
+            /:is\([^)]*\)|:where\([^)]*\)/g,
+            (match) => addGlobalInside(match),
+        );
+
+        // Transform Tailwind @apply directives by adding :global to the selector only if it does not already contain :global
+        transformedCss = transformedCss.replace(
+            applyDirectiveRegex,
+            (match, selector, content) => {
+                const trimmedSelector = selector.trim();
+
+                // Check if the selector is already wrapped in :global or contains :is(...) or :where(...)
+                if (
+                    !trimmedSelector.includes(':global') &&
+                    !/(:is\([^)]*\)|:where\([^)]*\))/.test(trimmedSelector)
+                ) {
+                    return `${trimmedSelector} :global {\n  @apply ${content.trim()};\n}`;
+                }
+
+                return match; // Return the original match if already globalized or contains :is(...) or :where(...)
+            },
+        );
+
+        return transformedCss;
+    }
+
+    // Handle CSS inside <style> tags and directly in CSS files
+    if (file.path.endsWith('.svelte')) {
+        // Process CSS inside <style> tags
+        const transformedSource = source.replace(
+            styleTagRegex,
+            (match, styleContent) => {
+                // Transform the extracted CSS content from <style> tags
+                const transformedStyleContent = transformCss(styleContent);
+                // Replace the original <style> content with the transformed content
+                return `<style>\n${transformedStyleContent}\n</style>`;
+            },
+        );
+
+        return transformedSource;
+    } else {
+        // Process CSS directly
+        return transformCss(source);
+    }
+}

--- a/packages/codemods/svelte/5/is-where-scoping/tsconfig.json
+++ b/packages/codemods/svelte/5/is-where-scoping/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES6",
+    "allowJs": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/svelte/5/is-where-scoping/vitest.config.ts
+++ b/packages/codemods/svelte/5/is-where-scoping/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, "**/test/*.ts"],
+  },
+});

--- a/packages/codemods/svelte/5/migration-recipe/.codemodrc.json
+++ b/packages/codemods/svelte/5/migration-recipe/.codemodrc.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "name": "svelte/5/migration-recipe",
+  "version": "1.0.4",
+  "private": false,
+  "engine": "recipe",
+  "names": [
+    "svelte/5/components-as-functions",
+    "svelte/5/components-as-functions-destroyfunction",
+    "svelte/5/components-as-functions-onfunction",
+    "svelte/5/is-where-scoping",
+    "svelte/5/server-api-changes",
+    "svelte/5/svelte-element-expression"
+  ],
+  "meta": {
+    "tags": ["migration", "svelte"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/svelte/5/migration-recipe"
+  },
+  "applicability": {
+    "from": [["svelte", ">=", "4.0.0"], ["svelte", "<", "5.0.0"]],
+    "to": [["svelte", ">=", "5.0.0"]]
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue", "**/*.svelte"]
+}

--- a/packages/codemods/svelte/5/migration-recipe/README.md
+++ b/packages/codemods/svelte/5/migration-recipe/README.md
@@ -1,0 +1,10 @@
+This recipe is a set of codemods that will help migrate to Svelte 5.  
+
+The recipe includes the following codemods:
+
+- svelte/5/components-as-functions
+- svelte/5/components-as-functions-destroyfunction
+- svelte/5/components-as-functions-onfunction
+- svelte/5/is-where-scoping
+- svelte/5/server-api-changes
+- svelte/5/svelte-element-expression

--- a/packages/codemods/svelte/5/migration-recipe/package.json
+++ b/packages/codemods/svelte/5/migration-recipe/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@codemod/svelte-5-migration-recipe",
+  "files": ["./README.md", "./.codemodrc.json"],
+  "type": "module",
+  "private": true
+}

--- a/packages/codemods/svelte/5/server-api-changes/.codemodrc.json
+++ b/packages/codemods/svelte/5/server-api-changes/.codemodrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "version": "1.0.2",
+  "private": false,
+  "name": "svelte/5/server-api-changes",
+  "engine": "jscodeshift",
+  "applicability": {
+    "from": [["svelte", ">=", "4.0.0"], ["svelte", "<", "5.0.0"]],
+    "to": [["svelte", ">=", "5.0.0"]]
+  },
+  "meta": {
+    "tags": ["svelte", "5", "migration"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/svelte/5/server-api-changes"
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue", "**/*.svelte"]
+}

--- a/packages/codemods/svelte/5/server-api-changes/.gitignore
+++ b/packages/codemods/svelte/5/server-api-changes/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/svelte/5/server-api-changes/LICENSE
+++ b/packages/codemods/svelte/5/server-api-changes/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Codemod Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/svelte/5/server-api-changes/README.md
+++ b/packages/codemods/svelte/5/server-api-changes/README.md
@@ -1,0 +1,24 @@
+This codemod updates Svelte component rendering:
+
+- Converts calls to `Component.render({...})` to `render(Component, { props })`.
+- Ensures the import statement `import { render } from 'svelte/server'` is added if render is used.
+
+
+## Before
+
+```jsx
+import App from './App.svelte';
+
+const { html, head } = App.render({ message: 'hello' });
+```
+
+## After
+
+```jsx
+import { render } from 'svelte/server';
+import App from './App.svelte';
+
+const { html, head } = render(App, {
+    props: { message: 'hello' },
+});
+```

--- a/packages/codemods/svelte/5/server-api-changes/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/svelte/5/server-api-changes/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,3 @@
+import App from './App.svelte';
+
+const { html, head } = App.render({ message: 'hello' });

--- a/packages/codemods/svelte/5/server-api-changes/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/svelte/5/server-api-changes/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,6 @@
+import { render } from 'svelte/server';
+import App from './App.svelte';
+
+const { html, head } = render(App, {
+    props: { message: 'hello' },
+});

--- a/packages/codemods/svelte/5/server-api-changes/package.json
+++ b/packages/codemods/svelte/5/server-api-changes/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@codemod/svelte-5-server-api-changes",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10",
+    "vitest": "^1.0.1",
+    "@vitest/coverage-v8": "^1.0.1"
+  },
+  "scripts": {},
+  "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],
+  "type": "module"
+}

--- a/packages/codemods/svelte/5/server-api-changes/src/index.ts
+++ b/packages/codemods/svelte/5/server-api-changes/src/index.ts
@@ -1,116 +1,113 @@
 import type {
-  API,
-  ArrowFunctionExpression,
-  FileInfo,
-  Options,
-} from "jscodeshift";
-
-export default function transform(
+    API,
+    ArrowFunctionExpression,
+    FileInfo,
+    Options,
+  } from "jscodeshift";
+  
+  export default function transform(
     file: FileInfo,
     api: API,
     options?: Options,
   ): string | undefined {
     const j = api.jscodeshift;
     const source = file.source;
-
-    // Regular expression to find content inside <script> tags
-    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
-
+  
+    // Regular expression to find content inside <script> tags and capture the entire opening tag
+    const scriptTagRegex = /(<script[^>]*>)([\s\S]*?)(<\/script>)/gm;
+  
     // Variable to hold the transformed source
     let transformedSource = source;
     let scriptFound = false;
-
+  
     // Function to perform the transformation logic
     function transformCode(code) {
-        const root = j(code);
-
-        let needsRenderImport = false;
-
-        // Find any calls to Component.render({...})
-        root.find(j.CallExpression, {
-            callee: {
-                property: { name: 'render' },
-            },
-        }).forEach((renderPath) => {
-            const componentName = renderPath.node.callee.object.name;
-
-            // Replace with `render(Component, { props })`
-            j(renderPath).replaceWith(
-                j.callExpression(j.identifier('render'), [
-                    j.identifier(componentName),
-                    j.objectExpression([
-                        j.property(
-                            'init',
-                            j.identifier('props'),
-                            renderPath.node.arguments[0],
-                        ),
-                    ]),
-                ]),
-            );
-
-            // Mark that we need to add `import { render } from 'svelte/server'`
-            needsRenderImport = true;
-        });
-
-        // If `render` was used, ensure the import is added
-        if (needsRenderImport) {
-            const hasRenderImport = root
-                .find(j.ImportDeclaration, {
-                    source: { value: 'svelte/server' },
-                })
-                .some((path) =>
-                    path.node.specifiers.some(
-                        (specifier) => specifier.imported.name === 'render',
-                    ),
-                );
-
-            // If not already imported, add the import statement
-            if (!hasRenderImport) {
-                const firstImport = root.find(j.ImportDeclaration).at(0);
-
-                if (firstImport.size()) {
-                    firstImport.insertBefore(
-                        j.importDeclaration(
-                            [j.importSpecifier(j.identifier('render'))],
-                            j.literal('svelte/server'),
-                        ),
-                    );
-                } else {
-                    // If no import statements, just insert at the top
-                    root.get().node.program.body.unshift(
-                        j.importDeclaration(
-                            [j.importSpecifier(j.identifier('render'))],
-                            j.literal('svelte/server'),
-                        ),
-                    );
-                }
-            }
-        }
-
-        return root.toSource();
-    }
-
-    // Handle JavaScript inside <script> tags and directly in JavaScript files
-    if (file.path.endsWith('.svelte')) {
-        transformedSource = transformedSource.replace(
-            scriptTagRegex,
-            (match, scriptContent) => {
-                scriptFound = true;
-                // Transform the extracted JavaScript content from <script> tags
-                const transformedScriptContent = transformCode(scriptContent);
-                // Replace the original <script> content with the transformed content
-                return `<script>\n${transformedScriptContent}\n</script>`;
-            },
+      const root = j(code);
+  
+      let needsRenderImport = false;
+  
+      // Find any calls to Component.render({...})
+      root.find(j.CallExpression, {
+        callee: {
+          property: { name: "render" },
+        },
+      }).forEach((renderPath) => {
+        const componentName = renderPath.node.callee.object.name;
+  
+        // Replace with `render(Component, { props })`
+        j(renderPath).replaceWith(
+          j.callExpression(j.identifier("render"), [
+            j.identifier(componentName),
+            j.objectExpression([
+              j.property("init", j.identifier("props"), renderPath.node.arguments[0]),
+            ]),
+          ])
         );
-
-        // If no <script> tags were found, assume it's a script-less Svelte file
-        if (!scriptFound) {
-            transformedSource = transformCode(source);
+  
+        // Mark that we need to add `import { render } from 'svelte/server'`
+        needsRenderImport = true;
+      });
+  
+      // If `render` was used, ensure the import is added
+      if (needsRenderImport) {
+        const hasRenderImport = root
+          .find(j.ImportDeclaration, {
+            source: { value: "svelte/server" },
+          })
+          .some((path) =>
+            path.node.specifiers.some(
+              (specifier) => specifier.imported.name === "render"
+            )
+          );
+  
+        // If not already imported, add the import statement
+        if (!hasRenderImport) {
+          const firstImport = root.find(j.ImportDeclaration).at(0);
+  
+          if (firstImport.size()) {
+            firstImport.insertBefore(
+              j.importDeclaration(
+                [j.importSpecifier(j.identifier("render"))],
+                j.literal("svelte/server")
+              )
+            );
+          } else {
+            // If no import statements, just insert at the top
+            root.get().node.program.body.unshift(
+              j.importDeclaration(
+                [j.importSpecifier(j.identifier("render"))],
+                j.literal("svelte/server")
+              )
+            );
+          }
         }
-    } else {
-        // Directly transform JavaScript files
-        transformedSource = transformCode(source);
+      }
+  
+      return root.toSource();
     }
-
+  
+    // Handle JavaScript inside <script> tags and directly in JavaScript files
+    if (file.path.endsWith(".svelte")) {
+      transformedSource = transformedSource.replace(
+        scriptTagRegex,
+        (match, openingTag, scriptContent, closingTag) => {
+          scriptFound = true;
+          // Transform the extracted JavaScript content from <script> tags
+          const transformedScriptContent = transformCode(scriptContent);
+          // Replace the original <script> content with the transformed content, preserving the original opening tag
+          return `${openingTag}\n${transformedScriptContent}\n${closingTag}`;
+        }
+      );
+  
+      // If no <script> tags were found, assume it's a script-less Svelte file
+      if (!scriptFound) {
+        transformedSource = transformCode(source);
+      }
+    } else {
+      // Directly transform JavaScript files
+      transformedSource = transformCode(source);
+    }
+  
     return transformedSource;
-}
+  }
+  

--- a/packages/codemods/svelte/5/server-api-changes/src/index.ts
+++ b/packages/codemods/svelte/5/server-api-changes/src/index.ts
@@ -1,0 +1,116 @@
+import type {
+  API,
+  ArrowFunctionExpression,
+  FileInfo,
+  Options,
+} from "jscodeshift";
+
+export default function transform(
+    file: FileInfo,
+    api: API,
+    options?: Options,
+  ): string | undefined {
+    const j = api.jscodeshift;
+    const source = file.source;
+
+    // Regular expression to find content inside <script> tags
+    const scriptTagRegex = /<script[^>]*>([\s\S]*?)<\/script>/gm;
+
+    // Variable to hold the transformed source
+    let transformedSource = source;
+    let scriptFound = false;
+
+    // Function to perform the transformation logic
+    function transformCode(code) {
+        const root = j(code);
+
+        let needsRenderImport = false;
+
+        // Find any calls to Component.render({...})
+        root.find(j.CallExpression, {
+            callee: {
+                property: { name: 'render' },
+            },
+        }).forEach((renderPath) => {
+            const componentName = renderPath.node.callee.object.name;
+
+            // Replace with `render(Component, { props })`
+            j(renderPath).replaceWith(
+                j.callExpression(j.identifier('render'), [
+                    j.identifier(componentName),
+                    j.objectExpression([
+                        j.property(
+                            'init',
+                            j.identifier('props'),
+                            renderPath.node.arguments[0],
+                        ),
+                    ]),
+                ]),
+            );
+
+            // Mark that we need to add `import { render } from 'svelte/server'`
+            needsRenderImport = true;
+        });
+
+        // If `render` was used, ensure the import is added
+        if (needsRenderImport) {
+            const hasRenderImport = root
+                .find(j.ImportDeclaration, {
+                    source: { value: 'svelte/server' },
+                })
+                .some((path) =>
+                    path.node.specifiers.some(
+                        (specifier) => specifier.imported.name === 'render',
+                    ),
+                );
+
+            // If not already imported, add the import statement
+            if (!hasRenderImport) {
+                const firstImport = root.find(j.ImportDeclaration).at(0);
+
+                if (firstImport.size()) {
+                    firstImport.insertBefore(
+                        j.importDeclaration(
+                            [j.importSpecifier(j.identifier('render'))],
+                            j.literal('svelte/server'),
+                        ),
+                    );
+                } else {
+                    // If no import statements, just insert at the top
+                    root.get().node.program.body.unshift(
+                        j.importDeclaration(
+                            [j.importSpecifier(j.identifier('render'))],
+                            j.literal('svelte/server'),
+                        ),
+                    );
+                }
+            }
+        }
+
+        return root.toSource();
+    }
+
+    // Handle JavaScript inside <script> tags and directly in JavaScript files
+    if (file.path.endsWith('.svelte')) {
+        transformedSource = transformedSource.replace(
+            scriptTagRegex,
+            (match, scriptContent) => {
+                scriptFound = true;
+                // Transform the extracted JavaScript content from <script> tags
+                const transformedScriptContent = transformCode(scriptContent);
+                // Replace the original <script> content with the transformed content
+                return `<script>\n${transformedScriptContent}\n</script>`;
+            },
+        );
+
+        // If no <script> tags were found, assume it's a script-less Svelte file
+        if (!scriptFound) {
+            transformedSource = transformCode(source);
+        }
+    } else {
+        // Directly transform JavaScript files
+        transformedSource = transformCode(source);
+    }
+
+    return transformedSource;
+}

--- a/packages/codemods/svelte/5/server-api-changes/tsconfig.json
+++ b/packages/codemods/svelte/5/server-api-changes/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES6",
+    "allowJs": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/svelte/5/server-api-changes/vitest.config.ts
+++ b/packages/codemods/svelte/5/server-api-changes/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, "**/test/*.ts"],
+  },
+});

--- a/packages/codemods/svelte/5/svelte-element-expression/.codemodrc.json
+++ b/packages/codemods/svelte/5/svelte-element-expression/.codemodrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://codemod-utils.s3.us-west-1.amazonaws.com/configuration_schema.json",
+  "version": "1.0.2",
+  "private": false,
+  "name": "svelte/5/svelte-element-expression",
+  "engine": "jscodeshift",
+  "applicability": {
+    "from": [["svelte", ">=", "4.0.0"], ["svelte", "<", "5.0.0"]],
+    "to": [["svelte", ">=", "5.0.0"]]
+  },
+  "meta": {
+    "tags": ["svelte", "5", "migration"],
+    "git": "https://github.com/codemod-com/codemod/tree/main/packages/codemods/svelte/5/svelte-element-expression"
+  },
+  "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", "**/*.vue", "**/*.svelte"]
+}

--- a/packages/codemods/svelte/5/svelte-element-expression/.gitignore
+++ b/packages/codemods/svelte/5/svelte-element-expression/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/packages/codemods/svelte/5/svelte-element-expression/LICENSE
+++ b/packages/codemods/svelte/5/svelte-element-expression/LICENSE
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2024 Codemod Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/codemods/svelte/5/svelte-element-expression/README.md
+++ b/packages/codemods/svelte/5/svelte-element-expression/README.md
@@ -1,0 +1,17 @@
+This codemod updates Svelte component definitions by transforming the `this` attribute in `<svelte:element>` tags:
+
+- Converts `this="..."` syntax to `this={...}` format.
+- Ensures proper JSX-like syntax within Svelte components for consistency with Svelte's latest standards.
+
+
+## Before
+
+```jsx
+<svelte:element this="div">
+```
+
+## After
+
+```jsx
+<svelte:element this={"div"}>
+```

--- a/packages/codemods/svelte/5/svelte-element-expression/__testfixtures__/fixture1.input.ts
+++ b/packages/codemods/svelte/5/svelte-element-expression/__testfixtures__/fixture1.input.ts
@@ -1,0 +1,1 @@
+<svelte:element this="div">

--- a/packages/codemods/svelte/5/svelte-element-expression/__testfixtures__/fixture1.output.ts
+++ b/packages/codemods/svelte/5/svelte-element-expression/__testfixtures__/fixture1.output.ts
@@ -1,0 +1,1 @@
+<svelte:element this={"div"}>

--- a/packages/codemods/svelte/5/svelte-element-expression/package.json
+++ b/packages/codemods/svelte/5/svelte-element-expression/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@codemod/svelte-5-svelte-element-expression",
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "jscodeshift": "^0.15.1",
+    "@types/jscodeshift": "^0.11.10",
+    "vitest": "^1.0.1",
+    "@vitest/coverage-v8": "^1.0.1"
+  },
+  "scripts": {},
+  "files": ["./README.md", "./.codemodrc.json", "./dist/index.cjs"],
+  "type": "module"
+}

--- a/packages/codemods/svelte/5/svelte-element-expression/src/index.ts
+++ b/packages/codemods/svelte/5/svelte-element-expression/src/index.ts
@@ -1,0 +1,36 @@
+import type {
+  API,
+  ArrowFunctionExpression,
+  FileInfo,
+  Options,
+} from "jscodeshift";
+
+
+export default function transform(
+    file: FileInfo,
+    api: API,
+    options?: Options,
+  ): string | undefined {
+    const j = api.jscodeshift; // Access jscodeshift API
+    const source = file.source; // Read the file content as text
+
+    if (typeof source !== 'string') {
+        throw new Error('Expected fileInfo.source to be a string');
+    }
+
+    // Regular expression to find <svelte:element this="...">
+    const svelteElementRegex =
+        /<svelte:element\s+([^>]*?)this="([^"]+)"([^>]*?)>/g;
+
+    // Replace matches with the desired format
+    const modifiedSource = source.replace(
+        svelteElementRegex,
+        (match, before, elementType, after) => {
+            return `<svelte:element ${before}this={${JSON.stringify(
+                elementType,
+            )}}${after}>`;
+        },
+    );
+
+    return modifiedSource;
+}

--- a/packages/codemods/svelte/5/svelte-element-expression/tsconfig.json
+++ b/packages/codemods/svelte/5/svelte-element-expression/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES6",
+    "allowJs": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": [
+    "./src/**/*.ts",
+    "./src/**/*.js",
+    "./test/**/*.ts",
+    "./test/**/*.js"
+  ],
+  "exclude": ["node_modules", "./dist/**/*"],
+  "ts-node": {
+    "transpileOnly": true
+  }
+}

--- a/packages/codemods/svelte/5/svelte-element-expression/vitest.config.ts
+++ b/packages/codemods/svelte/5/svelte-element-expression/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: [...configDefaults.include, "**/test/*.ts"],
+  },
+});


### PR DESCRIPTION

<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

### 📚 Description

- Link to official documentation : [Link](https://svelte-5-preview.vercel.app/docs/breaking-changes)

### Codemods

- **svelte/5/components-as-functions** - [Registry Link](https://codemod.com/registry/svelte-5-components-as-functions)
- **svelte/5/components-as-functions-destroyfunction** - [Registry Link](https://codemod.com/registry/svelte-5-components-as-functions-destroyfunction)
- **svelte/5/components-as-functions-onfunction** - [Registry Link](https://codemod.com/registry/svelte-5-components-as-functions-onfunction)
- **svelte/5/is-where-scoping** - [Registry Link](https://codemod.com/registry/svelte-5-is-where-scoping)
- **svelte/5/server-api-changes** - [Registry Link](https://codemod.com/registry/svelte-5-server-api-changes)
- **svelte/5/svelte-element-expression** - [Registry Link](https://codemod.com/registry/svelte-5-svelte-element-expression)
- **svelte/5/migration-recipe** - [Registry Link](https://codemod.com/registry/svelte-5-migration-recipe)