### PR TITLE
feat: add JavaScript AST grep functionality/step action to workflows

### DIFF
--- a/crates/codemod-sandbox/src/sandbox/engine/config.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/config.rs
@@ -29,6 +29,10 @@ where
     pub language: Option<SupportLang>,
     /// Extensions to use for execution
     pub extensions: Option<Vec<String>>,
+    /// Include glob patterns for files to process
+    pub include_globs: Option<Vec<String>>,
+    /// Exclude glob patterns for files to skip
+    pub exclude_globs: Option<Vec<String>>,
     /// Whether to dry run the execution
     pub dry_run: bool,
 }
@@ -54,6 +58,8 @@ where
             walk_options: WalkOptions::default(),
             language: None,
             extensions: None,
+            include_globs: None,
+            exclude_globs: None,
             dry_run: false,
         }
     }
@@ -90,6 +96,16 @@ where
 
     pub fn with_extensions(mut self, extensions: Vec<String>) -> Self {
         self.extensions = Some(extensions);
+        self
+    }
+
+    pub fn with_include_globs(mut self, include_globs: Vec<String>) -> Self {
+        self.include_globs = Some(include_globs);
+        self
+    }
+
+    pub fn with_exclude_globs(mut self, exclude_globs: Vec<String>) -> Self {
+        self.exclude_globs = Some(exclude_globs);
         self
     }
 

--- a/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
@@ -8,7 +8,7 @@ use crate::sandbox::filesystem::FileSystem;
 use crate::sandbox::loaders::ModuleLoader;
 use crate::sandbox::resolvers::ModuleResolver;
 use ast_grep_language::SupportLang;
-use ignore::{WalkBuilder, WalkState};
+use ignore::{overrides::OverrideBuilder, WalkBuilder, WalkState};
 use llrt_modules::module_builder::ModuleBuilder;
 use rquickjs_git::{async_with, AsyncContext, AsyncRuntime};
 use std::fmt;
