### PR TITLE
docs: Improve new CLI docs

### DIFF
--- a/apps/docs/cli/cli-reference.mdx
+++ b/apps/docs/cli/cli-reference.mdx
@@ -82,6 +82,15 @@ npx codemod@next workflow validate -w <workflow.yaml>
    Validation catches issues before execution, saving time and preventing runtime errors.
 </Info>
 
+<Accordion title="Validation vs. Logical Correctness">
+  The `workflow validate` command ensures your YAML is syntactically correct and follows the schema, but it cannot verify:
+
+  - **Logical correctness**: Whether your workflow does what you intend
+  - **Runtime behavior**: How your workflow behaves with real data
+  - **Dependencies**: Whether external files/scripts exist
+  - **State consistency**: Whether state updates are logically sound
+  </Accordion>
+
 #### `workflow status`
 
 Show workflow run status.

--- a/apps/docs/cli/cli-reference.mdx
+++ b/apps/docs/cli/cli-reference.mdx
@@ -23,38 +23,47 @@ Codemod CLI (new) is accessible using the `npx codemod@next` command. The follow
 
 Manage and execute workflow YAMLs.
 
-<ResponseField name="workflow run">
-  Run a workflow.
-</ResponseField>
+#### `workflow run`
+
+Run a workflow.
 
 ```bash
 npx codemod@next workflow run -w <workflow.yaml|directory> [--param key=value]
 ```
-
-- `-w, --workflow <PATH>` (string) — Path to workflow file or directory. (required)
-- `--param <KEY=VALUE>` (string) — Workflow parameters (format: key=value).
-
-<ResponseField name="workflow resume">
-  Resume a paused workflow.
+<ResponseField name="-w, --workflow <PATH>" type="string" required>
+  Path to workflow file or directory.
 </ResponseField>
+<ResponseField name="--param <KEY=VALUE>" type="string">
+  Workflow parameters (format: key=value).
+</ResponseField>
+
+#### `workflow resume`
+
+Resume a paused workflow.
 
 ```bash
 npx codemod@next workflow resume -i <ID> [-t <TASK>] [--trigger-all]
 ```
-
-- `-i, --id <ID>` (string) — Workflow run ID. (required)
-- `-t, --task <TASK>` (string) — Task ID to trigger (can be specified multiple times).
-- `--trigger-all` (boolean) — Trigger all awaiting tasks.
-
-<ResponseField name="workflow validate">
-  Validate a workflow file.
+<ResponseField name="-i, --id <ID>" type="string" required>
+  Workflow run ID.
 </ResponseField>
+<ResponseField name="-t, --task <TASK>" type="string">
+  Task ID to trigger (can be specified multiple times).
+</ResponseField>
+<ResponseField name="--trigger-all" type="boolean">
+  Trigger all awaiting tasks.
+</ResponseField>
+
+#### `workflow validate`
+
+Validate a workflow file.
 
 ```bash
 npx codemod@next workflow validate -w <workflow.yaml>
 ```
-
-- `-w, --workflow <FILE>` (string) — Path to workflow file. (required)
+<ResponseField name="-w, --workflow <FILE>" type="string" required>
+  Path to workflow file.
+</ResponseField>
 
 | Check                       | Ensures                                |
 | --------------------------- | -------------------------------------- |
@@ -68,44 +77,43 @@ npx codemod@next workflow validate -w <workflow.yaml>
 | Variable syntax             | `${{…}}` uses `params`, `env`, `state` |
 
 <Info>
-  <b>
   Why validate?
-  </b>
 
    Validation catches issues before execution, saving time and preventing runtime errors.
 </Info>
 
-<ResponseField name="workflow status">
-  Show workflow run status.
-</ResponseField>
+#### `workflow status`
+
+Show workflow run status.
 
 ```bash
 npx codemod@next workflow status -i <ID>
 ```
-
-- `-i, --id <ID>` (string) — Workflow run ID. (required)
-
-<ResponseField name="workflow list">
-  List workflow runs.
+<ResponseField name="-i, --id <ID>" type="string" required>
+  Workflow run ID.
 </ResponseField>
+
+#### `workflow list`
+
+List workflow runs.
 
 ```bash
 npx codemod@next workflow list [-l <LIMIT>]
 ```
-
-- `-l, --limit <LIMIT>` (number) — Number of workflow runs to show. (default: 10)
-
-<ResponseField name="workflow cancel">
-  Cancel a workflow run.
+<ResponseField name="-l, --limit <LIMIT>" type="number">
+  Number of workflow runs to show. (default: 10)
 </ResponseField>
+
+#### `workflow cancel`
+
+Cancel a workflow run.
 
 ```bash
 npx codemod@next workflow cancel -i <ID>
 ```
-
-- `-i, --id <ID>` (string) — Workflow run ID. (required)
-
----
+<ResponseField name="-i, --id <ID>" type="string" required>
+  Workflow run ID.
+</ResponseField>
 
 ### `codemod@next jssg`
 

