### PR TITLE
docs: remove filemod + add workflow engine references

### DIFF
--- a/apps/docs/building-codemods/build-package.mdx
+++ b/apps/docs/building-codemods/build-package.mdx
@@ -53,7 +53,7 @@ To scaffold a new codemod package, you should:
         ```
     </Step>
     <Step title="Update transform file content">
-        <Card title="For jscodeshift/ts-morph/filemod codemods:">
+        <Card title="For jscodeshift/ts-morph/workflow codemods:">
         Update the content inside the `src/index.ts` file with the content of your codemod's transform file.
         </Card>
         <Card title="For ast-grep codemods:">

--- a/apps/docs/building-codemods/package-requirements.mdx
+++ b/apps/docs/building-codemods/package-requirements.mdx
@@ -13,7 +13,7 @@ The structure of the codemod package can vary based on the codemod engine used. 
 
 ## Supported codemod engines
 
-Codemod platform currently supports the following codemod engines: [`ast-grep`](https://github.com/ast-grep/ast-grep), [`filemod`](https://github.com/codemod-com/codemod/tree/main/packages/filemod), [`jscodeshift`](https://github.com/facebook/jscodeshift), [`ts-morph`](https://github.com/dsherret/ts-morph), and [`piranha`](https://github.com/uber/piranha).
+Codemod platform currently supports the following codemod engines: [`ast-grep`](https://github.com/ast-grep/ast-grep), [`jscodeshift`](https://github.com/facebook/jscodeshift), [`ts-morph`](https://github.com/dsherret/ts-morph), [`Workflow Engine`](/deploying-codemods/workflow-engine), and [`piranha`](https://github.com/uber/piranha).
 
 ## `.codemodrc.json` reference
 
@@ -38,10 +38,10 @@ The `.codemodrc.json` configuration file includes several metafields that can be
 <ResponseField name="engine" type="string" required>
   Specifies the engine used to run the codemod.
   Can be any of:
-  - `filemod`
+  - `ast-grep`
   - `jscodeshift`
   - `ts-morph`
-  - `ast-grep`
+  - `Workflow Engine`
   - `piranha` (requires additional `language` field that specifies one of the supported piranha languages:
   `java`, `kt`, `go`, `py`, `swift`, `ts`, `tsx`, or `scala`)
   - `recipe` (requires additional `names` field, which is an ordered array of codemod names that will be executed)
@@ -124,7 +124,7 @@ The `.codemodrc.json` configuration file includes several metafields that can be
 Below, you can find the required codemod package structure for each codemod engine supported by Codemod platform.
 
 <Tabs>
-  <Tab title="jscodeshift, ts-morph, and filemod">
+  <Tab title="jscodeshift and ts-morph">
     ```bash
     ├── dist
     │   ├── index.cjs # built codemod file. when someone runs your codemod, this file will be executed.
@@ -145,7 +145,7 @@ Below, you can find the required codemod package structure for each codemod engi
     "private": false,
     "name": "framework/version/codemod-name",
     "description": "example codemod description",
-    "engine": "jscodeshift/ts-morph/filemod",
+    "engine": "jscodeshift/ts-morph/workflow",
     "meta": {
       "tags": ["framework", "migration", "etc"],
         "git": "https://github.com/user/repo"


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

This PR removes mentions of Filemod and replaces them with the newer and better Workflow Engine.