### PR TITLE
fix: Fix ast-grep runner when there are special characters

### DIFF
--- a/.changeset/pretty-monkeys-watch.md
+++ b/.changeset/pretty-monkeys-watch.md
@@ -1,0 +1,5 @@
+---
+"codemod": patch
+---
+
+Make ast-grep runner unicode-aware

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -92,7 +92,6 @@
     "@ast-grep/cli": "catalog:",
     "@ast-grep/napi": "catalog:",
     "@codemod.com/workflow": "workspace:*",
-    "@nodejs-loaders/alias": "^1.1.1",
     "@octokit/rest": "catalog:",
     "blessed": "catalog:",
     "esbuild": "^0.23.0",

--- a/packages/workflow/src/astGrep/astGrep.ts
+++ b/packages/workflow/src/astGrep/astGrep.ts
@@ -38,7 +38,6 @@ const fileExtensionToLang: Record<string, Lang> = {
   cpp: Lang.Cpp,
   hpp: Lang.Cpp,
   cs: Lang.CSharp,
-  dart: Lang.Dart,
   ex: Lang.Elixir,
   exs: Lang.Elixir,
   go: Lang.Go,
@@ -153,6 +152,7 @@ const runExternalAstGrepRule = async (rule: any, filepath: string) => {
     path.dirname(require.resolve("@ast-grep/cli/package.json")),
     binaries.sg,
   );
+  console.log(binaryPath);
   await execFile(binaryPath, [
     "scan",
     "--update-all",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ catalogs:
       specifier: ^7.1.4
       version: 7.1.4
     '@ast-grep/cli':
-      specifier: ^0.25.4
-      version: 0.25.4
+      specifier: ^0.32.0
+      version: 0.32.3
     '@ast-grep/napi':
-      specifier: ^0.25.4
-      version: 0.25.4
+      specifier: ^0.32.0
+      version: 0.32.3
     '@aws-sdk/client-s3':
       specifier: ^3.549.0
       version: 3.600.0
@@ -1232,16 +1232,13 @@ importers:
     dependencies:
       '@ast-grep/cli':
         specifier: 'catalog:'
-        version: 0.25.4
+        version: 0.32.3
       '@ast-grep/napi':
         specifier: 'catalog:'
-        version: 0.25.4
+        version: 0.32.3
       '@codemod.com/workflow':
         specifier: workspace:*
         version: link:../../packages/workflow
-      '@nodejs-loaders/alias':
-        specifier: ^1.1.1
-        version: 1.1.1
       '@octokit/rest':
         specifier: 'catalog:'
         version: 20.1.1
@@ -2406,10 +2403,10 @@ importers:
     dependencies:
       '@ast-grep/cli':
         specifier: 'catalog:'
-        version: 0.25.4
+        version: 0.32.3
       '@ast-grep/napi':
         specifier: 'catalog:'
-        version: 0.25.4
+        version: 0.32.3
       '@babel/core':
         specifier: ^7.24.4
         version: 7.24.7
@@ -2642,10 +2639,10 @@ importers:
     dependencies:
       '@ast-grep/cli':
         specifier: 'catalog:'
-        version: 0.25.4
+        version: 0.32.3
       '@ast-grep/napi':
         specifier: 'catalog:'
-        version: 0.25.4
+        version: 0.32.3
       '@octokit/rest':
         specifier: 'catalog:'
         version: 20.1.1
@@ -2800,109 +2797,109 @@ packages:
   '@asamuzakjp/dom-selector@2.0.2':
     resolution: {integrity: sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==}
 
-  '@ast-grep/cli-darwin-arm64@0.25.4':
-    resolution: {integrity: sha512-mzoQiHSYy3Kk/YjibVbkkDYD24+ajKopq1hq7vMrFtQjn6eYzk/ki1WFq0642qv5qxLrB3cyijUk5J97dQNInw==}
+  '@ast-grep/cli-darwin-arm64@0.32.3':
+    resolution: {integrity: sha512-o7H/zofqbJ2Mqyig1GOdsRAbJlaMjBCnH7QjKzYEstuAI5JmvLa8dl9H6zoShs/17XThYDW9opYFtRCEscxNYg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@ast-grep/cli-darwin-x64@0.25.4':
-    resolution: {integrity: sha512-hic4LZnsFZmuZWpp4wLqAlN3kBnam+iIgmicyCo+W7Rd031QWqH90rtsE2fvYTfUL3y11Dn2AoXLx66j6sZWXQ==}
+  '@ast-grep/cli-darwin-x64@0.32.3':
+    resolution: {integrity: sha512-CO3xmTw015fH/x5zO2QEA6C5nEzRxy+6UDGLEZ74Bmmz0CjRceE4h+Hcw/RCwBs1aNRIO+VCAVKoqz/Gudb/SQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@ast-grep/cli-linux-arm64-gnu@0.25.4':
-    resolution: {integrity: sha512-JWkZHLZlTxlprQ+IXNOv/bZR8MVMMhj2d+7QGBWPqOTC+R2YrH4zz1+iaaPLWoTkUUFHcBcXFnYz0jakHs8XrQ==}
+  '@ast-grep/cli-linux-arm64-gnu@0.32.3':
+    resolution: {integrity: sha512-1zw2DY3a4ZW71DmPLpbOwmb7LrsXvBRVcDg1a++0yI9EPkLDPpX9wtssQOugh5i830ouBkySTS5WEfKC7Ir3Cg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@ast-grep/cli-linux-x64-gnu@0.25.4':
-    resolution: {integrity: sha512-Pu6r4uGyl41mNsolutqffvil4oySGJpQNfZaObORcbN8Lz+Wy5GP/I0Yn3vwwPcmAxG5EE4jiFb9DBBt7fIxBw==}
+  '@ast-grep/cli-linux-x64-gnu@0.32.3':
+    resolution: {integrity: sha512-0isP7hCbR/0lttI7rEYPKBbdS/yljO5zte8AUXrZ9kSjBw5UR5J2AyTs0lL6PPTvO3feqYoeykWnzEyvCAIeXA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@ast-grep/cli-win32-arm64-msvc@0.25.4':
-    resolution: {integrity: sha512-ryBRHT5sNUhLKLAVV+KIE7oc3sSzA7yewxhq4cpHM2FG8FfdAF8kgYDY6J6fFLWlW30OyImdOW9Bz8ufki/UWw==}
+  '@ast-grep/cli-win32-arm64-msvc@0.32.3':
+    resolution: {integrity: sha512-WFELr1aSNWCwE+Pe6fwYggQ46DO741sUUSnM6Ep91fQ5qnYvHNeb7GZFkgO4bUiDMGPzwASz27oV+4fWj1uzkQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@ast-grep/cli-win32-ia32-msvc@0.25.4':
-    resolution: {integrity: sha512-t6L/6KksL/ZXzU9V/4N9Qgzgc2nrL4R1gcn7dgh+8yjm60KQ9W3l3iC6i1MHTo9XTrwgHYhC+PtoindTbVCTFg==}
+  '@ast-grep/cli-win32-ia32-msvc@0.32.3':
+    resolution: {integrity: sha512-D7vJXQ15ZCXmx+ruU5wdj0eYP/dcT8Joz35dB/qHhSpBwxb4sE4hIWo2usgJJSUjLVqy/iNcdL8OqFmMicPx1g==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@ast-grep/cli-win32-x64-msvc@0.25.4':
-    resolution: {integrity: sha512-3DSl6pdrn2OPtLKAACa7AwkCCiF58S3Y0zyzipIaAwQ8Bz9aymwHBwZH3xmJS1A6LkcbxN7Un9LJtsMU/XXzKw==}
+  '@ast-grep/cli-win32-x64-msvc@0.32.3':
+    resolution: {integrity: sha512-yBeQQsOvcjOTsfQcHuuQeV45KkICwqcc0ddAPmqCjmuTOiPCBRZxdG6j2iKOwbW1kmmlgDmvDf6gUxXKxK5/2g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@ast-grep/cli@0.25.4':
-    resolution: {integrity: sha512-m55UEv2EO1jAb3hgNp6TipydKsEff/odKSjpy2BF3eX4YaY9st/t/JBFakMqhfUA2lvGgrP894vYXPEzzs3kqA==}
+  '@ast-grep/cli@0.32.3':
+    resolution: {integrity: sha512-K8zt7dKeFFAGHJewjJyMpx6UGxh1iYSB5OSv/h9HZb1eGBFv9PPJ1x+hFvUDLLdzvlNDxmAfvl6t5nZQRlrezg==}
     engines: {node: '>= 12.0.0'}
     hasBin: true
 
-  '@ast-grep/napi-darwin-arm64@0.25.4':
-    resolution: {integrity: sha512-qjqj0nARO1dJcsG2AQ2vaxtPV7je1A6SoYv3AG58/4mXdFg56hoVL4Op5DJpHNvg0e8rqkFJpJ7YIEFF2sQuAw==}
+  '@ast-grep/napi-darwin-arm64@0.32.3':
+    resolution: {integrity: sha512-Ifh25Ra38+5TGvO48NVcJsRarBSqJ2ppN6J+Qc8Z19rKALYb61tsWj6oh0W1CTbsYQ/HJbIff//WkUDkY0wMMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@ast-grep/napi-darwin-x64@0.25.4':
-    resolution: {integrity: sha512-1JhmH7Nwpz90TtX2+4joN29kkn69j96guLZGueN1uE0q084po7DB8hJHmn37o3eL1WCdeh1cptGGoHCfBnYBWw==}
+  '@ast-grep/napi-darwin-x64@0.32.3':
+    resolution: {integrity: sha512-jkuXgdvBTK7aTV7IojqMCUbHE4bzJzJ/adR0segW+BpU/uh/pxNuCZAal7E7KmWgSWVSS56UCOjS0OyibZKb7Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@ast-grep/napi-linux-arm64-gnu@0.25.4':
-    resolution: {integrity: sha512-0oC/czHjMJ3mtu5+o374xf4aOmr4/0xyW4JKyjSSJKlWhME/LZH/O4BOPPBi/xAOsqmb+t0J/lYEO4MoJOKeaA==}
+  '@ast-grep/napi-linux-arm64-gnu@0.32.3':
+    resolution: {integrity: sha512-Kso32W1K/+guK1Jkk33MpvVHhulaGF7lf6HW9Bc4VxRHWyZBXuhwwPOtf7+89qa2nEb0YyUxgQTnMUXbCKyYAQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@ast-grep/napi-linux-arm64-musl@0.25.4':
-    resolution: {integrity: sha512-KGyHxoxXBcPrCezoGloFrkzFrQIEco5SicvK7hwuhOWuR521LygFtcR9QOq3tjOaLDmznLuM/M/RDYwTqQIPeQ==}
+  '@ast-grep/napi-linux-arm64-musl@0.32.3':
+    resolution: {integrity: sha512-7+u7F5rzaV0/N5WdP2q+kGl3v+l8iGFRx4p7NUcbNumYqGDS2mkfRkaesRDSd7BH94ZulGtJnpmu3imX7spolQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@ast-grep/napi-linux-x64-gnu@0.25.4':
-    resolution: {integrity: sha512-ttBnrapPkJQPjgE6dCjOTWkpBjKz9y2Sc/ZiOB1B5xEQWCy0Oh35W8xkBdRjlfiU9RvVBCq5LrR5VX6nvKPZlQ==}
+  '@ast-grep/napi-linux-x64-gnu@0.32.3':
+    resolution: {integrity: sha512-XwUjw+W1QWDAPjx+Hsa8ZwONN3MDPINdRkRM6Q1vV3pl0p9YrMpwL72xrWQA1G7r7ej9BI1fLiXWB4YEOeYzJw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@ast-grep/napi-linux-x64-musl@0.25.4':
-    resolution: {integrity: sha512-NwMPsne+xikZCbPDoXNdwYPJQ8+1mMPHXbrJvBUgil/xjwZFTy/Z7KKEHFJ64lOeQixswz2KNLZgkE2CtxvRRg==}
+  '@ast-grep/napi-linux-x64-musl@0.32.3':
+    resolution: {integrity: sha512-894fQNqBDUfCP/qYbrPcK6+tMTEskc+vV2IKOKqgCfDryeptaiJJTJL9+Vbj38rO1LWhY8MIZ8W5ZyjxuhDRBA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@ast-grep/napi-win32-arm64-msvc@0.25.4':
-    resolution: {integrity: sha512-FOCxrPFWR7WgfpCz9vmE1SJGM2RB26ZaB3aRvnmopBkQVvZTZ/CyjG9Eee2zzu659OA4SoDO4eQ0m/VdL3LXUA==}
+  '@ast-grep/napi-win32-arm64-msvc@0.32.3':
+    resolution: {integrity: sha512-T8nrZm3E+h2VgHuQ3THQLvqhou4MkSbNcyIOgLZ0l2NatHIckeHuly5fmnkd6KQsGP/AqAEGxZBoOVYvoDl7DA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@ast-grep/napi-win32-ia32-msvc@0.25.4':
-    resolution: {integrity: sha512-UEnMzBnGA900BjdgVek9pnzsxodykzvXaVkUvmyLDHfu9Ql/lkjvgPlRi57pdwTsknkvHFAdtvvsrVA9qC0P1Q==}
+  '@ast-grep/napi-win32-ia32-msvc@0.32.3':
+    resolution: {integrity: sha512-40RdPWWgVLCx6gRSXfVXt3TuV6dZQE8K74whq56+nliJqA4TA1QCrNtbX9keFvb1JDc/iOUKc4PKA3A7TGHANQ==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@ast-grep/napi-win32-x64-msvc@0.25.4':
-    resolution: {integrity: sha512-itYPveFAbV19XyqaHIVO78N4doPMqGjbnTFjZD2fvCHXzUujxqlCXEt45+tNq9iXtn38e4wZB21ew0N2bX6IEw==}
+  '@ast-grep/napi-win32-x64-msvc@0.32.3':
+    resolution: {integrity: sha512-4VKmBFhT0M8s1LbAXemPDnHyAjEi5owkqkz85akvic9u6vRI0evRk8j2sHmgEBXwyySLUHf0NfI0XqwZ0mAl7g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@ast-grep/napi@0.25.4':
-    resolution: {integrity: sha512-Ax6OBQehjv6Fw/qU3BlTvUmugK3BfMK7eV0aPrLAxJ3+0neQcE+p7QP42iiHsf1n/vG7npv7uUaBRfjzHH4hiQ==}
+  '@ast-grep/napi@0.32.3':
+    resolution: {integrity: sha512-EdgX3gnDGkKMeofSYQlmPccjnxmGGQoEKL7pVQUmenLrsUBXXcjY//6J0LJApfIzNCknjQkfWpj1IbWDkl66Iw==}
     engines: {node: '>= 10'}
 
   '@aws-crypto/crc32@5.2.0':
@@ -5562,10 +5559,6 @@ packages:
     peerDependencies:
       next: ^13.0.0 || ^14.0.0 || ^15.0.0
       react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-
-  '@nodejs-loaders/alias@1.1.1':
-    resolution: {integrity: sha512-7Iq7XeacMpjUcOVetNBoFtHTx84uOazn8mhqaHXrvxBTgxCfZHlDu3g5ogRJ6/9PD5+LSvigfRMLTQWhAsSEwQ==}
-    engines: {node: '>=22 || ^20.6.0 || ^18.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -16684,77 +16677,77 @@ snapshots:
       css-tree: 2.3.1
       is-potential-custom-element-name: 1.0.1
 
-  '@ast-grep/cli-darwin-arm64@0.25.4':
+  '@ast-grep/cli-darwin-arm64@0.32.3':
     optional: true
 
-  '@ast-grep/cli-darwin-x64@0.25.4':
+  '@ast-grep/cli-darwin-x64@0.32.3':
     optional: true
 
-  '@ast-grep/cli-linux-arm64-gnu@0.25.4':
+  '@ast-grep/cli-linux-arm64-gnu@0.32.3':
     optional: true
 
-  '@ast-grep/cli-linux-x64-gnu@0.25.4':
+  '@ast-grep/cli-linux-x64-gnu@0.32.3':
     optional: true
 
-  '@ast-grep/cli-win32-arm64-msvc@0.25.4':
+  '@ast-grep/cli-win32-arm64-msvc@0.32.3':
     optional: true
 
-  '@ast-grep/cli-win32-ia32-msvc@0.25.4':
+  '@ast-grep/cli-win32-ia32-msvc@0.32.3':
     optional: true
 
-  '@ast-grep/cli-win32-x64-msvc@0.25.4':
+  '@ast-grep/cli-win32-x64-msvc@0.32.3':
     optional: true
 
-  '@ast-grep/cli@0.25.4':
+  '@ast-grep/cli@0.32.3':
     dependencies:
       detect-libc: 2.0.3
     optionalDependencies:
-      '@ast-grep/cli-darwin-arm64': 0.25.4
-      '@ast-grep/cli-darwin-x64': 0.25.4
-      '@ast-grep/cli-linux-arm64-gnu': 0.25.4
-      '@ast-grep/cli-linux-x64-gnu': 0.25.4
-      '@ast-grep/cli-win32-arm64-msvc': 0.25.4
-      '@ast-grep/cli-win32-ia32-msvc': 0.25.4
-      '@ast-grep/cli-win32-x64-msvc': 0.25.4
+      '@ast-grep/cli-darwin-arm64': 0.32.3
+      '@ast-grep/cli-darwin-x64': 0.32.3
+      '@ast-grep/cli-linux-arm64-gnu': 0.32.3
+      '@ast-grep/cli-linux-x64-gnu': 0.32.3
+      '@ast-grep/cli-win32-arm64-msvc': 0.32.3
+      '@ast-grep/cli-win32-ia32-msvc': 0.32.3
+      '@ast-grep/cli-win32-x64-msvc': 0.32.3
 
-  '@ast-grep/napi-darwin-arm64@0.25.4':
+  '@ast-grep/napi-darwin-arm64@0.32.3':
     optional: true
 
-  '@ast-grep/napi-darwin-x64@0.25.4':
+  '@ast-grep/napi-darwin-x64@0.32.3':
     optional: true
 
-  '@ast-grep/napi-linux-arm64-gnu@0.25.4':
+  '@ast-grep/napi-linux-arm64-gnu@0.32.3':
     optional: true
 
-  '@ast-grep/napi-linux-arm64-musl@0.25.4':
+  '@ast-grep/napi-linux-arm64-musl@0.32.3':
     optional: true
 
-  '@ast-grep/napi-linux-x64-gnu@0.25.4':
+  '@ast-grep/napi-linux-x64-gnu@0.32.3':
     optional: true
 
-  '@ast-grep/napi-linux-x64-musl@0.25.4':
+  '@ast-grep/napi-linux-x64-musl@0.32.3':
     optional: true
 
-  '@ast-grep/napi-win32-arm64-msvc@0.25.4':
+  '@ast-grep/napi-win32-arm64-msvc@0.32.3':
     optional: true
 
-  '@ast-grep/napi-win32-ia32-msvc@0.25.4':
+  '@ast-grep/napi-win32-ia32-msvc@0.32.3':
     optional: true
 
-  '@ast-grep/napi-win32-x64-msvc@0.25.4':
+  '@ast-grep/napi-win32-x64-msvc@0.32.3':
     optional: true
 
-  '@ast-grep/napi@0.25.4':
+  '@ast-grep/napi@0.32.3':
     optionalDependencies:
-      '@ast-grep/napi-darwin-arm64': 0.25.4
-      '@ast-grep/napi-darwin-x64': 0.25.4
-      '@ast-grep/napi-linux-arm64-gnu': 0.25.4
-      '@ast-grep/napi-linux-arm64-musl': 0.25.4
-      '@ast-grep/napi-linux-x64-gnu': 0.25.4
-      '@ast-grep/napi-linux-x64-musl': 0.25.4
-      '@ast-grep/napi-win32-arm64-msvc': 0.25.4
-      '@ast-grep/napi-win32-ia32-msvc': 0.25.4
-      '@ast-grep/napi-win32-x64-msvc': 0.25.4
+      '@ast-grep/napi-darwin-arm64': 0.32.3
+      '@ast-grep/napi-darwin-x64': 0.32.3
+      '@ast-grep/napi-linux-arm64-gnu': 0.32.3
+      '@ast-grep/napi-linux-arm64-musl': 0.32.3
+      '@ast-grep/napi-linux-x64-gnu': 0.32.3
+      '@ast-grep/napi-linux-x64-musl': 0.32.3
+      '@ast-grep/napi-win32-arm64-msvc': 0.32.3
+      '@ast-grep/napi-win32-ia32-msvc': 0.32.3
+      '@ast-grep/napi-win32-x64-msvc': 0.32.3
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -19918,10 +19911,6 @@ snapshots:
       next: 14.2.4(@babel/core@7.24.7)(@opentelemetry/api@1.9.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       third-party-capital: 1.0.20
-
-  '@nodejs-loaders/alias@1.1.1':
-    dependencies:
-      lodash.get: 4.4.2
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -25576,7 +25565,7 @@ snapshots:
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       eslint-plugin-jsx-a11y: 6.9.0(eslint@8.56.0)
       eslint-plugin-react: 7.34.3(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.56.0)
@@ -25604,7 +25593,7 @@ snapshots:
       enhanced-resolve: 5.17.0
       eslint: 8.56.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.14.0
@@ -25626,7 +25615,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@6.21.0(eslint@8.56.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(eslint@8.56.0))(eslint@8.56.0))(eslint@8.56.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,8 +5,8 @@ packages:
 catalog:
     "@ariakit/react": ^0.4.6
     "@artsy/fresnel": ^7.1.4
-    "@ast-grep/cli": ^0.25.4
-    "@ast-grep/napi": ^0.25.4
+    "@ast-grep/cli": ^0.32.0
+    "@ast-grep/napi": ^0.32.0
     "@aws-sdk/client-s3": ^3.549.0
     "@aws-sdk/s3-request-presigner": ^3.549.0
     "@babel/plugin-syntax-flow": ^7.14.5


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

ast-grep offsets are not unicode aware and are just byte offsets. This causes our custom transformer producing broken texts. This PR introduces a fix that utilizes TextEncoder to make the updates unicode-aware.

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
