### PR TITLE
website: remove vs code from navigation

### DIFF
--- a/apps/frontend/components/global/Navigation/PlatformButtonWithDropdown.tsx
+++ b/apps/frontend/components/global/Navigation/PlatformButtonWithDropdown.tsx
@@ -90,17 +90,6 @@ export default function PlatformButtonWithDropdown() {
           </div>
           <DropdownMenu.Group className="flex flex-col border-b-[1px] border-b-border-light py-s dark:border-b-border-dark">
             <DropdownMenu.Item asChild>
-              <a
-                href="https://marketplace.visualstudio.com/items?itemName=codemod.codemod-vscode-extension"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="body-s-medium flex items-center gap-xs rounded-[8px] p-xs font-medium text-primary-light focus:outline-none data-[highlighted]:bg-emphasis-light dark:text-primary-dark dark:data-[highlighted]:bg-emphasis-dark"
-              >
-                <Icon name="vscode" className="h-4 w-4" />
-                <span>VS Code Extension</span>
-              </a>
-            </DropdownMenu.Item>
-            <DropdownMenu.Item asChild>
               <Link
                 href="https://go.codemod.com/cli-docs"
                 prefetch


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
This PR removes the broken VS Code navigation item from the website.
