### PR TITLE
feat(packages/codemod-utils): add tsup and CJS for require support in codemod-utils

### DIFF
--- a/.changeset/beige-planes-happen.md
+++ b/.changeset/beige-planes-happen.md
@@ -1,0 +1,5 @@
+---
+"@codemod.com/codemod-utils": minor
+---
+
+Add tsup for build and add support for common js for require

--- a/packages/codemod-utils/package.json
+++ b/packages/codemod-utils/package.json
@@ -18,7 +18,7 @@
     "tsconfig.json"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "coverage": "vitest run --coverage"
@@ -29,11 +29,18 @@
     "@types/node": "20.10.3",
     "@vitest/coverage-v8": "catalog:",
     "ts-node": "10.9.1",
+    "tsup": "^8.3.6",
+    "typescript": "5.5.4",
     "vitest": "^1.0.1"
   },
   "dependencies": {
-    "@types/jscodeshift": "^0.11.11",
     "@babel/parser": "^7.24.4",
+    "@types/jscodeshift": "^0.11.11",
     "jscodeshift": "^0.16.1"
+  },
+  "exports": {
+    "types": "./dist/index.d.ts",
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
   }
 }

--- a/packages/codemod-utils/tsup.config.ts
+++ b/packages/codemod-utils/tsup.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: {
+    compilerOptions: {
+      incremental: false, // Fix for incremental error
+    },
+  },
+  clean: true,
+  sourcemap: true,
+});


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->
This PR adds `tsup` as a build tool and includes CommonJS (`.cjs`) support in **codemod-utils**.  
With this change, the package can now be used with both `import` and `require`, improving compatibility.  

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->
- Built the package using `tsup` and verified that both ESM (`.js`) and CommonJS (`.cjs`) outputs were generated correctly.  
- Tested importing the package in both `import` and `require` environments to ensure compatibility.  
