### PR TITLE
chore(docs): add info about namespaces & update cli nav

### DIFF
--- a/apps/docs/building-codemods/package-requirements.mdx
+++ b/apps/docs/building-codemods/package-requirements.mdx
@@ -22,6 +22,22 @@ The `.codemodrc.json` configuration file includes several metafields that can be
 
 <ResponseField name="name" type="string" required>
   Specifies the slugified name of the codemod published to the codemod registry.
+  
+  <Tip>
+    We recommend using the following naming convention for better codemod discoverability:
+
+    ```
+    library/version/codemod-name
+    ```
+    
+    Optionally, you can specify an organization's namespace for your codemod:
+
+    ```
+    @organization/library/version/codemod-name
+    ```
+    
+    To create an organization namespace, [contact us](https://codemod.com/contact) message us on the [Slack community](https://go.codemod.com/community).
+  </Tip>
 </ResponseField>
 
 <ResponseField name="version" type="string" required>
@@ -34,8 +50,9 @@ The `.codemodrc.json` configuration file includes several metafields that can be
 <ResponseField name="private" type="boolean" default="false">
   Can be used to set the codemod visibility to `private`.
 
-  By default, when a codemod is published without a namespace, visibility will be set as `public`.
-  If a codemod is published under a namespace, such as `@codemod/my-codemod`, visibility will be set as `private`.
+  <Info>
+    If a codemod is published under an organization's namespace, such as `@codemod/my-codemod`, visibility will default to `private` unless explicitly specified.
+  </Info>
 </ResponseField>
 
 <ResponseField name="engine" type="string" required>

--- a/apps/docs/deploying-codemods/cli.mdx
+++ b/apps/docs/deploying-codemods/cli.mdx
@@ -1,5 +1,5 @@
 ---
-title: "All commands"
+title: "Codemod CLI"
 description: "Get started with using the Codemod command-line interface."
 icon: "terminal"
 ---

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -54,6 +54,10 @@
                   "codemod-registry/introduction",
                   "sharing/publishing-codemods"
                 ]
+              },
+              {
+                "group": "Locally Running Codemods",
+                "pages": ["deploying-codemods/cli"]
               }
             ]
           },


### PR DESCRIPTION
Minor update:
- added info about how namespaces work
- added navigation to legacy cli doc