### PR TITLE
docs: remove workflow engine api reference

### DIFF
--- a/apps/docs/building-codemods/codemod2.mdx
+++ b/apps/docs/building-codemods/codemod2.mdx
@@ -143,10 +143,6 @@ npx codemod@latest mui/named-import-to-direct-import --OPENAI_API_KEY=$OPENAI_AP
 
 ![Codemod Diff View](/images/guides/codemod2/diff-view.png)
 
-P.S.
-
-If you want simplify things more, take a look at [workflow engine documentation](/api-reference) and improve code a little bit:
-
 ```tsx
 import type { Api } from '@codemod.com/workflow';
 


### PR DESCRIPTION
Removes reference of deprecated workflow engine api doc.