### PR TITLE
docs(publishing-guide): add publish with studio option

### DIFF
--- a/apps/docs/sharing/publishing-codemods.mdx
+++ b/apps/docs/sharing/publishing-codemods.mdx
@@ -8,7 +8,7 @@ This guide will walk you through the steps needed to publish codemods to [Codemo
 There are three ways to publish codemods to Codemod Registry:
 1. [publishing a codemod package](#option-1-publishing-a-codemod-compatible-package-recommended)
 2. [publishing from source file](#option-2-publishing-a-codemod-from-source-file)
-3. publishing with Codemod Studio (Coming soon)
+3. [publishing with Codemod Studio](#option-3-publishing-with-codemod-studio)
 
 <Tip>
 Publishing codemods to the registry is especially useful for framework/library builders. With features like shareable codemod deep links and Codemod CLI & IDE extenion, your users can adopt your latest releases with one click, straight from your migration doc. <Tooltip tip="MSW V2 migration">[See example ->](https://mswjs.io/docs/migrations/1.x-to-2.x/#codemods)</Tooltip>
@@ -61,6 +61,21 @@ Creating and publishing a [Codemod-compatible package](/building-codemods/packag
         ```
     </Step>
 </Steps>
+
+### Option 3: Publishing with Codemod Studio
+
+After building a codemod with Codemod Studio, you can instantly publish it to your private registry to quickly run it over your local project(s).
+
+To do so, you can click `Run with CLI`. After publishing the codemod, you will be able to run the codemod using Codemod CLI while being logged in with the same user used on Codemod Studio.
+
+To run the codemod, you can simply copy the exported command in the pop-up modal and run the command on any local codebase of your choice.
+
+<video
+  autoPlay
+  loop
+  className="w-full aspect-video"
+  src="/images/codemod-studio/studio-publish.mp4"
+></video>
 
 ## Unpublishing codemods
 


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

This PR adds a section for publishing with the studio publish feature.

<img width="1512" alt="Screenshot 2024-09-27 at 4 48 45 PM" src="https://github.com/user-attachments/assets/7a025abe-f3ca-4c74-a04e-7ffcb1c73697">