--- a/apps/docs/cli/workflows.mdx
+++ b/apps/docs/cli/workflows.mdx
@@ -57,10 +57,9 @@ Codemod Workflows can be run using [Codemod CLI](cli/cli-reference) or [Codemod 
     ```
   </Step>
   <Step title="Understand the example workflow">
-    The generated `workflow.yaml` defines a simple workflow that applies an AST-grep rule to all TypeScript files in the `src/` directory (excluding test files):
+    The generated `workflow.yaml` (when you choose the YAML-based ast-grep codemod for JavaScript/TypeScript) defines a simple workflow that applies an AST-grep rule to all TypeScript files in the `src/` directory (excluding test files):
 
     ```yaml
-    id: example-codemod
     version: "1"
     nodes:
       - id: apply-rules
@@ -82,15 +81,16 @@ Codemod Workflows can be run using [Codemod CLI](cli/cli-reference) or [Codemod 
 
     ```yaml
     id: replace-console-log
-    language: tsx
+    language: javascript
     rule:
       any:
         - pattern: console.log($ARG)
+        - pattern: console.debug($ARG)
     fix:
       logger.log($ARG)
     ```
 
-    This rule will replace all `console.log(...)` calls with `logger.log(...)` in your TypeScript/TSX files.
+    This rule will replace all `console.log(...)` and `console.debug(...)` calls with `logger.log(...)` in your TypeScript/JavaScript files.
   </Step>
   <Step title="Validate & run your workflow">
     ```bash
@@ -98,6 +98,12 @@ Codemod Workflows can be run using [Codemod CLI](cli/cli-reference) or [Codemod 
     npx codemod@next workflow run -w workflow.yaml
     ```
     This will check your workflow for errors and then run it locally.
+
+    <Info>
+    The `workflow validate` command checks syntax and schema compliance, but not logical correctness. Always test your workflows with real data to ensure they behave as expected. 
+    
+    Learn more about validating workflows [here](/cli/cli-reference#workflow-validate).
+    </Info>
   </Step>
 </Steps>
 
@@ -152,6 +158,7 @@ A workflow has four top-level keys:
 ## Shared State
 
 ```yaml
+version: "1"
 state:
   schema:
     - name: shards
@@ -168,6 +175,7 @@ state:
 ## Templates
 
 ```yaml
+version: "1"
 templates:
   - id: checkout-repo
     name: Checkout Repository
@@ -202,6 +210,7 @@ steps:
 ### Nodes
 
 ```yaml
+version: "1"
 nodes:
   - id: build
     name: Build
@@ -255,6 +264,16 @@ nodes:
 ## Matrix Strategy
 
 ```yaml
+version: "1"
+state:
+  schema:
+    - name: shards
+      type: array
+      items:
+        type: object
+        properties:
+          team: { type: string }
+          shardId: { type: string }
 nodes:
   - id: matrix-codemod
     name: Matrix Codemod
@@ -283,6 +302,7 @@ Matrix nodes have a <b>master task</b> that tracks the status of all generated t
 ## Manual Trigger
 
 ```yaml
+version: "1"
 nodes:
   - id: manual-approval
     name: Manual Approval
@@ -372,6 +392,8 @@ This error is shown when you run `npx codemod@next workflow validate` or `npx co
 
 ## End-to-End Example
 
+This comprehensive workflow demonstrates state management, templates, matrix strategies, and manual triggers:
+
 ```yaml
 version: "1"
 state:
@@ -413,6 +435,15 @@ nodes:
       - name: PR
         run: codemodctl pr create
 ```
+
+**What this workflow does:**
+
+1. **State Management**: Defines a `shards` array to store team and shard information
+2. **Template Reuse**: Creates a reusable `checkout-repo` template for cloning repositories
+3. **Dynamic State**: The `make-shards` node populates the state with shard data
+4. **Matrix Execution**: The `matrix-codemod` node creates parallel tasks for each shard
+5. **Manual Gates**: Requires approval before running the codemod on each shard
+6. **Multi-step Tasks**: Each matrix task runs both the codemod and creates a PR
 
 ---
 

--- a/apps/docs/cli/workflows.mdx
+++ b/apps/docs/cli/workflows.mdx
@@ -168,6 +168,7 @@ state:
         properties:
           team:    { type: string }
           shardId: { type: string }
+nodes: []
 ```
 
 ---
@@ -192,16 +193,9 @@ templates:
 
 Templates can define required or optional inputs, which are referenced in their steps.
 
-To use a template in a node step:
-
-```yaml
-steps:
-  - name: Checkout
-    uses:
-      - template: checkout-repo
-        inputs:
-          repo_url: ${{params.repo_url}}
-```
+<Info>
+Template usage in node steps is planned for future releases. For now, templates serve as reusable workflow components that can be referenced in documentation and examples.
+</Info>
 
 ---
 
@@ -371,9 +365,17 @@ If your workflow has a cycle:
 ```yaml
 nodes:
   - id: a
+    name: Task A
     depends_on: [b]
+    steps:
+      - name: Task A
+        run: echo "Task A"
   - id: b
+    name: Task B
     depends_on: [a]
+    steps:
+      - name: Task B
+        run: echo "Task B"
 ```
 
 You'll see:


### PR DESCRIPTION
- CLI Reference: Convert subcommand headings to H4s and switch subcommands' options to Mintlify ResponseFields
- Workflows: Fix Quick Start example to match actual CLI output, validate all workflow examples, and fix missing required fields
- Examples: Ensure all workflow examples pass `npx codemod@next workflow validate `and are syntactically correct