### PR TITLE
fix: hide example heading in markdown purview in registry card

### DIFF
--- a/apps/frontend/components/templates/Registry/helpers.ts
+++ b/apps/frontend/components/templates/Registry/helpers.ts
@@ -19,7 +19,10 @@ export const getDescriptionShortText = (description: string) => {
   const descriptionWithoutHeadings = description
     .split("\n")
     .filter(
-      (line) => !line.startsWith("# ") && !line.startsWith("## Description"),
+      (line) =>
+        !line.startsWith("# ") &&
+        !line.startsWith("## Description") &&
+        !line.startsWith("## Example"),
     )
     .join("\n");
 


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->
This PR improves the UI/UX of the registry page by hiding the "example" heading in the `getDescriptionShortText` function. Removing this unnecessary heading results in a cleaner and more streamlined user experience.





