### PR TITLE
feat(cli): add non-interactive mode for init command

### DIFF
--- a/crates/cli/src/commands/init.rs
+++ b/crates/cli/src/commands/init.rs
@@ -121,7 +121,7 @@ pub fn handler(args: &Command) -> Result<()> {
     let (project_path, project_name) = if args.no_interactive {
         let project_path = match args.path.clone() {
             Some(path) => path,
-            None => return Err(anyhow!("Path argument is required --path")),
+            None => return Err(anyhow!("Path argument is required")),
         };
 
         let project_name = match args.name.clone() {


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine  
feat(cli)!: revamp the design (BREAKING CHANGE)  
fix(cli): fix a bug for the formatter  
chore(backend): upgrade node  
docs: improve codemod publish docs  
refactor(registry www): modularize filters  
test(vsce): add tests for VS Code extension  
-->

#### 📚 Description
This PR introduces support for a **non-interactive mode** in the `init` command of the CLI. This enables users to initialize projects programmatically or in CI/CD pipelines without manual input.  
This enhancement will significantly improve automation and scripting capabilities for users of the Codemod CLI.
example commands:
```bash
codemod init --no-interactive --author=amirabbas08dev@gmail.com --project-type=ast-grep-js --description=lorem --license=MIT --package-manager=pnpm --language=Python ./test233
```
```bash
codemod init --no-interactive --author=amirabbas08dev@gmail.com --project-type=ast-grep-yaml --description=lorem --license=MIT --language=rust ./yamlcodemod
```

#### 🧪 Test Plan
- Ran `codemod init --non-interactive` with all required flags and verified successful initialization.
- Manually tested error handling when required options are missing.
- Confirmed interactive mode behavior remains unchanged.