### PR TITLE
Relative paths can start with a dot for hidden files

### DIFF
--- a/packages/workflow/src/fs/move.ts
+++ b/packages/workflow/src/fs/move.ts
@@ -103,7 +103,7 @@ const renameImport = async (
       ),
       pathPosix.basename(newAbsoluteImportPath),
     );
-    if (!relativePath.startsWith(".")) {
+    if (!relativePath.startsWith("./")) {
       relativePath = `./${relativePath}`;
     }
 


### PR DESCRIPTION

<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

Relative paths can also link to hidden directories (e.g. `.nuxt/eslint.config.mjs`). The check for "is it already a relative path" should therefore be for `./` - not just for `.`.

#### 🔗 Linked Issue

Fixes #1425
Fixes #1247
fixes [#commons/issues/66 ](https://github.com/codemod-com/commons/issues/66)

#### 🧪 Test Plan

* Create a plain nuxt project including eslint
* add `  future: {    compatibilityVersion: 4,  },` to the nuxt config
* run codemod `nuxt/4/file-structure` against this

Before / without this PR: 

![image](https://github.com/user-attachments/assets/f497118d-f970-41bb-9e67-4ad24cb1372f)

After: no change to the eslint.config.mjs file

