### PR TITLE
feat(docs): add new cli docs

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -30,7 +30,13 @@
           },
           {
             "group": "Codemod Platform",
-            "pages": ["scanner", "migrations", "insights", "codemod-studio"]
+            "pages": [
+              "scanner",
+              "migrations",
+              "insights",
+              "codemod-studio",
+              "workflows"
+            ]
           },
           {
             "group": "OSS & Community",

--- a/apps/docs/workflows.mdx
+++ b/apps/docs/workflows.mdx
@@ -1,0 +1,499 @@
+---
+title: 'Codemod CLI'
+description: Run, validate, and automate code-modification workflows locally or in the cloud.
+icon: 'code'
+---
+
+---
+
+Codemod CLI is a self-hosted workflow engine for code-base changes—codemods, grep-style edits, automated lint fixes, and more. Define once in YAML; run unchanged on your laptop **or** in the Codemod platform.
+
+## Core Features
+
+- **Single binary, no server** — works anywhere you have a shell  
+- **Schema-validated shared state** — tasks share one JSON document  
+- **Dynamic matrix fan-out** — tasks appear/disappear as state arrays change  
+- **Manual gates** — pause tasks until you trigger them  
+- **Durable & resumable** — state survives crashes or reboots  
+- **Parallel scheduling** — independent nodes run when dependencies allow  
+- **Host-shell execution** — commands run directly on your machine (container runtimes on the roadmap)
+
+---
+
+## Quick Start
+
+<Steps>
+  <Step title="Install">
+    ```bash
+    cargo install codemod-cli
+    ```
+  </Step>
+  <Step title="Create a minimal workflow">
+    ```yaml workflow.yaml
+    version: "1"
+    nodes:
+      - id: hello
+        name: Hello World
+        type: automatic
+        steps:
+          - name: Say hello
+            run: echo "Hello, World!"
+    ```
+  </Step>
+  <Step title="Validate & run">
+    ```bash
+    codemod validate -w workflow.yaml
+    codemod run      -w workflow.yaml
+    codemod run      ./my-workflow/   # run a bundle folder
+    ```
+  </Step>
+</Steps>
+
+<Info>
+Registry identifiers such as `my-registry/react-mods:latest` are on the roadmap.
+</Info>
+
+---
+
+## Directory Layout
+
+```
+my-workflow/
+├─ workflow.yaml
+├─ scripts/
+└─ rules/
+```
+
+The folder—called a **workflow bundle**—is the root when you run `codemod run ./my-workflow/`. `$CODEMOD_PATH` points here inside every task.
+
+<Accordion title="Workflow Bundle & Loading Workflows">
+A <b>workflow bundle</b> is a directory containing your <code>workflow.yaml</code> and any scripts, rules, or assets referenced by your workflow.
+
+- When you run <code>codemod run ./my-workflow/</code>, the directory is used as the root for all relative paths.
+- You can also run a workflow directly from a file:
+  <br/>
+  <code>codemod run -w workflow.yaml</code>
+
+<Info>
+Registry support (run workflows from remote sources) is planned for the future.
+</Info>
+</Accordion>
+
+## Workflow File
+
+```yaml workflow.yaml
+version: "1"
+state:
+  schema: []
+templates: []
+nodes: []
+```
+
+A workflow has four top-level keys:
+
+| Key | Required | Purpose |
+|-----|----------|---------|
+| `version`   | ✓ | Declare workflow schema version (default: `"1"`). |
+| [`state`](#shared-state)     |   | Declares shared-state schema. |
+| [`templates`](#templates) |   | Re-usable blocks. |
+| [`nodes`](#nodes)     | ✓ | Executable DAG. |
+
+---
+
+## Shared State
+
+```yaml
+state:
+  schema:
+    - name: shards
+      type: array
+      items:
+        type: object
+        properties:
+          team:    { type: string }
+          shardId: { type: string }
+```
+
+---
+
+## Templates
+
+```yaml
+templates:
+  - id: checkout-repo
+    name: Checkout Repository
+    inputs:
+      - name: repo_url
+        type: string
+        required: true
+    steps:
+      - name: Clone
+        run: git clone ${{inputs.repo_url}} repo
+```
+
+**Template Inputs & Usage**:
+
+Templates can define required or optional inputs, which are referenced in their steps.
+
+To use a template in a node step:
+
+```yaml
+steps:
+  - name: Checkout
+    uses:
+      - template: checkout-repo
+        inputs:
+          repo_url: ${{params.repo_url}}
+```
+
+---
+## Nodes & Steps
+
+### Nodes
+
+```yaml
+nodes:
+  - id: build
+    name: Build
+    type: automatic
+    steps:
+      - name: npm install
+        run: npm ci
+```
+
+<ParamField path="id" type="string" required>
+  Unique within the workflow.
+</ParamField>
+<ParamField path="name" type="string" required>
+  Display name.
+</ParamField>
+<ParamField path="type" type="string" required>
+  `automatic` (default) or `manual`.
+</ParamField>
+<ParamField path="depends_on" type="string[]">
+  Upstream node IDs.
+</ParamField>
+<ParamField path="trigger" type="object">
+  `{ type: manual }` → approval gate.
+</ParamField>
+<ParamField path="strategy" type="object">
+  Matrix configuration.
+</ParamField>
+<ParamField path="steps" type="array" required>
+  Ordered list of steps.
+</ParamField>
+<ParamField path="runtime" type="object">Container/runtime configuration (e.g., Docker).</ParamField>
+<ParamField path="env" type="object">Environment variables for the node or step.</ParamField>
+
+### Step
+
+<ParamField path="name" type="string" required>
+  Step label.
+</ParamField>
+<ParamField path="run" type="string">
+  Inline shell command to execute.
+  <br/>
+  <b>Provide either <code>run</code> or <code>uses</code>, not both.</b>
+</ParamField>
+<ParamField path="uses" type="object">
+  Template call(s).
+  <br/>
+  <b>Provide either <code>run</code> or <code>uses</code>, not both.</b>
+</ParamField>
+
+
+## Matrix Strategy
+
+```yaml
+nodes:
+  - id: matrix-codemod
+    name: Matrix Codemod
+    strategy:
+      type: matrix
+      from_state: shards
+    steps:
+      - name: Codemod
+        run: node codemod.js --team=$team --shard=$shardId
+```
+
+<Accordion title="Dynamic Matrix Task Recompilation">
+When the array referenced by `from_state` changes, Codemod CLI:
+
+1. Creates new tasks for new items.
+2. Marks tasks as `WontDo` if their item is removed.
+3. Leaves existing tasks untouched if their item remains.
+
+<Info>
+Matrix nodes have a <b>master task</b> that tracks the status of all generated tasks.
+</Info>
+</Accordion>
+
+---
+
+## Manual Trigger
+
+```yaml
+nodes:
+  - id: manual-approval
+    name: Manual Approval
+    trigger:
+      type: manual
+    steps:
+      - name: Wait for approval
+        run: echo "Waiting for manual approval"
+```
+
+<Accordion title="Task UUIDs & Resume">
+Manual tasks are assigned unique UUIDs. You can resume:
+
+- All paused tasks:
+  ```bash
+  codemod resume -i <run-id> --trigger-all
+  ```
+- A specific task:
+  ```bash
+  codemod resume -i <run-id> -t <task-uuid>
+  ```
+</Accordion>
+
+---
+
+## State Updates
+
+| Syntax         | Meaning                                      | Example                                      |
+|----------------|----------------------------------------------|----------------------------------------------|
+| `KEY=VAL`      | Set state key to value                       | `count=10`                                   |
+| `KEY@=VAL`     | Append value to array at state key           | `shards@={"team":"core","shardId":"1"}`      |
+| Dot notation   | Set nested state fields                      | `config.retries=5`                           |
+| JSON values    | Use valid JSON for objects/arrays            | `user={"name":"Alice","id":123}`             |
+
+<Info>
+All state updates must be valid JSON if not a primitive. Updates are applied only if the task exits successfully.
+</Info>
+
+<AccordionGroup>
+<Accordion title="Container Runtimes">
+You can specify how a node or template runs:
+
+```yaml
+runtime:
+  type: docker
+  image: node:18-alpine
+```
+
+Supported types: `docker`, `podman`, `direct` (host shell).
+</Accordion>
+
+<Accordion title="State Management & Persistence">
+<Info>
+Workflow state is persisted after every task. If interrupted, you can resume from the last saved state—no work is lost.
+</Info>
+</Accordion>
+
+<Accordion title="Matrix Master Task">
+For matrix nodes, a master task aggregates the status of all generated tasks.  
+If all child tasks complete, the master is `Completed`. If any fail, the master is `Failed`.
+</Accordion>
+
+<Accordion title="Cyclic Dependency Example">
+If your workflow has a cycle:
+
+```yaml
+nodes:
+  - id: a
+    depends_on: [b]
+  - id: b
+    depends_on: [a]
+```
+
+You'll see:
+
+```bash
+✗ Workflow definition is invalid
+Error: Cyclic dependency detected: a → b → a
+```
+</Accordion>
+
+</AccordionGroup>
+
+---
+
+## End-to-End Example
+
+```yaml
+version: "1"
+state:
+  schema:
+    - name: shards
+      type: array
+      items:
+        type: object
+        properties:
+          team: { type: string }
+          shardId: { type: string }
+templates:
+  - id: checkout-repo
+    name: Checkout Repository
+    inputs:
+      - name: repo_url
+        type: string
+        required: true
+    steps:
+      - name: Clone
+        run: git clone ${{inputs.repo_url}} repo
+nodes:
+  - id: make-shards
+    name: Make Shards
+    type: automatic
+    steps:
+      - name: Write shards
+        run: echo 'shards@={"team":"core","shardId":"1"}' >> "$STATE_OUTPUTS"
+  - id: matrix-codemod
+    name: Matrix Codemod
+    strategy:
+      type: matrix
+      from_state: shards
+    trigger:
+      type: manual
+    steps:
+      - name: Codemod
+        run: node codemod.js --team=$team --shard=$shardId
+      - name: PR
+        run: codemodctl pr create
+```
+
+---
+
+## Task Statuses
+
+<ResponseField name="Pending">
+  Queued; waiting for runner.
+</ResponseField>
+<ResponseField name="Running">
+  Currently executing.
+</ResponseField>
+<ResponseField name="Completed">
+  Succeeded; diff applied.
+</ResponseField>
+<ResponseField name="Failed">
+  Script exited non-zero; diff discarded.
+</ResponseField>
+<ResponseField name="AwaitingTrigger">
+  Waiting for manual approval.
+</ResponseField>
+<ResponseField name="Blocked">
+  Dependencies not finished.
+</ResponseField>
+<ResponseField name="WontDo">
+  Matrix item removed; task skipped.
+</ResponseField>
+
+
+## Variable Resolution
+
+- **Parameter:** `${{params.branch}}` — Supplied at runtime
+- **Environment:** `${{env.CI}}` — Host env var
+- **Shared State:** `${{state.counter}}` — Live JSON value
+
+<Info>
+In matrix tasks, each object key becomes an environment variable (e.g., `$team`, `$shardId`, …).
+</Info>
+
+---
+
+## CLI Commands
+
+### `codemod validate`
+Lint workflow & print issues.
+
+<ResponseField name="-w <file>" type="string" required>
+  Path to the workflow file.
+</ResponseField>
+
+### `codemod run`
+Start a run.
+
+<ResponseField name="-w <file>" type="string">
+  Path to the workflow file.
+</ResponseField>
+<ResponseField name="<dir>" type="string">
+  Path to a workflow bundle directory.
+</ResponseField>
+
+### `codemod resume`
+Resume or trigger tasks.
+
+<ResponseField name="-i <run-id>" type="string" required>
+  Run ID to resume.
+</ResponseField>
+<ResponseField name="--trigger-all" type="boolean">
+  Resume all paused tasks.
+</ResponseField>
+<ResponseField name="-t <uuid>" type="string">
+  Resume a single task by UUID.
+</ResponseField>
+
+### `codemod graph`
+Render DAG image.
+
+<ResponseField name="-w <file>" type="string" required>
+  Path to the workflow file.
+</ResponseField>
+<ResponseField name="-o <png>" type="string" required>
+  Output PNG file for the DAG image.
+</ResponseField>
+
+
+## Task Statuses
+
+<ResponseField name="Pending">
+  Queued; waiting for runner.
+</ResponseField>
+<ResponseField name="Running">
+  Currently executing.
+</ResponseField>
+<ResponseField name="Completed">
+  Succeeded; diff applied.
+</ResponseField>
+<ResponseField name="Failed">
+  Script exited non-zero; diff discarded.
+</ResponseField>
+<ResponseField name="AwaitingTrigger">
+  Waiting for manual approval.
+</ResponseField>
+<ResponseField name="Blocked">
+  Dependencies not finished.
+</ResponseField>
+<ResponseField name="WontDo">
+  Matrix item removed; task skipped.
+</ResponseField>
+
+
+## Validation Checks
+
+`codemod validate` catches issues before execution:
+
+| Check | Ensures |
+|-------|---------|
+| Schema validation           | YAML matches spec |
+| Unique IDs                  | Node & template IDs unique |
+| Dependency validation       | Every `depends_on` exists |
+| Cyclic dependency detection | DAG has no cycles |
+| Template references         | All `template:` IDs exist |
+| Matrix validation           | `from_state` matches schema |
+| State schema validation     | `state.schema` is valid |
+| Variable syntax             | `${{…}}` uses `params`, `env`, `state` |
+
+---
+
+## Roadmap
+
+<Update label="Planned" description="Container runtime support">
+  Support for <code>runtime: docker</code> and other container runtimes, allowing tasks to run in isolated environments.
+</Update>
+<Update label="Planned" description="Parameter flags">
+  Ability to pass parameters to workflows via <code>--param key=value</code> flags.
+</Update>
+<Update label="Planned" description="Nested matrix strategies">
+  Support for matrix strategies within matrix strategies, enabling more complex task fan-out.
+</Update>


### PR DESCRIPTION
New Codemod CLI docs 🥳 

Merge when new Codemod CLI (~Butterflow~) is released. @mohebifar If you prefer the name Codemod Workflows instead, we can use that. I prefer that to avoid confusion with the legacy CLI + the scope of this tool is bigger than the context of a CLI.

FYI, reviewing would be really helpful since some of the tooling is still TBD so getting we might want to change things based on where we see the product once the CLI is released.



https://github.com/user-attachments/assets/90068536-55d5-40ed-86f5-fc0fd1d0b2bb


