### PR TITLE
Update Feature Type to Support Both Image and Video Backgrounds

### DIFF
--- a/apps/frontend/components/sections/sectionComponents/Features.tsx
+++ b/apps/frontend/components/sections/sectionComponents/Features.tsx
@@ -51,7 +51,7 @@ export default function Features(props: FeaturesProps) {
           replay={replay}
           playOnView
           className={isDark ? "hidden dark:block" : "dark:hidden"}
-          video={version.asset}
+          video={version.asset.asset}
         />
       );
     }
@@ -61,8 +61,8 @@ export default function Features(props: FeaturesProps) {
         <img
           className={
             isDark
-              ? "hidden dark:block w-full h-auto"
-              : "dark:hidden w-full h-auto"
+              ? "hidden dark:block w-full aspect-[2/1] object-cover"
+              : "dark:hidden w-full aspect-[2/1] object-cover"
           }
           src={version.image.asset?.url}
           alt=""
@@ -79,6 +79,7 @@ export default function Features(props: FeaturesProps) {
       <div className="hidden w-full px-6 py-[60px] lg:grid lg:grid-cols-2 lg:px-20 lg:py-[80px]">
         {props?.features?.map((feature, index) => {
           const size = index === 2 ? "large" : "small";
+
           return (
             <div
               key={feature._key}

--- a/apps/frontend/components/sections/sectionComponents/Features.tsx
+++ b/apps/frontend/components/sections/sectionComponents/Features.tsx
@@ -10,38 +10,73 @@ import { cx } from "cva";
 import { useState } from "react";
 
 export default function Features(props: FeaturesProps) {
-  const [videoReplay, setVideoReplay] = useState(
+  const [interactionState, setInteractionState] = useState(
     props.features?.reduce((o, key) => ({ ...o, [key._key!]: false }), {}) ||
       {},
   );
-  const getSides = (index: number) => {
-    return {
-      right: true,
-      left: index === 1 || index === 3 || index === 4,
-      bottom: index === 3 || index === 4 || index === 5,
-      top: index === 1 || index === 2 || index === 3,
-    };
-  };
 
-  const getMobileSides = (index: number) => {
-    return {
-      right: true,
-      left: true,
-      bottom: index === 5,
-      top: true,
-    };
-  };
+  const getSides = (index: number) => ({
+    right: true,
+    left: index === 1 || index === 3 || index === 4,
+    bottom: index === 3 || index === 4 || index === 5,
+    top: index === 1 || index === 2 || index === 3,
+  });
+
+  const getMobileSides = (index: number) => ({
+    right: true,
+    left: true,
+    bottom: index === 5,
+    top: true,
+  });
 
   function handleInteraction(_key: string) {
-    setVideoReplay((prev) => ({ ...prev, [_key]: true }));
+    setInteractionState((prev) => ({ ...prev, [_key]: true }));
     setTimeout(() => {
-      setVideoReplay((prev) => ({ ...prev, [_key]: false }));
+      setInteractionState((prev) => ({ ...prev, [_key]: false }));
     }, 1000);
   }
 
+  const renderBackground = (
+    background: any,
+    replay: boolean,
+    isDark: boolean,
+  ) => {
+    if (!background) return null;
+
+    const version = isDark ? background.dark : background.light;
+
+    if (version?.type === "video" && version.asset) {
+      return (
+        <MuxVideo
+          replay={replay}
+          playOnView
+          className={isDark ? "hidden dark:block" : "dark:hidden"}
+          video={version.asset}
+        />
+      );
+    }
+
+    if (version?.type === "image" && version.image) {
+      return (
+        <img
+          className={
+            isDark
+              ? "hidden dark:block w-full h-auto"
+              : "dark:hidden w-full h-auto"
+          }
+          src={version.image.asset?.url}
+          alt=""
+        />
+      );
+    }
+
+    return null;
+  };
+
   return (
     <>
-      <div className="hidden w-full  px-6 py-[60px] lg:grid lg:grid-cols-2 lg:px-20 lg:py-[80px] ">
+      {/* Desktop */}
+      <div className="hidden w-full px-6 py-[60px] lg:grid lg:grid-cols-2 lg:px-20 lg:py-[80px]">
         {props?.features?.map((feature, index) => {
           const size = index === 2 ? "large" : "small";
           return (
@@ -53,27 +88,21 @@ export default function Features(props: FeaturesProps) {
               )}
             >
               <div
-                className={cx("absolute  z-10", {
+                className={cx("absolute z-10", {
                   "left-0 top-0 w-full": size === "small",
                   "right-0 top-1/2 my-auto w-1/2 -translate-y-1/2 transform":
                     size !== "small",
                 })}
               >
-                {feature.bgVideo?.dark?.asset && (
-                  <MuxVideo
-                    replay={videoReplay[feature._key!]}
-                    playOnView
-                    className="hidden dark:block"
-                    video={feature.bgVideo?.dark?.asset}
-                  />
+                {renderBackground(
+                  feature.background,
+                  interactionState[feature._key!],
+                  true,
                 )}
-                {feature.bgVideo?.light?.asset && (
-                  <MuxVideo
-                    replay={videoReplay[feature._key!]}
-                    playOnView
-                    className="dark:hidden"
-                    video={feature.bgVideo?.light.asset}
-                  />
+                {renderBackground(
+                  feature.background,
+                  interactionState[feature._key!],
+                  false,
                 )}
                 <div className="absolute bottom-0 h-1/4 w-full bg-gradient-to-t from-white dark:from-background-dark" />
               </div>
@@ -84,7 +113,7 @@ export default function Features(props: FeaturesProps) {
               >
                 <div
                   className={cx(
-                    "flex h-[600px] flex-col items-start  p-l lg:p-xl",
+                    "flex h-[600px] flex-col items-start p-l lg:p-xl",
                     size === "small"
                       ? "justify-end lg:h-[586px]"
                       : "max-w-[460px] justify-center lg:h-[590px]",
@@ -127,9 +156,9 @@ export default function Features(props: FeaturesProps) {
         })}
       </div>
 
+      {/* Mobile */}
       <div className="grid w-full grid-cols-2 px-6 py-[60px] lg:hidden lg:px-20 lg:py-[80px]">
         {props?.features?.map((feature, index) => {
-          // const { cleaned: size } = vercelStegaSplit(feature?.size || "");
           return (
             <div key={feature._key} className={cx("col-span-2")}>
               <GradientBorderBox
@@ -142,21 +171,15 @@ export default function Features(props: FeaturesProps) {
                   )}
                 >
                   <div className={cx("-mt-l w-full sm:-mx-l", {})}>
-                    {feature.bgVideo?.dark?.asset && (
-                      <MuxVideo
-                        replay={videoReplay[feature._key!]}
-                        playOnView
-                        className="hidden dark:block"
-                        video={feature.bgVideo?.dark?.asset}
-                      />
+                    {renderBackground(
+                      feature.background,
+                      interactionState[feature._key!],
+                      true,
                     )}
-                    {feature.bgVideo?.light?.asset && (
-                      <MuxVideo
-                        replay={videoReplay[feature._key!]}
-                        playOnView
-                        className="dark:hidden"
-                        video={feature.bgVideo?.light.asset}
-                      />
+                    {renderBackground(
+                      feature.background,
+                      interactionState[feature._key!],
+                      false,
                     )}
                   </div>
                   {feature?.tag ? (

--- a/apps/frontend/data/sanity/queries.ts
+++ b/apps/frontend/data/sanity/queries.ts
@@ -45,17 +45,35 @@ const SECTIONS_FRAGMENT = groq`
         _id,
         features {
             ...,
-            bgVideo {
-              light ${MUX_VIDEO_FRAGMENT},
-              dark ${MUX_VIDEO_FRAGMENT},
+            background {
+              light {
+                type,
+                asset ${MUX_VIDEO_FRAGMENT},
+                image {
+                  ...,
+                  asset->{
+                    url,
+                    metadata
+                  }
+                }
+              },
+              dark {
+                type,
+                asset ${MUX_VIDEO_FRAGMENT},
+                image {
+                  ...,
+                  asset->{
+                    url,
+                    metadata
+                  }
+                }
+              }
             },
-
         }[]
     },
     _type == "section.fullWidthMedia" => {
         ${FULL_WIDTH_MEDIA_FRAGMENT}
     },
-
     _type == "section.registry" => {
         ...,
         "filterIconDictionary": *[_type == "filterIconDictionary"][0],

--- a/apps/frontend/sanity/schemas/sections/features.ts
+++ b/apps/frontend/sanity/schemas/sections/features.ts
@@ -30,19 +30,73 @@ export const features = defineSection({
           icon: BlockContentIcon,
           fields: [
             {
-              name: "bgVideo",
-              title: "Background Video",
+              name: "background",
+              title: "Background",
               type: "object",
               fields: [
                 {
                   name: "light",
                   title: "Light Version",
-                  type: "mux.video",
+                  type: "object",
+                  fields: [
+                    {
+                      name: "type",
+                      title: "Type",
+                      type: "string",
+                      options: {
+                        list: [
+                          { title: "Image", value: "image" },
+                          { title: "Video", value: "video" },
+                        ],
+                        layout: "radio",
+                      },
+                      validation: (Rule) => Rule.required(),
+                    },
+                    {
+                      name: "asset",
+                      title: "Asset",
+                      type: "mux.video",
+                      hidden: ({ parent }) => parent?.type !== "video",
+                    },
+                    {
+                      name: "image",
+                      title: "Image",
+                      type: "image",
+                      hidden: ({ parent }) => parent?.type !== "image",
+                    },
+                  ],
                 },
                 {
                   name: "dark",
                   title: "Dark Version",
-                  type: "mux.video",
+                  type: "object",
+                  fields: [
+                    {
+                      name: "type",
+                      title: "Type",
+                      type: "string",
+                      options: {
+                        list: [
+                          { title: "Image", value: "image" },
+                          { title: "Video", value: "video" },
+                        ],
+                        layout: "radio",
+                      },
+                      validation: (Rule) => Rule.required(),
+                    },
+                    {
+                      name: "asset",
+                      title: "Asset",
+                      type: "mux.video",
+                      hidden: ({ parent }) => parent?.type !== "video",
+                    },
+                    {
+                      name: "image",
+                      title: "Image",
+                      type: "image",
+                      hidden: ({ parent }) => parent?.type !== "image",
+                    },
+                  ],
                 },
               ],
             },
@@ -62,7 +116,6 @@ export const features = defineSection({
               name: "description",
               title: "Description",
             },
-
             {
               type: "string",
               name: "snippet",

--- a/apps/frontend/types/index.ts
+++ b/apps/frontend/types/index.ts
@@ -233,9 +233,33 @@ export type Feature = {
   snippet?: string;
   toastText?: string;
   cta?: SanityLinkType;
-  bgVideo?: {
-    light?: MuxVideo;
-    dark?: MuxVideo;
+  background?: {
+    light?: {
+      type: "image" | "video";
+      asset?: MuxVideo;
+      image?: {
+        asset: {
+          url: string;
+          metadata?: {
+            dimensions?: { width: number; height: number };
+            lqip?: string; // Low-quality image placeholder
+          };
+        };
+      };
+    };
+    dark?: {
+      type: "image" | "video";
+      asset?: MuxVideo;
+      image?: {
+        asset: {
+          url: string;
+          metadata?: {
+            dimensions?: { width: number; height: number };
+            lqip?: string; // Low-quality image placeholder
+          };
+        };
+      };
+    };
   };
 };
 


### PR DESCRIPTION
#### **Summary**
This PR refactors the `Feature` type to replace `bgVideo` with a more flexible `background` field, supporting both image and video assets for light and dark modes.

---

#### **Key Changes**
1. Renamed `bgVideo` to `background`.
2. Added `type` field (`"image"` or `"video"`) to specify background type.
3. Introduced `image` field with support for `url` and optional metadata (e.g., dimensions, LQIP).
4. Retained video support via `MuxVideo` under `asset`.
5. Light and dark mode backgrounds are now optional.

---

#### **Impact**
- **Breaking Change:** Existing `bgVideo` usage must be updated to the new `background` format.
- **Enhanced Flexibility:** Supports dynamic content with both images and videos.

---

#### **Testing**
- Verified correct handling of both image and video types.
- Ensured optional light and dark modes work as intended.