### PR TITLE
chore(apps/cli): remove auto bump version in publish step

### DIFF
--- a/.changeset/kind-roses-try.md
+++ b/.changeset/kind-roses-try.md
@@ -1,0 +1,5 @@
+---
+"codemod": minor
+---
+
+Delete auto bump version in publish step

--- a/apps/cli/src/commands/publish.ts
+++ b/apps/cli/src/commands/publish.ts
@@ -164,9 +164,16 @@ export const handlePublishCliCommand = async (options: {
         ({ version }) => version === codemodRc.version,
       )
     ) {
+      const latestVersion =
+        existingCodemod.versions.length > 0
+          ? existingCodemod.versions[0]?.version
+          : "unknown";
+
       const errorMessage = `${chalk.bold(
         `Could not publish the "${codemodRc.name}" codemod`,
-      )}:\nVersion ${codemodRc.version} already exists.`;
+      )}:\n${chalk.yellow(
+        `Version ${codemodRc.version} is lower than the latest published or the same as the latest published version: ${chalk.bold(latestVersion)}`,
+      )}\nPlease bump the version to a higher one.`;
 
       return printer.printOperationMessage({
         kind: "error",


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine  
feat(cli)!: revamp the design (BREAKING CHANGE)  
fix(cli): fix a bug for the formatter  
chore(backend): upgrade node  
docs: improve codemod publish docs  
refactor(registry www): modularize filters  
test(vsce): add tests for VS Code extension  
-->

#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->
This PR removes the **auto bump version** from the publish step in CLI.  
Versioning will now be handled manually to provide more control over releases.  

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->
- Manually test the CLI in different cases.