### PR TITLE
fix(frontend): Decrease features section validation limit

### DIFF
--- a/apps/frontend/sanity/schemas/sections/features.ts
+++ b/apps/frontend/sanity/schemas/sections/features.ts
@@ -20,7 +20,7 @@ export const features = defineSection({
       title: "Features",
       description:
         "The third feature will be displayed as a large card. The rest will be small cards.",
-      validation: (Rule) => Rule.min(5).max(5),
+      validation: (Rule) => Rule.min(2).max(5),
       options: {
         sortable: false,
       },


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

Decreases features section minimum allowed items limit so that we can add landing pages with less than 5 items.
<img width="1500" alt="Screenshot 2024-12-30 at 6 06 00 PM" src="https://github.com/user-attachments/assets/8edccf3f-1084-41d6-ab6d-9155ed484203" />