@@ -207,7 +207,7 @@ where
         // Execute in a blocking context since WalkParallel is synchronous
         let target_dir = target_dir.to_path_buf();
         tokio::task::spawn_blocking(move || {
-            let mut walk_builder = WalkBuilder::new(target_dir);
+            let mut walk_builder = WalkBuilder::new(&target_dir);
             walk_builder
                 .git_ignore(config.walk_options.respect_gitignore)
                 .hidden(!config.walk_options.include_hidden)
@@ -215,6 +215,48 @@ where
 
             if let Some(max_depth) = config.walk_options.max_depth {
                 walk_builder.max_depth(Some(max_depth));
+            }
+
+            // Build glob overrides for include/exclude patterns
+            let globs = if config.include_globs.is_some() || config.exclude_globs.is_some() {
+                let mut builder = OverrideBuilder::new(&target_dir);
+
+                // Add include patterns
+                if let Some(include_globs) = &config.include_globs {
+                    for glob in include_globs {
+                        if let Err(e) = builder.add(glob) {
+                            eprintln!("Warning: Invalid include glob '{}': {}", glob, e);
+                        }
+                    }
+                }
+
+                // Add exclude patterns (prefixed with !)
+                if let Some(exclude_globs) = &config.exclude_globs {
+                    for glob in exclude_globs {
+                        let exclude_pattern = if glob.starts_with('!') {
+                            glob.to_string()
+                        } else {
+                            format!("!{}", glob)
+                        };
+                        if let Err(e) = builder.add(&exclude_pattern) {
+                            eprintln!("Warning: Invalid exclude glob '{}': {}", exclude_pattern, e);
+                        }
+                    }
+                }
+
+                match builder.build() {
+                    Ok(overrides) => Some(overrides),
+                    Err(e) => {
+                        eprintln!("Warning: Failed to build glob overrides: {}", e);
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+
+            if let Some(overrides) = globs {
+                walk_builder.overrides(overrides);
             }
 
             walk_builder.build_parallel().run(|| {
@@ -231,8 +273,16 @@ where
                         Ok(entry) => {
                             let file_path = entry.path();
 
-                            if entry.file_type().is_some_and(|ft| ft.is_dir())
-                                || !ts_extensions
+                            // Skip directories
+                            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                                return WalkState::Continue;
+                            }
+
+                            // If glob patterns are used, the walker already filtered files
+                            // If no glob patterns, use extension filtering
+                            if config.include_globs.is_none()
+                                && config.exclude_globs.is_none()
+                                && !ts_extensions
                                     .iter()
                                     .any(|ext| file_path.to_string_lossy().ends_with(ext))
                             {
@@ -298,10 +348,6 @@ where
             let modified = modified_count.load(std::sync::atomic::Ordering::Relaxed);
             let unmodified = unmodified_count.load(std::sync::atomic::Ordering::Relaxed);
             let errors = error_count.load(std::sync::atomic::Ordering::Relaxed);
-
-            if modified + unmodified + errors == 0 {
-                return Err(ExecutionError::NoFilesFound);
-            }
 
             Ok(ExecutionStats {
                 files_modified: modified,
@@ -480,6 +526,18 @@ where
                     .map_err(|e| ExecutionError::Runtime {
                         source: crate::sandbox::errors::RuntimeError::InitializationFailed {
                             message: format!("Failed to set global variable: {}", e),
+                        },
+                    })?;
+
+                // Set the language for the codemod
+                let language_str = config.language
+                    .map(|lang| lang.to_string())
+                    .unwrap_or_else(|| "typescript".to_string());
+                ctx.globals()
+                    .set("CODEMOD_LANGUAGE", language_str)
+                    .map_err(|e| ExecutionError::Runtime {
+                        source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                            message: format!("Failed to set language global variable: {}", e),
                         },
                     })?;
 

--- a/crates/codemod-sandbox/src/sandbox/engine/language_data.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/language_data.rs
@@ -11,9 +11,15 @@ pub fn create_language_extension_map() -> HashMap<SupportLang, Vec<&'static str>
     {
         use ast_grep_language::SupportLang::*;
 
-        map.insert(JavaScript, vec![".js", ".mjs", ".cjs"]);
-        map.insert(TypeScript, vec![".ts", ".mts", ".cts"]);
-        map.insert(Tsx, vec![".tsx", ".jsx"]);
+        map.insert(JavaScript, vec![".js", ".mjs", ".cjs", ".jsx"]);
+        map.insert(
+            TypeScript,
+            vec![".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"],
+        );
+        map.insert(
+            Tsx,
+            vec![".tsx", ".jsx", ".ts", ".js", ".mjs", ".cjs", ".mts", ".cts"],
+        );
         map.insert(Bash, vec![".sh", ".bash", ".zsh", ".fish"]);
         map.insert(C, vec![".c", ".h"]);
         map.insert(CSharp, vec![".cs"]);

--- a/crates/codemod-sandbox/src/sandbox/engine/scripts/main_script.js.txt
+++ b/crates/codemod-sandbox/src/sandbox/engine/scripts/main_script.js.txt
@@ -3,7 +3,7 @@ import transform from "./{script_name}";
 
 export function executeCodemod() {{
     try {{
-        const sgRoot = astGrep.parseFile("javascript", CODEMOD_TARGET_FILE_PATH);
+        const sgRoot = astGrep.parseFile(CODEMOD_LANGUAGE, CODEMOD_TARGET_FILE_PATH);
         return transform(sgRoot);
     }} catch (e) {{
         console.error(e);

--- a/crates/core/tests/engine_tests.rs
+++ b/crates/core/tests/engine_tests.rs
@@ -9,7 +9,7 @@ use butterflow_core::{
     WorkflowStatus,
 };
 use butterflow_models::node::NodeType;
-use butterflow_models::step::{StepAction, UseAstGrep};
+use butterflow_models::step::{StepAction, UseAstGrep, UseJSAstGrep};
 use butterflow_models::strategy::Strategy;
 use butterflow_models::trigger::TriggerType;
 use butterflow_models::{DiffOperation, FieldDiff, TaskDiff};
@@ -1395,7 +1395,7 @@ message: "Found var declaration"
                 base_path: None,
                 config_file: "ast-grep-rules.yaml".to_string(),
             },
-            Some(temp_path.to_path_buf()),
+            Some(temp_path),
         )
         .await;
 
@@ -1460,7 +1460,7 @@ message: "Found interface declaration"
                 base_path: None,
                 config_file: "ts-rules.yaml".to_string(),
             },
-            Some(temp_path.to_path_buf()),
+            Some(temp_path),
         )
         .await;
 
@@ -1490,7 +1490,7 @@ async fn test_execute_ast_grep_step_nonexistent_config() {
                 base_path: None,
                 config_file: "nonexistent.yaml".to_string(),
             },
-            Some(temp_path.to_path_buf()),
+            Some(temp_path),
         )
         .await;
 
@@ -1542,7 +1542,7 @@ message: "Found console.log statement"
                 base_path: None,
                 config_file: "rules.yaml".to_string(),
             },
-            Some(temp_path.to_path_buf()),
+            Some(temp_path),
         )
         .await;
 
@@ -1551,5 +1551,579 @@ message: "Found console.log statement"
         result.is_ok(),
         "Should succeed even with no matches: {:?}",
         result
+    );
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a simple JavaScript codemod file
+    create_test_file(
+        temp_path,
+        "codemod.js",
+        r#"
+import { CallExpression } from '@ast-grep/napi';
+
+export default function transform(ast) {
+  return ast
+    .findAll({ rule: { pattern: 'console.log($$$)' } })
+    .replace('logger.info($$$)');
+}
+"#,
+    );
+
+    // Create test files to transform
+    create_test_file(
+        temp_path,
+        "src/app.js",
+        r#"
+function main() {
+    console.log("Starting app");
+    var count = 0;
+    console.log("Count:", count);
+}
+"#,
+    );
+
+    create_test_file(
+        temp_path,
+        "src/utils.js",
+        r#"
+function helper() {
+    console.log("Helper function");
+    let data = getData();
+    return data;
+}
+"#,
+    );
+
+    // Create engine and test execution
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "codemod.js".to_string(),
+                base_path: Some("src".to_string()),
+                include: Some(vec!["**/*.js".to_string()]),
+                exclude: None,
+                no_gitignore: Some(false),
+                include_hidden: Some(false),
+                max_threads: Some(2),
+                dry_run: Some(false),
+                language: Some("javascript".to_string()),
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Assert the step executed successfully
+    assert!(
+        result.is_ok(),
+        "JS AST grep step should execute successfully: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step_with_typescript() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a TypeScript codemod file
+    create_test_file(
+        temp_path,
+        "ts-codemod.js",
+        r#"
+export default function transform(ast) {
+  return ast
+    .findAll({ 
+      rule: { 
+        pattern: 'interface $NAME { $$$ }' 
+      } 
+    })
+    .replace('type $NAME = { $$$ }');
+}
+"#,
+    );
+
+    // Create test TypeScript files
+    create_test_file(
+        temp_path,
+        "src/types.ts",
+        r#"
+interface User {
+    name: string;
+    age: number;
+}
+
+interface Product {
+    id: number;
+    title: string;
+}
+"#,
+    );
+
+    create_test_file(
+        temp_path,
+        "src/models.ts",
+        r#"
+interface ApiResponse {
+    data: any;
+    status: number;
+}
+"#,
+    );
+
+    // Create engine and test execution
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "ts-codemod.js".to_string(),
+                base_path: Some("src".to_string()),
+                include: Some(vec!["**/*.ts".to_string(), "**/*.tsx".to_string()]),
+                exclude: None,
+                no_gitignore: Some(false),
+                include_hidden: Some(false),
+                max_threads: Some(4),
+                dry_run: Some(false),
+                language: Some("typescript".to_string()),
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Assert the step executed successfully
+    assert!(
+        result.is_ok(),
+        "TypeScript JS AST grep step should execute successfully: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step_dry_run() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a codemod file
+    create_test_file(
+        temp_path,
+        "dry-run-codemod.js",
+        r#"
+export default function transform(ast) {
+  return ast
+    .findAll({ rule: { pattern: 'var $VAR = $VALUE' } })
+    .replace('const $VAR = $VALUE');
+}
+"#,
+    );
+
+    // Create test file
+    create_test_file(
+        temp_path,
+        "test.js",
+        r#"
+var name = "test";
+var count = 0;
+"#,
+    );
+
+    // Create engine and test execution with dry run
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "dry-run-codemod.js".to_string(),
+                base_path: None, // Use current directory
+                include: Some(vec!["**/*.js".to_string()]),
+                exclude: None,
+                no_gitignore: Some(false),
+                include_hidden: Some(false),
+                max_threads: None,   // Use default
+                dry_run: Some(true), // Enable dry run
+                language: Some("javascript".to_string()),
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Assert the step executed successfully
+    assert!(
+        result.is_ok(),
+        "Dry run JS AST grep step should execute successfully: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step_nonexistent_js_file() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create test file but no codemod
+    create_test_file(temp_path, "test.js", "console.log('test');");
+
+    // Create engine and test execution with nonexistent JavaScript file
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "nonexistent-codemod.js".to_string(),
+                base_path: None,
+                include: None,
+                exclude: None,
+                no_gitignore: Some(false),
+                include_hidden: Some(false),
+                max_threads: None,
+                dry_run: Some(false),
+                language: None,
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Should fail gracefully
+    assert!(result.is_err(), "Should fail with nonexistent JS file");
+    assert!(result.unwrap_err().to_string().contains("JavaScript file"));
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step_with_gitignore() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a codemod file
+    create_test_file(
+        temp_path,
+        "gitignore-codemod.js",
+        r#"
+export default function transform(ast) {
+  return ast
+    .findAll({ rule: { pattern: 'console.log($$$)' } })
+    .replace('logger.info($$$)');
+}
+"#,
+    );
+
+    // Create .gitignore file
+    create_test_file(
+        temp_path,
+        ".gitignore",
+        r#"
+node_modules/
+*.log
+build/
+"#,
+    );
+
+    // Create test files in different locations
+    create_test_file(temp_path, "src/app.js", "console.log('main app');");
+    create_test_file(temp_path, "build/dist.js", "console.log('built file');");
+    create_test_file(
+        temp_path,
+        "node_modules/lib.js",
+        "console.log('dependency');",
+    );
+
+    // Create engine and test execution respecting gitignore
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "gitignore-codemod.js".to_string(),
+                base_path: None,
+                include: Some(vec!["**/*.js".to_string()]),
+                exclude: None,
+                no_gitignore: Some(false), // Respect gitignore
+                include_hidden: Some(false),
+                max_threads: Some(1),
+                dry_run: Some(false),
+                language: Some("javascript".to_string()),
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Assert the step executed successfully
+    assert!(
+        result.is_ok(),
+        "JS AST grep step with gitignore should execute successfully: {:?}",
+        result
+    );
+
+    // Test without respecting gitignore
+    let result_no_gitignore = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "gitignore-codemod.js".to_string(),
+                base_path: None,
+                include: Some(vec!["**/*.js".to_string()]),
+                exclude: None,
+                no_gitignore: Some(true), // Don't respect gitignore
+                include_hidden: Some(false),
+                max_threads: Some(1),
+                dry_run: Some(false),
+                language: Some("javascript".to_string()),
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Should also succeed
+    assert!(
+        result_no_gitignore.is_ok(),
+        "JS AST grep step without gitignore should execute successfully: {:?}",
+        result_no_gitignore
+    );
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step_with_hidden_files() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a codemod file
+    create_test_file(
+        temp_path,
+        "hidden-codemod.js",
+        r#"
+export default function transform(ast) {
+  return ast
+    .findAll({ rule: { pattern: 'const $VAR = $VALUE' } })
+    .replace('let $VAR = $VALUE');
+}
+"#,
+    );
+
+    // Create hidden file
+    create_test_file(temp_path, ".hidden.js", "const secret = 'hidden';");
+
+    // Create regular file
+    create_test_file(temp_path, "regular.js", "const normal = 'visible';");
+
+    // Create engine and test execution including hidden files
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "hidden-codemod.js".to_string(),
+                base_path: None,
+                include: Some(vec!["**/*.js".to_string()]),
+                exclude: None,
+                no_gitignore: Some(false),
+                include_hidden: Some(true), // Include hidden files
+                max_threads: Some(1),
+                dry_run: Some(false),
+                language: Some("javascript".to_string()),
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Assert the step executed successfully
+    assert!(
+        result.is_ok(),
+        "JS AST grep step with hidden files should execute successfully: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step_invalid_max_threads() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a simple codemod file
+    create_test_file(
+        temp_path,
+        "codemod.js",
+        r#"
+export default function transform(ast) {
+  return ast;
+}
+"#,
+    );
+
+    // Create test file
+    create_test_file(temp_path, "test.js", "console.log('test');");
+
+    // Create engine and test execution with invalid max_threads
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "codemod.js".to_string(),
+                base_path: None,
+                include: None,
+                exclude: None,
+                no_gitignore: Some(false),
+                include_hidden: Some(false),
+                max_threads: Some(0), // Invalid: must be > 0
+                dry_run: Some(false),
+                language: None,
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Should fail gracefully
+    assert!(result.is_err(), "Should fail with invalid max_threads");
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("max-threads must be greater than 0"));
+}
+
+#[tokio::test]
+async fn test_execute_js_ast_grep_step_invalid_language() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create a simple codemod file
+    create_test_file(
+        temp_path,
+        "codemod.js",
+        r#"
+export default function transform(ast) {
+  return ast;
+}
+"#,
+    );
+
+    // Create test file
+    create_test_file(temp_path, "test.js", "console.log('test');");
+
+    // Create engine and test execution with invalid language
+    let engine = Engine::new();
+    let result = engine
+        .execute_js_ast_grep_step_with_dir(
+            &UseJSAstGrep {
+                js_file: "codemod.js".to_string(),
+                base_path: None,
+                include: None,
+                exclude: None,
+                no_gitignore: Some(false),
+                include_hidden: Some(false),
+                max_threads: None,
+                dry_run: Some(false),
+                language: Some("invalid-language".to_string()), // Invalid language
+            },
+            Some(temp_path),
+        )
+        .await;
+
+    // Should fail gracefully
+    assert!(result.is_err(), "Should fail with invalid language");
+    assert!(result.unwrap_err().to_string().contains("Invalid language"));
+}
+
+// Helper function to create a workflow with JSAstGrep step
+fn create_js_ast_grep_workflow() -> Workflow {
+    Workflow {
+        version: "1".to_string(),
+        state: None,
+        templates: vec![],
+        nodes: vec![Node {
+            id: "js-ast-grep-node".to_string(),
+            name: "JS AST Grep Node".to_string(),
+            description: Some("Test node for JS AST grep".to_string()),
+            r#type: NodeType::Automatic,
+            depends_on: vec![],
+            trigger: None,
+            strategy: None,
+            runtime: Some(Runtime {
+                r#type: RuntimeType::Direct,
+                image: None,
+                working_dir: None,
+                user: None,
+                network: None,
+                options: None,
+            }),
+            steps: vec![Step {
+                name: "JS AST Grep Step".to_string(),
+                action: StepAction::JSAstGrep(UseJSAstGrep {
+                    js_file: "codemod.js".to_string(),
+                    base_path: Some("src".to_string()),
+                    include: Some(vec!["**/*.js".to_string()]),
+                    exclude: None,
+                    no_gitignore: Some(false),
+                    include_hidden: Some(false),
+                    max_threads: Some(2),
+                    dry_run: Some(false),
+                    language: Some("javascript".to_string()),
+                }),
+                env: None,
+            }],
+            env: HashMap::new(),
+        }],
+    }
+}
+
+#[tokio::test]
+async fn test_js_ast_grep_workflow_execution() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create codemod and test files
+    create_test_file(
+        temp_path,
+        "codemod.js",
+        r#"
+import { CallExpression } from '@ast-grep/napi';
+
+export default function transform(ast) {
+  return ast
+    .findAll({ rule: { pattern: 'console.log($$$)' } })
+    .replace('logger.info($$$)');
+}
+"#,
+    );
+
+    create_test_file(temp_path, "src/app.js", "console.log('Hello, World!');");
+
+    // Create engine with workflow
+    let state_adapter = Box::new(MockStateAdapter::new());
+    let engine = Engine::with_state_adapter(state_adapter);
+
+    let workflow = create_js_ast_grep_workflow();
+    let params = HashMap::new();
+
+    let workflow_run_id = engine
+        .run_workflow(workflow, params, Some(temp_path.to_path_buf()))
+        .await
+        .unwrap();
+
+    // Allow some time for the workflow to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Get the workflow run
+    let workflow_run = engine.get_workflow_run(workflow_run_id).await.unwrap();
+
+    // Check that the workflow run is running or completed
+    assert!(
+        workflow_run.status == WorkflowStatus::Running
+            || workflow_run.status == WorkflowStatus::Completed
+    );
+
+    // Get the tasks
+    let tasks = engine.get_tasks(workflow_run_id).await.unwrap();
+
+    // There should be at least 1 task
+    assert!(!tasks.is_empty());
+
+    // Check that the task for the JS AST grep node exists
+    let js_ast_grep_task = tasks
+        .iter()
+        .find(|t| t.node_id == "js-ast-grep-node")
+        .unwrap();
+
+    // Check that the task status is valid
+    assert!(
+        js_ast_grep_task.status == TaskStatus::Running
+            || js_ast_grep_task.status == TaskStatus::Completed
+            || js_ast_grep_task.status == TaskStatus::Failed
     );
 }

--- a/crates/models/src/step.rs
+++ b/crates/models/src/step.rs
@@ -33,6 +33,10 @@ pub enum StepAction {
     /// ast-grep
     #[serde(rename = "ast-grep")]
     AstGrep(UseAstGrep),
+
+    /// JavaScript AST grep execution
+    #[serde(rename = "js-ast-grep")]
+    JSAstGrep(UseJSAstGrep),
 }
 
 /// Represents a template use in a step
@@ -67,4 +71,51 @@ pub struct UseAstGrep {
 
     /// Path to the ast-grep config file (.yaml)
     pub config_file: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+pub struct UseJSAstGrep {
+    /// Path to the JavaScript file to execute
+    pub js_file: String,
+
+    /// Include globs for files to search (optional, defaults to language-specific extensions)
+    #[serde(default)]
+    #[ts(optional, as = "Option<Vec<String>>")]
+    pub include: Option<Vec<String>>,
+
+    /// Exclude globs for files to skip (optional)
+    #[serde(default)]
+    #[ts(optional, as = "Option<Vec<String>>")]
+    pub exclude: Option<Vec<String>>,
+
+    /// Base path for resolving relative globs (optional, defaults to current working directory)
+    #[serde(default)]
+    #[ts(optional, as = "Option<String>")]
+    pub base_path: Option<String>,
+
+    /// Don't respect .gitignore files (optional, defaults to false)
+    #[serde(default)]
+    #[ts(optional, as = "Option<bool>")]
+    pub no_gitignore: Option<bool>,
+
+    /// Include hidden files and directories (optional, defaults to false)
+    #[serde(default)]
+    #[ts(optional, as = "Option<bool>")]
+    pub include_hidden: Option<bool>,
+
+    /// Set maximum number of concurrent threads (optional, defaults to CPU cores)
+    #[serde(default)]
+    #[ts(optional, as = "Option<usize>")]
+    pub max_threads: Option<usize>,
+
+    /// Perform a dry run without making changes (optional, defaults to false)
+    #[serde(default)]
+    #[ts(optional, as = "Option<bool>")]
+    pub dry_run: Option<bool>,
+
+    /// Language to process (optional)
+    #[serde(default)]
+    #[ts(optional, as = "Option<String>")]
+    pub language: Option<String>,
 }

--- a/crates/models/src/workflow.rs
+++ b/crates/models/src/workflow.rs
@@ -65,10 +65,8 @@ pub struct WorkflowRun {
     #[ts(optional=nullable)]
     pub ended_at: Option<DateTime<Utc>>,
 
-    // This is not persisted, only used during runtime
     /// The absolute path to the root directory of the workflow bundle
     #[ts(skip)]
-    #[serde(skip)]
     pub bundle_path: Option<PathBuf>,
 }
 

--- a/examples/codemods/interface-to-type.js
+++ b/examples/codemods/interface-to-type.js
@@ -1,0 +1,21 @@
+/**
+ * Codemod to convert TypeScript interfaces to type aliases
+ * This is an example codemod for the js-ast-grep workflow
+ */
+
+export default function transform(sgRoot) {
+  const rootNode = sgRoot.root();
+  const interfaces = rootNode.findAll({
+    rule: {
+      pattern: "interface $NAME { $$$BODY }",
+    },
+  });
+
+  const edits = interfaces.map((node) => {
+    const name = node.getMatch("NAME");
+    const body = node.getMatch("BODY");
+    return node.replace(`type ${name} = { ${body} }`);
+  });
+
+  return rootNode.commitEdits(edits);
+}

--- a/examples/codemods/remove-console-logs.js
+++ b/examples/codemods/remove-console-logs.js
@@ -1,0 +1,15 @@
+/**
+ * Codemod to remove console.log statements
+ * This is an example codemod for the js-ast-grep workflow
+ */
+
+export default function transform(ast) {
+  const rootNode = ast.root();
+  const consoleLogs = rootNode.findAll({
+    rule: {
+      pattern: "console.log($$$ARGS);",
+    },
+  });
+
+  return rootNode.commitEdits(consoleLogs.map((node) => node.replace("")));
+}

--- a/examples/codemods/var-to-const.js
+++ b/examples/codemods/var-to-const.js
@@ -1,0 +1,16 @@
+/**
+ * Simple var to let codemod for testing
+ */
+
+export default function transform(sgRoot) {
+  const rootNode = sgRoot.root();
+  const varDeclarations = rootNode.findAll({
+    rule: {
+      pattern: "var $VAR = $VALUE",
+    },
+  });
+
+  return rootNode.commitEdits(
+    varDeclarations.map((node) => node.replace("let $VAR = $VALUE")),
+  );
+}

--- a/examples/js-ast-grep-workflow.yaml
+++ b/examples/js-ast-grep-workflow.yaml
@@ -1,0 +1,55 @@
+name: "JavaScript AST Grep Codemods"
+description: "Example workflow demonstrating js-ast-grep functionality for code transformations"
+version: 1
+
+nodes:
+  - id: "modernize-javascript"
+    name: "Modernize JavaScript Code"
+    steps:
+      - name: "Convert var to const/let"
+        js-ast-grep:
+          js_file: "codemods/var-to-const.js"
+          base_path: "."
+          include:
+            - "**/*.js"
+            - "**/*.mjs"
+          exclude:
+            - "**/node_modules/**"
+            - "**/dist/**"
+          language: "javascript"
+          dry_run: false
+          max_threads: 4
+
+      - name: "Log JavaScript modernization completion"
+        run: "echo 'JavaScript modernization completed'"
+
+  - id: "typescript-migration"
+    name: "TypeScript Migration and Cleanup"
+    depends_on: ["modernize-javascript"]
+    steps:
+      - name: "Convert interfaces to types"
+        js-ast-grep:
+          js_file: "codemods/interface-to-type.js"
+          base_path: "."
+          include:
+            - "**/*.ts"
+            - "**/*.tsx"
+          exclude:
+            - "**/node_modules/**"
+            - "**/*.test.ts"
+            - "**/*.spec.ts"
+          language: "typescript"
+          no_gitignore: false
+          include_hidden: false
+          max_threads: 2
+
+      - name: "Remove console.log statements"
+        js-ast-grep:
+          js_file: "codemods/remove-console-logs.js"
+          base_path: "."
+          include:
+            - "**/*.ts"
+            - "**/*.tsx"
+          exclude:
+            - "**/node_modules/**"
+          language: "typescript"

--- a/test-language-inference.yaml
+++ b/test-language-inference.yaml
@@ -1,0 +1,28 @@
+version: "1"
+name: "Test Language Extension Inference"
+description: "Test workflow demonstrating automatic language extension inference"
+
+nodes:
+  - id: test-no-include
+    name: "Test with No Include (Auto-infer)"
+    type: automatic
+    runtime:
+      type: direct
+    steps:
+      - name: "Auto-infer languages from rules"
+        ast-grep:
+          # No include field - should auto-infer from rule languages
+          config_file: "examples/ast-grep-config.yaml"
+
+  - id: test-generic-glob
+    name: "Test with Generic Glob Enhancement"
+    type: automatic
+    runtime:
+      type: direct
+    depends_on: ["test-no-include"]
+    steps:
+      - name: "Enhance generic glob with language extensions"
+        ast-grep:
+          include:
+            - "**" # Generic glob - should be enhanced with .js, .mjs, .cjs extensions
+          config_file: "examples/ast-grep-config.yaml"


### PR DESCRIPTION


<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
- Introduced `JSAstGrep` step type for workflows, enabling JavaScript code transformations.
- Enhanced the execution engine to support include/exclude glob patterns and dry run options for JavaScript files.
- Added new example workflows demonstrating the use of JavaScript codemods for modernizing code and migrating TypeScript.
- Created example codemods for converting `var` to `let`, removing `console.log` statements, and converting TypeScript interfaces to types.
- Updated documentation and examples to reflect new features and usage patterns.

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
