### PR TITLE
feat: add changeset for #1418 PR changes

### DIFF
--- a/.changeset/spotty-donuts-tap.md
+++ b/.changeset/spotty-donuts-tap.md
@@ -1,0 +1,5 @@
+---
+"codemod": minor
+---
+
+Fixed issues with the Codemod CLI, including resolving the build failure on the publish command, removing automatic dependency installation during the init command, fixing .gitignore in package-boilerplate.ts, and removing the LICENSE file from the boilerplate list.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7368,8 +7368,6 @@ importers:
         specifier: ^4.11.0
         version: 4.15.7
 
-  packages/database/generated/client: {}
-
   packages/deprecated: {}
 
   packages/filemod:


### PR DESCRIPTION

<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->
This PR includes the changes and summary for [PR #1418](https://github.com/codemod-com/codemod/pull/1418). It uses `pnpm changeset` to resolve issues with the `publish` the Codemod CLI from the previous PR.
