### PR TITLE
feat(CLI): add git dirty check for `run` commands

### DIFF
--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -8,6 +8,8 @@ use codemod_sandbox::sandbox::{
 };
 use std::{path::Path, sync::Arc};
 
+use crate::dirty_git_check;
+
 #[derive(Args, Debug)]
 pub struct Command {
     /// Path to the JavaScript file to execute
@@ -39,6 +41,10 @@ pub struct Command {
     /// File extensions to process (comma-separated)
     #[arg(long)]
     pub extensions: Option<String>,
+
+    /// Allow dirty git status
+    #[arg(long)]
+    pub allow_dirty: bool,
 }
 
 pub async fn handler(args: &Command) -> Result<()> {
@@ -59,6 +65,8 @@ pub async fn handler(args: &Command) -> Result<()> {
 
     let mut config = ExecutionConfig::new(filesystem, resolver, loader, script_base_dir);
     let mut walk_options = WalkOptions::default();
+
+    dirty_git_check::dirt_check(args.allow_dirty)?;
 
     // Apply command line options
     if args.no_gitignore {

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -66,7 +66,7 @@ pub async fn handler(args: &Command) -> Result<()> {
     let mut config = ExecutionConfig::new(filesystem, resolver, loader, script_base_dir);
     let mut walk_options = WalkOptions::default();
 
-    dirty_git_check::dirt_check(args.allow_dirty)?;
+    dirty_git_check::dirty_check(args.allow_dirty)?;
 
     // Apply command line options
     if args.no_gitignore {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 
 use crate::auth_provider::CliAuthProvider;
+use crate::dirty_git_check;
 use crate::workflow_runner::{run_workflow, WorkflowRunConfig};
 use butterflow_core::engine::Engine;
 use butterflow_core::registry::{RegistryClient, RegistryConfig, RegistryError};
@@ -35,11 +36,17 @@ pub struct Command {
     /// Additional arguments to pass to the codemod
     #[arg(last = true)]
     args: Vec<String>,
+
+    /// Allow dirty git status
+    #[arg(long)]
+    allow_dirty: bool,
 }
 
 pub async fn handler(engine: &Engine, args: &Command) -> Result<()> {
     // Create auth provider
     let auth_provider = CliAuthProvider::new()?;
+
+    dirty_git_check::dirt_check(args.allow_dirty)?;
 
     // Get cache directory and default registry from config
     let cache_dir = get_cache_dir()?;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -46,7 +46,7 @@ pub async fn handler(engine: &Engine, args: &Command) -> Result<()> {
     // Create auth provider
     let auth_provider = CliAuthProvider::new()?;
 
-    dirty_git_check::dirt_check(args.allow_dirty)?;
+    dirty_git_check::dirty_check(args.allow_dirty)?;
 
     // Get cache directory and default registry from config
     let cache_dir = get_cache_dir()?;

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -37,7 +37,7 @@ pub async fn handler(engine: &Engine, args: &Command) -> Result<()> {
         wait_for_completion: true,
     };
 
-    dirty_git_check::dirt_check(args.allow_dirty)?;
+    dirty_git_check::dirty_check(args.allow_dirty)?;
 
     // Run workflow using the extracted workflow runner
     run_workflow(engine, config).await?;

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -3,6 +3,7 @@ use butterflow_core::engine::Engine;
 use butterflow_core::utils;
 use clap::Args;
 
+use crate::dirty_git_check;
 use crate::workflow_runner::{resolve_workflow_source, run_workflow, WorkflowRunConfig};
 
 #[derive(Args, Debug)]
@@ -14,6 +15,10 @@ pub struct Command {
     /// Workflow parameters (format: key=value)
     #[arg(long = "param", value_name = "KEY=VALUE")]
     params: Vec<String>,
+
+    /// Allow dirty git status
+    #[arg(long)]
+    allow_dirty: bool,
 }
 
 /// Run a workflow
@@ -31,6 +36,8 @@ pub async fn handler(engine: &Engine, args: &Command) -> Result<()> {
         params,
         wait_for_completion: true,
     };
+
+    dirty_git_check::dirt_check(args.allow_dirty)?;
 
     // Run workflow using the extracted workflow runner
     run_workflow(engine, config).await?;

--- a/crates/cli/src/dirty_git_check.rs
+++ b/crates/cli/src/dirty_git_check.rs
@@ -1,10 +1,14 @@
 use anyhow::Result;
 use inquire::Confirm;
-use std::process::Command as ProcessCommand;
+use std::path::Path;
+use std::process::Command;
 
-pub fn dirt_check(allow_dirty: bool) -> Result<()> {
-    if !allow_dirty {
-        let output = ProcessCommand::new("git")
+pub fn dirty_check(allow_dirty: bool) -> Result<()> {
+    if !allow_dirty
+        && Command::new("git").arg("--version").output().is_ok()
+        && Path::new(".git").exists()
+    {
+        let output = Command::new("git")
             .args(["status", "--porcelain"])
             .output()
             .expect("Failed to run git");

--- a/crates/cli/src/dirty_git_check.rs
+++ b/crates/cli/src/dirty_git_check.rs
@@ -13,10 +13,7 @@ pub fn dirty_check(allow_dirty: bool) -> Result<()> {
             .output()
             .expect("Failed to run git");
 
-        if !output.stdout.is_empty()
-            && !String::from_utf8_lossy(&output.stdout)
-                .contains("nothing to commit, working tree clean")
-        {
+        if !output.stdout.is_empty() {
             let answer =
                 Confirm::new("⚠️  You have uncommitted changes. Do you want to continue anyway?")
                     .with_default(false)

--- a/crates/cli/src/dirty_git_check.rs
+++ b/crates/cli/src/dirty_git_check.rs
@@ -1,0 +1,28 @@
+use std::io::{self, Write};
+
+use anyhow::Result;
+use std::process::Command as ProcessCommand;
+
+pub fn dirt_check(allow_dirty: bool) -> Result<()> {
+    if !allow_dirty {
+        let output = ProcessCommand::new("git")
+            .args(["status", "--porcelain"])
+            .output()
+            .expect("Failed to run git");
+
+        if !output.stdout.is_empty()
+            && !String::from_utf8_lossy(&output.stdout)
+                .contains("nothing to commit, working tree clean")
+        {
+            print!("⚠️  You have uncommitted changes. Do you want to continue anyway? [y/N]: ");
+            io::stdout().flush().unwrap();
+            let mut answer = String::new();
+            io::stdin().read_line(&mut answer).unwrap();
+            if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+                return Err(anyhow::anyhow!("Aborting due to uncommitted changes"));
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/dirty_git_check.rs
+++ b/crates/cli/src/dirty_git_check.rs
@@ -1,6 +1,5 @@
-use std::io::{self, Write};
-
 use anyhow::Result;
+use inquire::Confirm;
 use std::process::Command as ProcessCommand;
 
 pub fn dirt_check(allow_dirty: bool) -> Result<()> {
@@ -14,11 +13,13 @@ pub fn dirt_check(allow_dirty: bool) -> Result<()> {
             && !String::from_utf8_lossy(&output.stdout)
                 .contains("nothing to commit, working tree clean")
         {
-            print!("⚠️  You have uncommitted changes. Do you want to continue anyway? [y/N]: ");
-            io::stdout().flush().unwrap();
-            let mut answer = String::new();
-            io::stdin().read_line(&mut answer).unwrap();
-            if !matches!(answer.trim().to_lowercase().as_str(), "y" | "yes") {
+            let answer =
+                Confirm::new("⚠️  You have uncommitted changes. Do you want to continue anyway?")
+                    .with_default(false)
+                    .with_help_message("Press 'y' to continue or 'n' to abort")
+                    .prompt()?;
+
+            if !answer {
                 return Err(anyhow::anyhow!("Aborting due to uncommitted changes"));
             }
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,6 +6,7 @@ mod ascii_art;
 mod auth;
 mod auth_provider;
 mod commands;
+mod dirty_git_check;
 mod engine;
 mod workflow_runner;
 use ascii_art::print_ascii_art;


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine  
feat(cli)!: revamp the design (BREAKING CHANGE)  
fix(cli): fix a bug for the formatter  
chore(backend): upgrade node  
docs: improve codemod publish docs  
refactor(registry www): modularize filters  
test(vsce): add tests for VS Code extension  
-->

#### 📚 Description

This PR adds support for detecting a dirty Git working tree before executing codemod using run commands. This feature has been integrated into the following commands:
- `run`
- `jssg/run`
- `workflow/run`

If the repository contains uncommitted changes, a warning will be displayed to inform users before proceeding. This ensures improved awareness and safety during codemod executions.


#### 🧪 Test Plan
- Verified that the dirty state check works for all 3 run-related commands.
- Manually tested the behavior with both clean and dirty Git states.
- Confirmed that warnings are shown appropriately and command behavior remains unchanged otherwise.
- Confirmed `--allow-dirty` is working as well
