### PR TITLE
chore(apps/frontend): remove VS Code Extension link from logo context menu

### DIFF
--- a/apps/frontend/components/global/Navigation/LogoWithContextMenu.tsx
+++ b/apps/frontend/components/global/Navigation/LogoWithContextMenu.tsx
@@ -170,17 +170,6 @@ export default function LogoWithContextMenu() {
               </a>
             </DropdownMenu.Item>
             <DropdownMenu.Item asChild>
-              <a
-                href="https://marketplace.visualstudio.com/items?itemName=codemod.codemod-vscode-extension"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="body-s-medium flex items-center gap-xs rounded-[8px] p-xs font-medium text-primary-light focus:outline-none data-[highlighted]:bg-emphasis-light dark:text-primary-dark dark:data-[highlighted]:bg-emphasis-dark"
-              >
-                <Icon name="vscode" className="h-4 w-4" />
-                <span>VS Code Extension</span>
-              </a>
-            </DropdownMenu.Item>
-            <DropdownMenu.Item asChild>
               <Link
                 href="/cli"
                 prefetch


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
This PR removes the VS Code Extension link from the logo context menu.  
The link was no longer necessary in this location, ensuring a cleaner and more intuitive UI.

#### 🧪 Test Plan
- Manually tested the logo context menu to confirm the VS Code Extension link is no longer present.
- Verified that other menu options remain functional.