### PR TITLE
fix(cli): empty ~/.codemod same as non-existent for credentials

### DIFF
--- a/apps/cli/test/credentialsStorage.test.ts
+++ b/apps/cli/test/credentialsStorage.test.ts
@@ -1,0 +1,71 @@
+import { fs, type DirectoryJSON, vol } from "memfs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock all fs promises functions
+vi.mock("node:fs/promises", () => fs.promises);
+
+// Use a mock homedir in order to reliably have a memfs home directory
+vi.mock("node:os", () => ({ homedir: () => "/home/codemod-test/" }));
+
+import {
+  CredentialsStorage,
+  CredentialsStorageType,
+} from "../src/credentials-storage.js";
+
+describe("CredentialsStorage", () => {
+  const testService = "codemod.com-test";
+  const testAccount = CredentialsStorageType.ACCOUNT;
+  const testPassword = "test-password";
+
+  describe("when .codemod directory does not exist", () => {
+    beforeEach(() => {
+      vol.reset();
+    });
+
+    it("should return null without throwing an error", async () => {
+      const storage = new CredentialsStorage();
+      const result = await storage.get(testAccount);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("when there is a different kind of error reading the directory", () => {
+    beforeEach(() => {
+      vol.reset();
+    });
+
+    it("should rethrow the error", async () => {
+      // the error we are using to test is ENOTDIR, ie readDir on a file
+      vol.fromJSON({ "": "" }, "/home/codemod-test/.codemod");
+
+      const storage = new CredentialsStorage();
+      expect(storage.get(testAccount)).rejects.toThrow();
+    });
+  });
+
+  describe("when .codemod directory exists", () => {
+    beforeEach(() => {
+      vol.reset();
+    });
+
+    it("should return null when no credentials are found", async () => {
+      vol.fromJSON({}, "/home/codemod-test/.codemod");
+      const storage = new CredentialsStorage();
+      const result = await storage.get(testAccount);
+
+      expect(result).toBeNull();
+    });
+
+    it("should retrieve existing credentials when found", async () => {
+      const directory: DirectoryJSON = {
+        [`${testService}:${testAccount}`]: testPassword,
+      };
+      vol.fromJSON(directory, "/home/codemod-test/.codemod");
+      const storage = new CredentialsStorage();
+      const result = await storage.get(testAccount);
+
+      expect(result).toBe(testPassword);
+    });
+  });
+});


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
When a user attempts to login to the codemod platform using the CLI, and doesn't have the right binaries installed for `keytar` to work as intended, it's supposed to print an error like the following to help users install the right packages, or allow them to proceed with plaintext password storage if they want to live more adventurously:

![CleanShot 2024-12-01 at 22 02 21](https://github.com/user-attachments/assets/f9d38aed-6ad9-4b3f-9bc3-1e453c098ea8) 

However, first time installers of the `codemod` cli may run into this issue if they do not have a `~/.codemod` directory in their home path:

![CleanShot 2024-12-01 at 21 58 43](https://github.com/user-attachments/assets/19496c65-8c32-436a-9e80-6df5c55e4260)

Because the login command will create this directory when successfully setting authentication credentials, the more proper behavior would be to treat a non-existent directory as an empty one.

#### 🔗 Linked Issue

Fixes #1397 

#### 🧪 Test Plan
On the latest `main`, in addition to npm `latest`, running `codemod login` locally has different results if the ~/.codemod directory is missing or simply empty.

Build first:
`npx turbo build`

Then run the following:

```zsh
└─(06:50:36 on main ✹)──> rm -rf ~/.codemod && node apps/cli/dist/index.cjs login           

ENOENT: no such file or directory, scandir '/home/developer/.codemod'

└─(06:50:43 on main ✹)──> mkdir -p ~/.codemod && node apps/cli/dist/index.cjs login                                                      
Error: libsecret-1.so.0: cannot open shared object file: No such file or directory 

Codemod CLI uses "keytar" to store your credentials securely. 
Please make sure you have "libsecret" installed on your system. 
Depending on your distribution, you will need to run the following command 
Debian/Ubuntu: sudo apt-get install libsecret-1-dev 
Fedora: sudo dnf install libsecret 
Arch Linux: sudo pacman -S libsecret 

If you were not able to install the necessary package or CLI was not able to detect the installationplease reach out to us at our Community Slack channel. 
You can still use the CLI with file-based replacement that will store your credentials at your home directory.
⠋ Redirecting to Codemod sign-in pagenode:events:496
      throw er; // Unhandled 'error' event
      ^

Error: spawn xdg-open ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn xdg-open',
  path: 'xdg-open',
  spawnargs: [
    'https://staging.codemod.com?command=accessTokenRequestedByCLI&sessionId=f1vSZl7jHosGsD6-R4APfRESwpwKHCPC_fr2hRI2kMZNKwFZlTTXK4i9DUdSPBRi&iv=HCkCFrE5fatr-EedwDuHcA'
  ]
}

Node.js v20.18.1
```

Using the version in this branch, the behavior is consistent:

```
└─(06:52:21 on cs/codemod-login-first-time ✹)──> rm -rf ~/.codemod && node apps/cli/dist/index.cjs login   
Error: libsecret-1.so.0: cannot open shared object file: No such file or directory 

Codemod CLI uses "keytar" to store your credentials securely. 
Please make sure you have "libsecret" installed on your system. 
Depending on your distribution, you will need to run the following command 
Debian/Ubuntu: sudo apt-get install libsecret-1-dev 
Fedora: sudo dnf install libsecret 
Arch Linux: sudo pacman -S libsecret 

If you were not able to install the necessary package or CLI was not able to detect the installationplease reach out to us at our Community Slack channel. 
You can still use the CLI with file-based replacement that will store your credentials at your home directory.
⠋ Redirecting to Codemod sign-in pagenode:events:496
      throw er; // Unhandled 'error' event
      ^

Error: spawn xdg-open ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn xdg-open',
  path: 'xdg-open',
  spawnargs: [
    'https://staging.codemod.com?command=accessTokenRequestedByCLI&sessionId=NTfhpqdvCJHkdHH0WCC5rzj8ubLAtszRLJ5kiVH5snLKIW5Doj793XFDrN9t9GIY&iv=hv3z_TyeomDHMYHniIm4QA'
  ]
}

Node.js v20.18.1

└─(06:52:29 on cs/codemod-login-first-time ✹)──> mkdir -p ~/.codemod && node apps/cli/dist/index.cjs login                           
Error: libsecret-1.so.0: cannot open shared object file: No such file or directory 

Codemod CLI uses "keytar" to store your credentials securely. 
Please make sure you have "libsecret" installed on your system. 
Depending on your distribution, you will need to run the following command 
Debian/Ubuntu: sudo apt-get install libsecret-1-dev 
Fedora: sudo dnf install libsecret 
Arch Linux: sudo pacman -S libsecret 

If you were not able to install the necessary package or CLI was not able to detect the installationplease reach out to us at our Community Slack channel. 
You can still use the CLI with file-based replacement that will store your credentials at your home directory.
⠋ Redirecting to Codemod sign-in pagenode:events:496
      throw er; // Unhandled 'error' event
      ^

Error: spawn xdg-open ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at onErrorNT (node:internal/child_process:483:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn xdg-open',
  path: 'xdg-open',
  spawnargs: [
    'https://staging.codemod.com?command=accessTokenRequestedByCLI&sessionId=iT_bscKcL9d3LevshflsoqN_Fgzj7hqz0dMujfqIRq7gj-dj676KTluCQ-c_GZUx&iv=awLENs_2UwQEHiKFq3OJNw'
  ]
}

Node.js v20.18.1
```

The change is accomplished by breaking out the logic that reads the directory into it's own function, which returns an empty list of credentials to the caller if the directory is empty _or_ if it doesn't exist. Unit tests using `memfs` are provided to test this functionality. 

#### 📄 Documentation to Update
Unaware of any documentation to update.
