### PR TITLE
feat(cli): bundle jssg codemods pre-publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "js-sys",
  "llrt_modules",
  "oxc_resolver",
+ "regex",
  "rquickjs 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rquickjs 0.9.0 (git+https://github.com/DelSkayn/rquickjs.git)",
  "serde",

--- a/crates/cli/src/commands/jssg/bundle.rs
+++ b/crates/cli/src/commands/jssg/bundle.rs
@@ -1,0 +1,217 @@
+use anyhow::Result;
+use clap::Parser;
+use codemod_sandbox::utils::{
+    bundler::{Bundler, BundlerConfig, RuntimeSystem},
+    project_discovery::find_tsconfig,
+};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug, Clone)]
+pub struct Command {
+    /// Path to the entry JavaScript/TypeScript file to bundle
+    pub entry_path: PathBuf,
+
+    /// Path to tsconfig.json file (optional, will be auto-discovered if not provided)
+    #[arg(long)]
+    pub tsconfig: Option<PathBuf>,
+
+    /// Output file path for the bundle (optional, defaults to stdout)
+    #[arg(long, short)]
+    pub output: Option<PathBuf>,
+
+    /// Base directory for module resolution (defaults to entry file's directory)
+    #[arg(long)]
+    pub base_dir: Option<PathBuf>,
+
+    /// Runtime module system to use
+    #[arg(long, value_enum, default_value = "commonjs")]
+    pub runtime: RuntimeSystemArg,
+
+    /// Enable source maps
+    #[arg(long)]
+    pub source_maps: bool,
+
+    /// Verbose output
+    #[arg(long, short)]
+    pub verbose: bool,
+}
+
+#[derive(clap::ValueEnum, Clone, Debug, PartialEq)]
+pub enum RuntimeSystemArg {
+    /// CommonJS module system (module.exports/require)
+    Commonjs,
+    /// Custom lightweight runtime system
+    Custom,
+}
+
+impl From<RuntimeSystemArg> for RuntimeSystem {
+    fn from(arg: RuntimeSystemArg) -> Self {
+        match arg {
+            RuntimeSystemArg::Commonjs => RuntimeSystem::CommonJS,
+            RuntimeSystemArg::Custom => RuntimeSystem::Custom,
+        }
+    }
+}
+
+impl Command {
+    pub async fn run(self) -> Result<()> {
+        let entry_path = self.entry_path.canonicalize().map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to resolve entry path '{}': {}",
+                self.entry_path.display(),
+                e
+            )
+        })?;
+
+        if self.verbose {
+            eprintln!("📦 Bundling entry point: {}", entry_path.display());
+        }
+
+        // Determine base directory
+        let base_dir = if let Some(base_dir) = self.base_dir {
+            base_dir.canonicalize().map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to resolve base directory '{}': {}",
+                    base_dir.display(),
+                    e
+                )
+            })?
+        } else {
+            entry_path
+                .parent()
+                .ok_or_else(|| anyhow::anyhow!("Entry path has no parent directory"))?
+                .to_path_buf()
+        };
+
+        if self.verbose {
+            eprintln!("📁 Base directory: {}", base_dir.display());
+        }
+
+        // Determine tsconfig path
+        let tsconfig_path = if let Some(tsconfig) = self.tsconfig {
+            let resolved = tsconfig.canonicalize().map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to resolve tsconfig path '{}': {}",
+                    tsconfig.display(),
+                    e
+                )
+            })?;
+            if self.verbose {
+                eprintln!("⚙️  Using provided tsconfig: {}", resolved.display());
+            }
+            Some(resolved)
+        } else {
+            // Auto-discover tsconfig.json
+            let discovered = find_tsconfig(&base_dir);
+            if let Some(ref path) = discovered {
+                if self.verbose {
+                    eprintln!("⚙️  Auto-discovered tsconfig: {}", path.display());
+                }
+            } else if self.verbose {
+                eprintln!(
+                    "⚙️  No tsconfig.json found, proceeding without TypeScript configuration"
+                );
+            }
+            discovered
+        };
+
+        // Configure bundler
+        let config = BundlerConfig {
+            base_dir: base_dir.clone(),
+            tsconfig_path,
+            runtime_system: self.runtime.into(),
+            source_maps: self.source_maps,
+        };
+
+        if self.verbose {
+            eprintln!("🔧 Runtime system: {:?}", config.runtime_system);
+            eprintln!("🗺️  Source maps: {}", config.source_maps);
+        }
+
+        // Create bundler
+        let mut bundler =
+            Bundler::new(config).map_err(|e| anyhow::anyhow!("Failed to create bundler: {}", e))?;
+
+        // Bundle the entry file
+        let result = bundler
+            .bundle(entry_path.to_str().unwrap())
+            .map_err(|e| anyhow::anyhow!("Bundling failed: {}", e))?;
+
+        if self.verbose {
+            eprintln!("✅ Bundle created successfully!");
+            eprintln!("   📊 Modules bundled: {}", result.modules.len());
+            eprintln!("   📏 Bundle size: {} bytes", result.code.len());
+
+            // List bundled modules
+            eprintln!("\n📋 Bundled modules:");
+            for module in &result.modules {
+                eprintln!("   • {}", module.id);
+                if !module.dependencies.is_empty() && self.verbose {
+                    eprintln!("     └─ Dependencies: {:?}", module.dependencies);
+                }
+            }
+            eprintln!();
+        }
+
+        // Output the bundle
+        if let Some(output_path) = self.output {
+            std::fs::write(&output_path, &result.code).map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to write bundle to '{}': {}",
+                    output_path.display(),
+                    e
+                )
+            })?;
+
+            if self.verbose {
+                eprintln!("💾 Bundle written to: {}", output_path.display());
+            }
+        } else {
+            // Output to stdout
+            println!("{}", result.code);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_bundle_command_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let entry_path = temp_dir.path().join("index.js");
+        fs::write(&entry_path, "console.log('Hello, world!');").unwrap();
+
+        let command = Command {
+            entry_path: entry_path.clone(),
+            tsconfig: None,
+            output: None,
+            base_dir: None,
+            runtime: RuntimeSystemArg::Commonjs,
+            source_maps: false,
+            verbose: false,
+        };
+
+        // Should not panic when creating the command
+        assert_eq!(command.entry_path, entry_path);
+        assert_eq!(command.runtime, RuntimeSystemArg::Commonjs);
+        assert!(!command.source_maps);
+    }
+
+    #[test]
+    fn test_runtime_system_conversion() {
+        assert!(matches!(
+            RuntimeSystem::from(RuntimeSystemArg::Commonjs),
+            RuntimeSystem::CommonJS
+        ));
+        assert!(matches!(
+            RuntimeSystem::from(RuntimeSystemArg::Custom),
+            RuntimeSystem::Custom
+        ));
+    }
+}

--- a/crates/cli/src/commands/jssg/mod.rs
+++ b/crates/cli/src/commands/jssg/mod.rs
@@ -1,3 +1,4 @@
+pub mod bundle;
 pub mod run;
 pub mod test;
 pub mod testing;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -105,6 +105,8 @@ enum WorkflowCommands {
 
 #[derive(Subcommand, Debug)]
 enum JssgCommands {
+    /// Bundle JavaScript/TypeScript files and dependencies
+    Bundle(commands::jssg::bundle::Command),
     /// Run JavaScript code transformation
     Run(commands::jssg::run::Command),
     /// Test JavaScript code transformations
@@ -246,6 +248,9 @@ async fn main() -> Result<()> {
             }
         },
         Some(Commands::Jssg(args)) => match &args.command {
+            JssgCommands::Bundle(args) => {
+                args.clone().run().await?;
+            }
             JssgCommands::Run(args) => {
                 commands::jssg::run::handler(args).await?;
             }

--- a/crates/codemod-sandbox/Cargo.toml
+++ b/crates/codemod-sandbox/Cargo.toml
@@ -9,6 +9,7 @@ rquickjs-git = { package = "rquickjs", git = "https://github.com/DelSkayn/rquick
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+regex = { workspace = true }
 tokio = { version = "1.0", features = [
   "rt-multi-thread",
   "macros",

--- a/crates/codemod-sandbox/src/utils/bundler/mod.rs
+++ b/crates/codemod-sandbox/src/utils/bundler/mod.rs
@@ -1,0 +1,593 @@
+use crate::sandbox::resolvers::{oxc_resolver::OxcResolver, traits::ModuleResolver};
+use crate::utils::bundler::module_analyzer::{ModuleAnalyzer, ModuleExports};
+use crate::utils::bundler::module_transformer::ModuleTransformer;
+use crate::utils::transpiler;
+use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
+use swc_core::common::SourceMap;
+use swc_core::ecma::codegen::{text_writer::JsWriter, Emitter};
+use swc_core::{
+    common::{BytePos, FileName},
+    ecma::{
+        ast::{EsVersion, ModuleItem},
+        parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax},
+        visit::{VisitMutWith, VisitWith},
+    },
+};
+
+mod module_analyzer;
+mod module_transformer;
+
+/// Represents a module in the dependency graph
+#[derive(Debug, Clone)]
+pub struct BundledModule {
+    /// Unique module ID
+    pub id: String,
+    /// Resolved absolute path
+    pub path: String,
+    /// Transpiled JavaScript code
+    pub code: String,
+    /// Dependencies (module names as they appear in imports)
+    pub dependencies: Vec<String>,
+    /// Resolved dependency paths
+    pub resolved_dependencies: Vec<String>,
+    /// Export information
+    pub exports: ModuleExports,
+}
+
+/// Configuration for the bundler
+#[derive(Debug, Clone)]
+pub struct BundlerConfig {
+    /// Base directory for resolution
+    pub base_dir: PathBuf,
+    /// TypeScript configuration file path (optional)
+    pub tsconfig_path: Option<PathBuf>,
+    /// Runtime module system to use
+    pub runtime_system: RuntimeSystem,
+    /// Whether to include source maps
+    pub source_maps: bool,
+}
+
+/// Runtime module system options
+#[derive(Debug, Clone)]
+pub enum RuntimeSystem {
+    /// CommonJS-style module system
+    CommonJS,
+    /// Custom runtime with require/module.exports
+    Custom,
+}
+
+/// Main bundler implementation
+pub struct Bundler {
+    resolver: Box<dyn ModuleResolver>,
+    config: BundlerConfig,
+    /// Maps resolved absolute paths to obfuscated numeric IDs
+    module_id_map: HashMap<String, u32>,
+    /// Counter for generating unique module IDs
+    next_module_id: u32,
+}
+
+impl Bundler {
+    /// Check if a module path is a built-in module (codemod:* prefix)
+    pub fn is_builtin_module(module_path: &str) -> bool {
+        module_path.starts_with("codemod:")
+            || module_path == "fs"
+            || module_path == "path"
+            || module_path == "os"
+            || module_path == "child_process"
+            || module_path == "console"
+            || module_path == "process"
+    }
+
+    /// Create a new bundler instance
+    pub fn new(config: BundlerConfig) -> Result<Self, Box<dyn std::error::Error>> {
+        let resolver: Box<dyn ModuleResolver> = if let Some(tsconfig_path) = &config.tsconfig_path {
+            Box::new(OxcResolver::with_tsconfig(
+                config.base_dir.clone(),
+                tsconfig_path.clone(),
+            )?)
+        } else {
+            Box::new(OxcResolver::new(config.base_dir.clone())?)
+        };
+
+        Ok(Self {
+            resolver,
+            config,
+            module_id_map: HashMap::new(),
+            next_module_id: 1, // Start from 1, reserve 0 for potential special use
+        })
+    }
+
+    /// Bundle a JavaScript/TypeScript file and its dependencies
+    pub fn bundle(&mut self, entry_path: &str) -> Result<BundleResult, Box<dyn std::error::Error>> {
+        let mut visited = HashSet::new();
+        let mut modules = HashMap::new();
+        let mut dependency_graph = HashMap::new();
+        let mut builtin_modules = HashSet::new();
+
+        // Build dependency graph starting from entry point
+        self.build_dependency_graph(
+            entry_path,
+            "",
+            &mut visited,
+            &mut modules,
+            &mut dependency_graph,
+            &mut builtin_modules,
+        )?;
+
+        // Generate bundled code
+        let bundle_code =
+            self.generate_bundle(&modules, &dependency_graph, entry_path, &builtin_modules)?;
+
+        Ok(BundleResult {
+            code: bundle_code,
+            modules: modules.into_values().collect(),
+            entry_module: entry_path.to_string(),
+        })
+    }
+
+    /// Recursively build the dependency graph
+    fn build_dependency_graph(
+        &mut self,
+        module_path: &str,
+        base_path: &str,
+        visited: &mut HashSet<String>,
+        modules: &mut HashMap<String, BundledModule>,
+        dependency_graph: &mut HashMap<String, Vec<String>>,
+        builtin_modules: &mut HashSet<String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Resolve the module path
+        let resolved_path = self.resolver.resolve(base_path, module_path)?;
+
+        if visited.contains(&resolved_path) {
+            return Ok(());
+        }
+
+        visited.insert(resolved_path.clone());
+
+        // Read and parse the module
+        let source_code = std::fs::read_to_string(&resolved_path)?;
+
+        // Transpile the code
+        let transpiled_code = self.transpile_module(&source_code, &resolved_path)?;
+
+        let (dependencies, exports) = self.analyze_module(&transpiled_code, &resolved_path)?;
+
+        // Resolve dependencies
+        let mut resolved_dependencies = Vec::new();
+        for dep in &dependencies {
+            if Self::is_builtin_module(dep) {
+                // Built-in modules are not bundled, but we track them
+                resolved_dependencies.push(dep.to_string());
+                builtin_modules.insert(dep.to_string());
+            } else {
+                let resolved_dep = self.resolver.resolve(&resolved_path, dep)?;
+                resolved_dependencies.push(resolved_dep.clone());
+
+                // Recursively process dependencies (skip built-ins)
+                self.build_dependency_graph(
+                    dep,
+                    &resolved_path,
+                    visited,
+                    modules,
+                    dependency_graph,
+                    builtin_modules,
+                )?;
+            }
+        }
+
+        // Create bundled module
+        let module = BundledModule {
+            id: self.generate_module_id(&resolved_path),
+            path: resolved_path.clone(),
+            code: transpiled_code,
+            dependencies: dependencies.clone(),
+            resolved_dependencies: resolved_dependencies.clone(),
+            exports,
+        };
+
+        modules.insert(resolved_path.clone(), module);
+        dependency_graph.insert(resolved_path, resolved_dependencies);
+
+        Ok(())
+    }
+
+    /// Analyze a module's imports and exports using SWC AST
+    fn analyze_module(
+        &self,
+        source_code: &str,
+        file_path: &str,
+    ) -> Result<(Vec<String>, ModuleExports), Box<dyn std::error::Error>> {
+        let _file_name = FileName::Real(PathBuf::from(file_path));
+
+        // Determine syntax based on file extension
+        let syntax = if file_path.ends_with(".ts") || file_path.ends_with(".tsx") {
+            Syntax::Typescript(TsSyntax {
+                tsx: file_path.ends_with(".tsx"),
+                decorators: true,
+                ..Default::default()
+            })
+        } else {
+            Syntax::Es(Default::default())
+        };
+
+        let lexer = Lexer::new(
+            syntax,
+            EsVersion::Es2020,
+            StringInput::new(source_code, BytePos(0), BytePos(source_code.len() as u32)),
+            None,
+        );
+
+        let mut parser = Parser::new_from(lexer);
+        let module = parser
+            .parse_module()
+            .map_err(|e| format!("Parse error: {e:?}"))?;
+
+        let mut visitor = ModuleAnalyzer::new();
+        module.visit_with(&mut visitor);
+
+        Ok((visitor.dependencies, visitor.exports))
+    }
+
+    /// Transpile TypeScript to JavaScript using the existing transpiler utility
+    fn transpile_module(
+        &self,
+        source_code: &str,
+        file_path: &str,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        // If it's already a JavaScript file, return as-is
+        if file_path.ends_with(".js") || file_path.ends_with(".jsx") {
+            return Ok(source_code.to_string());
+        }
+
+        // Use the existing transpiler utility with panic handling
+        let transpile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            transpiler::transpile(source_code.to_string(), file_path.to_string())
+        }));
+
+        match transpile_result {
+            Ok(Ok(transpiled_bytes)) => {
+                // Convert bytes back to string
+                String::from_utf8(transpiled_bytes)
+                    .map_err(|e| format!("Failed to convert transpiled code to UTF-8: {e}").into())
+            }
+            Ok(Err(e)) => {
+                eprintln!("Warning: TypeScript transpilation failed for {file_path}: {e:?}");
+                eprintln!("Falling back to original source code...");
+                Ok(source_code.to_string())
+            }
+            Err(_) => {
+                eprintln!("Warning: TypeScript transpilation panicked for {file_path}");
+                eprintln!("Falling back to original source code...");
+                Ok(source_code.to_string())
+            }
+        }
+    }
+
+    /// Generate or retrieve obfuscated numeric module ID for a resolved path
+    fn generate_module_id(&mut self, resolved_path: &str) -> String {
+        // Use existing ID if we've seen this resolved path before
+        if let Some(&existing_id) = self.module_id_map.get(resolved_path) {
+            return existing_id.to_string();
+        }
+
+        // Generate new numeric ID
+        let new_id = self.next_module_id;
+        self.next_module_id += 1;
+
+        // Store mapping from resolved path to numeric ID
+        self.module_id_map.insert(resolved_path.to_string(), new_id);
+
+        new_id.to_string()
+    }
+
+    /// Generate the final bundled code with runtime module system
+    fn generate_bundle(
+        &self,
+        modules: &HashMap<String, BundledModule>,
+        _dependency_graph: &HashMap<String, Vec<String>>,
+        entry_path: &str,
+        builtin_modules: &HashSet<String>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let mut bundle = String::new();
+
+        // Find the entry module and get its ID
+        let entry_module_id = modules
+            .get(entry_path)
+            .map(|m| m.id.clone())
+            .unwrap_or_else(|| entry_path.to_string());
+
+        match self.config.runtime_system {
+            RuntimeSystem::CommonJS => {
+                bundle.push_str(&self.generate_commonjs_runtime(builtin_modules));
+                bundle.push_str(&self.generate_commonjs_modules(modules)?);
+                bundle.push_str(&format!(
+                    "\n// Entry point\nconst __entry = __codemod_require('{entry_module_id}');\nexport default __entry.default || __entry.transform;\n"
+                ));
+            }
+            RuntimeSystem::Custom => {
+                bundle.push_str(&self.generate_custom_runtime(builtin_modules));
+                bundle.push_str(&self.generate_custom_modules(modules)?);
+                bundle.push_str(&format!(
+                    "\n// Entry point\nconst __entry = __codemod_require('{entry_module_id}');\nexport default __entry.default || __entry.transform;\n"
+                ));
+            }
+        }
+
+        Ok(bundle)
+    }
+
+    /// Generate CommonJS-style runtime
+    fn generate_commonjs_runtime(&self, builtin_modules: &HashSet<String>) -> String {
+        let mut runtime = include_str!("runtime_commonjs.tpl").to_string();
+
+        // Generate top-level imports for built-in modules
+        let builtin_imports = self.generate_builtin_imports(builtin_modules);
+        if !builtin_imports.is_empty() {
+            runtime.push('\n');
+            runtime.push_str(&builtin_imports);
+        }
+
+        runtime
+    }
+
+    /// Generate custom runtime system
+    fn generate_custom_runtime(&self, builtin_modules: &HashSet<String>) -> String {
+        let mut runtime = include_str!("runtime_custom.tpl").to_string();
+
+        // Generate top-level imports for built-in modules
+        let builtin_imports = self.generate_builtin_imports(builtin_modules);
+        if !builtin_imports.is_empty() {
+            runtime.push('\n');
+            runtime.push_str(&builtin_imports);
+        }
+
+        runtime
+    }
+
+    /// Generate top-level imports for built-in modules
+    fn generate_builtin_imports(&self, builtin_modules: &HashSet<String>) -> String {
+        let mut imports = String::new();
+
+        for module in builtin_modules {
+            let variable_name = self.get_builtin_variable_name(module);
+            imports.push_str(&format!("import * as {variable_name} from '{module}';"));
+            imports.push('\n');
+        }
+
+        // Register built-in modules with the runtime
+        for module in builtin_modules {
+            let variable_name = self.get_builtin_variable_name(module);
+            imports.push_str(&format!(
+                "__codemod_register_builtin('{module}', {variable_name});"
+            ));
+            imports.push('\n');
+        }
+
+        imports
+    }
+
+    /// Get variable name for a built-in module
+    fn get_builtin_variable_name(&self, module_path: &str) -> String {
+        // Convert module path to valid variable name
+        match module_path {
+            "fs" => "__builtin_fs".to_string(),
+            "path" => "__builtin_path".to_string(),
+            "os" => "__builtin_os".to_string(),
+            "child_process" => "__builtin_child_process".to_string(),
+            "console" => "__builtin_console".to_string(),
+            "process" => "__builtin_process".to_string(),
+            module if module.starts_with("codemod:") => {
+                format!(
+                    "__builtin_{}",
+                    module.replace("codemod:", "").replace("-", "_")
+                )
+            }
+            _ => format!(
+                "__builtin_{}",
+                module_path.replace("-", "_").replace(":", "_")
+            ),
+        }
+    }
+
+    /// Generate CommonJS-style module definitions
+    fn generate_commonjs_modules(
+        &self,
+        modules: &HashMap<String, BundledModule>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let mut result = String::new();
+
+        for module in modules.values() {
+            let module_id = &module.id;
+
+            // Create dependency ID mapping for this module
+            let mut dependency_id_map = HashMap::new();
+            for (i, resolved_dep) in module.resolved_dependencies.iter().enumerate() {
+                let original_dep = &module.dependencies[i];
+                if Self::is_builtin_module(original_dep) {
+                    // Built-in modules keep their original import path
+                    dependency_id_map.insert(original_dep.clone(), original_dep.clone());
+                } else if let Some(dep_module) = modules.get(resolved_dep) {
+                    dependency_id_map.insert(original_dep.clone(), dep_module.id.clone());
+                }
+            }
+
+            let wrapped_code =
+                self.wrap_module_commonjs(&module.code, &module.dependencies, &dependency_id_map)?;
+
+            result.push_str(&format!(
+                "__codemod_define('{module_id}', function(module, exports, require) {{\n{wrapped_code}\n}});\n\n"
+            ));
+        }
+
+        Ok(result)
+    }
+
+    /// Generate custom module definitions
+    fn generate_custom_modules(
+        &self,
+        modules: &HashMap<String, BundledModule>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        let mut result = String::new();
+
+        for module in modules.values() {
+            let module_id = &module.id;
+
+            // Create dependency ID mapping for this module
+            let mut dependency_id_map = HashMap::new();
+            for (i, resolved_dep) in module.resolved_dependencies.iter().enumerate() {
+                let original_dep = &module.dependencies[i];
+                if Self::is_builtin_module(original_dep) {
+                    // Built-in modules keep their original import path
+                    dependency_id_map.insert(original_dep.clone(), original_dep.clone());
+                } else if let Some(dep_module) = modules.get(resolved_dep) {
+                    dependency_id_map.insert(original_dep.clone(), dep_module.id.clone());
+                }
+            }
+
+            let wrapped_code =
+                self.wrap_module_custom(&module.code, &module.dependencies, &dependency_id_map)?;
+
+            result.push_str(&format!(
+                "__codemod_define('{module_id}', function(exports, require) {{\n{wrapped_code}\n}});\n\n"
+            ));
+        }
+
+        Ok(result)
+    }
+
+    /// Wrap module code for CommonJS
+    fn wrap_module_commonjs(
+        &self,
+        code: &str,
+        dependencies: &[String],
+        dependency_id_map: &HashMap<String, String>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        // Transform ES6 imports/exports to CommonJS
+        self.transform_to_commonjs(code, dependencies, dependency_id_map)
+    }
+
+    /// Wrap module code for custom runtime
+    fn wrap_module_custom(
+        &self,
+        code: &str,
+        dependencies: &[String],
+        dependency_id_map: &HashMap<String, String>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        // Similar to CommonJS but with custom module format
+        self.transform_to_commonjs(code, dependencies, dependency_id_map)
+    }
+
+    /// Transform ES6 modules to CommonJS using SWC AST transformations
+    fn transform_to_commonjs(
+        &self,
+        source_code: &str,
+        dependencies: &[String],
+        dependency_id_map: &HashMap<String, String>,
+    ) -> Result<String, Box<dyn std::error::Error>> {
+        // Parse the source code
+        let syntax = Syntax::Es(Default::default());
+        let lexer = Lexer::new(
+            syntax,
+            EsVersion::Es2020,
+            StringInput::new(source_code, BytePos(0), BytePos(source_code.len() as u32)),
+            None,
+        );
+
+        let mut parser = Parser::new_from(lexer);
+        let mut module = parser
+            .parse_module()
+            .map_err(|e| format!("Parse error: {e:?}"))?;
+
+        // Create builtin variable map
+        let mut builtin_variable_map = HashMap::new();
+        for dep in dependencies {
+            if Self::is_builtin_module(dep) {
+                builtin_variable_map.insert(dep.clone(), self.get_builtin_variable_name(dep));
+            }
+        }
+
+        // Apply transformations
+        let mut transformer =
+            ModuleTransformer::new(dependency_id_map.clone(), builtin_variable_map);
+        module.visit_mut_with(&mut transformer);
+
+        // Add any remaining export assignments at the end
+        for export_stmt in transformer.export_assignments {
+            module.body.push(ModuleItem::Stmt(export_stmt));
+        }
+
+        let cm = Arc::new(SourceMap::default());
+        let mut buf = Vec::new();
+        {
+            let writer = JsWriter::new(cm.clone(), "\n", &mut buf, None);
+            let mut emitter = Emitter {
+                cfg: Default::default(),
+                comments: None,
+                cm: cm.clone(),
+                wr: writer,
+            };
+            emitter.emit_module(&module)?;
+        }
+
+        String::from_utf8(buf).map_err(|e| e.into())
+    }
+}
+
+/// Result of bundling operation
+pub struct BundleResult {
+    /// Final bundled code
+    pub code: String,
+    /// All modules in the bundle
+    pub modules: Vec<BundledModule>,
+    /// Entry module path
+    pub entry_module: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_bundler_creation() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = BundlerConfig {
+            base_dir: temp_dir.path().to_path_buf(),
+            tsconfig_path: None,
+            runtime_system: RuntimeSystem::CommonJS,
+            source_maps: false,
+        };
+
+        let bundler = Bundler::new(config);
+        assert!(bundler.is_ok());
+    }
+
+    #[test]
+    fn test_module_analysis() {
+        let temp_dir = TempDir::new().unwrap();
+        let config = BundlerConfig {
+            base_dir: temp_dir.path().to_path_buf(),
+            tsconfig_path: None,
+            runtime_system: RuntimeSystem::CommonJS,
+            source_maps: false,
+        };
+
+        let bundler = Bundler::new(config).unwrap();
+
+        let source = r#"
+            import { foo } from './other';
+            export const bar = 42;
+            export default function() { return bar; }
+        "#;
+
+        let (deps, exports) = bundler.analyze_module(source, "test.js").unwrap();
+
+        assert_eq!(deps, vec!["./other"]);
+        assert!(exports.has_default);
+        assert!(exports.named.contains(&"bar".to_string()));
+    }
+}

--- a/crates/codemod-sandbox/src/utils/bundler/mod.rs
+++ b/crates/codemod-sandbox/src/utils/bundler/mod.rs
@@ -248,23 +248,17 @@ impl Bundler {
         }
 
         // Use the existing transpiler utility with panic handling
-        let transpile_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            transpiler::transpile(source_code.to_string(), file_path.to_string())
-        }));
+        let transpile_result =
+            transpiler::transpile(source_code.to_string(), file_path.to_string());
 
         match transpile_result {
-            Ok(Ok(transpiled_bytes)) => {
+            Ok(transpiled_bytes) => {
                 // Convert bytes back to string
                 String::from_utf8(transpiled_bytes)
                     .map_err(|e| format!("Failed to convert transpiled code to UTF-8: {e}").into())
             }
-            Ok(Err(e)) => {
-                eprintln!("Warning: TypeScript transpilation failed for {file_path}: {e:?}");
-                eprintln!("Falling back to original source code...");
-                Ok(source_code.to_string())
-            }
-            Err(_) => {
-                eprintln!("Warning: TypeScript transpilation panicked for {file_path}");
+            Err(e) => {
+                eprintln!("Warning: TypeScript transpilation failed for {file_path}: {e}");
                 eprintln!("Falling back to original source code...");
                 Ok(source_code.to_string())
             }

--- a/crates/codemod-sandbox/src/utils/bundler/module_analyzer.rs
+++ b/crates/codemod-sandbox/src/utils/bundler/module_analyzer.rs
@@ -15,13 +15,13 @@ pub struct ModuleExports {
 }
 
 /// SWC visitor to analyze imports and exports
-pub struct ModuleAnalyzer {
-    pub dependencies: Vec<String>,
-    pub exports: ModuleExports,
+pub(crate) struct ModuleAnalyzer {
+    pub(crate) dependencies: Vec<String>,
+    pub(crate) exports: ModuleExports,
 }
 
 impl ModuleAnalyzer {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             dependencies: Vec::new(),
             exports: ModuleExports::default(),
@@ -81,7 +81,7 @@ impl Visit for ModuleAnalyzer {
 }
 
 impl ModuleAnalyzer {
-    fn extract_export_name(&self, spec: &ExportSpecifier) -> Option<String> {
+    pub(crate) fn extract_export_name(&self, spec: &ExportSpecifier) -> Option<String> {
         match spec {
             ExportSpecifier::Named(named) => match &named.exported {
                 Some(ModuleExportName::Ident(ident)) => Some(ident.sym.to_string()),

--- a/crates/codemod-sandbox/src/utils/bundler/module_analyzer.rs
+++ b/crates/codemod-sandbox/src/utils/bundler/module_analyzer.rs
@@ -1,0 +1,107 @@
+use swc_core::ecma::{
+    ast::{Decl, ExportSpecifier, ModuleDecl, ModuleExportName, ModuleItem, Pat},
+    visit::{Visit, VisitWith},
+};
+
+/// Information about module exports
+#[derive(Debug, Clone, Default)]
+pub struct ModuleExports {
+    /// Named exports
+    pub named: Vec<String>,
+    /// Default export exists
+    pub has_default: bool,
+    /// Namespace export exists
+    pub has_namespace: bool,
+}
+
+/// SWC visitor to analyze imports and exports
+pub struct ModuleAnalyzer {
+    pub dependencies: Vec<String>,
+    pub exports: ModuleExports,
+}
+
+impl ModuleAnalyzer {
+    pub fn new() -> Self {
+        Self {
+            dependencies: Vec::new(),
+            exports: ModuleExports::default(),
+        }
+    }
+}
+
+impl Visit for ModuleAnalyzer {
+    fn visit_module_item(&mut self, item: &ModuleItem) {
+        if let ModuleItem::ModuleDecl(decl) = item {
+            match decl {
+                ModuleDecl::Import(import_decl) => {
+                    self.dependencies.push(import_decl.src.value.to_string());
+                }
+                ModuleDecl::ExportNamed(export) => {
+                    if let Some(src) = &export.src {
+                        self.dependencies.push(src.value.to_string());
+                    }
+                    for spec in &export.specifiers {
+                        if let Some(name) = self.extract_export_name(spec) {
+                            self.exports.named.push(name);
+                        }
+                    }
+                }
+                ModuleDecl::ExportDefaultDecl(_) | ModuleDecl::ExportDefaultExpr(_) => {
+                    self.exports.has_default = true;
+                }
+                ModuleDecl::ExportAll(export_all) => {
+                    self.dependencies.push(export_all.src.value.to_string());
+                    self.exports.has_namespace = true;
+                }
+                ModuleDecl::ExportDecl(export_decl) => {
+                    // Handle export declarations (export const x = ...)
+                    match &export_decl.decl {
+                        Decl::Var(var_decl) => {
+                            for decl in &var_decl.decls {
+                                if let Pat::Ident(ident) = &decl.name {
+                                    self.exports.named.push(ident.id.sym.to_string());
+                                }
+                            }
+                        }
+                        Decl::Fn(fn_decl) => {
+                            self.exports.named.push(fn_decl.ident.sym.to_string());
+                        }
+                        Decl::Class(class_decl) => {
+                            self.exports.named.push(class_decl.ident.sym.to_string());
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        item.visit_children_with(self);
+    }
+}
+
+impl ModuleAnalyzer {
+    fn extract_export_name(&self, spec: &ExportSpecifier) -> Option<String> {
+        match spec {
+            ExportSpecifier::Named(named) => match &named.exported {
+                Some(ModuleExportName::Ident(ident)) => Some(ident.sym.to_string()),
+                Some(ModuleExportName::Str(str_lit)) => Some(str_lit.value.to_string()),
+                None => {
+                    if let ModuleExportName::Ident(ident) = &named.orig {
+                        Some(ident.sym.to_string())
+                    } else {
+                        None
+                    }
+                }
+            },
+            ExportSpecifier::Default(_) => {
+                // Default export
+                None
+            }
+            ExportSpecifier::Namespace(ns) => match &ns.name {
+                ModuleExportName::Ident(ident) => Some(ident.sym.to_string()),
+                ModuleExportName::Str(str_lit) => Some(str_lit.value.to_string()),
+            },
+        }
+    }
+}

--- a/crates/codemod-sandbox/src/utils/bundler/module_transformer.rs
+++ b/crates/codemod-sandbox/src/utils/bundler/module_transformer.rs
@@ -1,0 +1,570 @@
+use std::collections::HashMap;
+use swc_core::{
+    common::{SyntaxContext, DUMMY_SP},
+    ecma::{
+        ast::{
+            AssignTarget, Decl, ExportSpecifier, Expr, Ident, IdentName, ImportDecl,
+            ImportSpecifier, ModuleDecl, ModuleExportName, ModuleItem, Pat, Stmt, VarDecl,
+            VarDeclarator,
+        },
+        visit::{VisitMut, VisitMutWith},
+    },
+};
+
+/// SWC visitor for transforming ES6 modules to CommonJS
+pub struct ModuleTransformer {
+    pub dependency_id_map: HashMap<String, String>,
+    pub builtin_variable_map: HashMap<String, String>,
+    pub export_assignments: Vec<Stmt>,
+}
+
+impl ModuleTransformer {
+    pub fn new(
+        dependency_id_map: HashMap<String, String>,
+        builtin_variable_map: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            dependency_id_map,
+            builtin_variable_map,
+            export_assignments: Vec::new(),
+        }
+    }
+
+    fn is_builtin_module(module_path: &str) -> bool {
+        module_path.starts_with("codemod:")
+    }
+
+    fn create_require_call(&self, module_path: &str) -> Box<Expr> {
+        let resolved_id = self
+            .dependency_id_map
+            .get(module_path)
+            .map(|s| s.as_str())
+            .unwrap_or(module_path);
+
+        Box::new(Expr::Call(swc_core::ecma::ast::CallExpr {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            callee: swc_core::ecma::ast::Callee::Expr(Box::new(Expr::Ident(Ident::new(
+                "require".into(),
+                DUMMY_SP,
+                SyntaxContext::empty(),
+            )))),
+            args: vec![swc_core::ecma::ast::ExprOrSpread {
+                spread: None,
+                expr: Box::new(Expr::Lit(swc_core::ecma::ast::Lit::Str(
+                    swc_core::ecma::ast::Str {
+                        span: DUMMY_SP,
+                        value: resolved_id.into(),
+                        raw: None,
+                    },
+                ))),
+            }],
+            type_args: None,
+        }))
+    }
+
+    fn create_module_exports_assignment(&self, name: &str, value: Box<Expr>) -> Stmt {
+        Stmt::Expr(swc_core::ecma::ast::ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::new(Expr::Assign(swc_core::ecma::ast::AssignExpr {
+                span: DUMMY_SP,
+                op: swc_core::ecma::ast::AssignOp::Assign,
+                left: AssignTarget::Simple(swc_core::ecma::ast::SimpleAssignTarget::Member(
+                    swc_core::ecma::ast::MemberExpr {
+                        span: DUMMY_SP,
+                        obj: Box::new(Expr::Member(swc_core::ecma::ast::MemberExpr {
+                            span: DUMMY_SP,
+                            obj: Box::new(Expr::Ident(Ident::new(
+                                "module".into(),
+                                DUMMY_SP,
+                                SyntaxContext::empty(),
+                            ))),
+                            prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                                "exports".into(),
+                                DUMMY_SP,
+                            )),
+                        })),
+                        prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                            name.into(),
+                            DUMMY_SP,
+                        )),
+                    },
+                )),
+                right: value,
+            })),
+        })
+    }
+
+    fn transform_import_decl(&self, import: &ImportDecl) -> ModuleItem {
+        let module_path = import.src.value.as_str();
+
+        // Transform built-in modules to use pre-imported variables
+        if Self::is_builtin_module(module_path) {
+            if let Some(builtin_var) = self.builtin_variable_map.get(module_path) {
+                return self.transform_builtin_import_decl(import, builtin_var);
+            } else {
+                // Fallback to keeping import (shouldn't happen)
+                return ModuleItem::ModuleDecl(ModuleDecl::Import(import.clone()));
+            }
+        }
+
+        let require_call = self.create_require_call(module_path);
+
+        // Create variable declarations based on import specifiers
+        let mut declarators = Vec::new();
+
+        for spec in &import.specifiers {
+            match spec {
+                ImportSpecifier::Named(named) => {
+                    let imported_name = match &named.imported {
+                        Some(ModuleExportName::Ident(ident)) => ident.sym.as_str(),
+                        Some(ModuleExportName::Str(str_lit)) => str_lit.value.as_str(),
+                        None => named.local.sym.as_str(),
+                    };
+
+                    // const { imported_name } = require('module')
+                    declarators.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(named.local.clone().into()),
+                        init: Some(Box::new(Expr::Member(swc_core::ecma::ast::MemberExpr {
+                            span: DUMMY_SP,
+                            obj: require_call.clone(),
+                            prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                                imported_name.into(),
+                                DUMMY_SP,
+                            )),
+                        }))),
+                        definite: false,
+                    });
+                }
+                ImportSpecifier::Default(default) => {
+                    // const default_name = require('module').default || require('module')
+                    declarators.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(default.local.clone().into()),
+                        init: Some(Box::new(Expr::Bin(swc_core::ecma::ast::BinExpr {
+                            span: DUMMY_SP,
+                            op: swc_core::ecma::ast::BinaryOp::LogicalOr,
+                            left: Box::new(Expr::Member(swc_core::ecma::ast::MemberExpr {
+                                span: DUMMY_SP,
+                                obj: require_call.clone(),
+                                prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                                    "default".into(),
+                                    DUMMY_SP,
+                                )),
+                            })),
+                            right: require_call.clone(),
+                        }))),
+                        definite: false,
+                    });
+                }
+                ImportSpecifier::Namespace(namespace) => {
+                    // const namespace = require('module')
+                    declarators.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(namespace.local.clone().into()),
+                        init: Some(require_call.clone()),
+                        definite: false,
+                    });
+                }
+            }
+        }
+
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            kind: swc_core::ecma::ast::VarDeclKind::Const,
+            declare: false,
+            decls: declarators,
+        }))))
+    }
+
+    fn transform_export_named(&self, export: &swc_core::ecma::ast::NamedExport) -> Vec<Stmt> {
+        let mut stmts = Vec::new();
+
+        if let Some(src) = &export.src {
+            // Re-export from another module
+            let require_call = self.create_require_call(src.value.as_str());
+            for spec in &export.specifiers {
+                if let ExportSpecifier::Named(named) = spec {
+                    let exported_name = match &named.exported {
+                        Some(ModuleExportName::Ident(ident)) => ident.sym.as_str(),
+                        Some(ModuleExportName::Str(str_lit)) => str_lit.value.as_str(),
+                        None => {
+                            if let ModuleExportName::Ident(ident) = &named.orig {
+                                ident.sym.as_str()
+                            } else {
+                                continue;
+                            }
+                        }
+                    };
+
+                    let orig_name = if let ModuleExportName::Ident(ident) = &named.orig {
+                        ident.sym.as_str()
+                    } else {
+                        continue;
+                    };
+
+                    let value = Box::new(Expr::Member(swc_core::ecma::ast::MemberExpr {
+                        span: DUMMY_SP,
+                        obj: require_call.clone(),
+                        prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                            orig_name.into(),
+                            DUMMY_SP,
+                        )),
+                    }));
+
+                    stmts.push(self.create_module_exports_assignment(exported_name, value));
+                }
+            }
+        } else {
+            // Export existing variables/functions
+            for spec in &export.specifiers {
+                if let ExportSpecifier::Named(named) = spec {
+                    let exported_name = match &named.exported {
+                        Some(ModuleExportName::Ident(ident)) => ident.sym.as_str(),
+                        Some(ModuleExportName::Str(str_lit)) => str_lit.value.as_str(),
+                        None => {
+                            if let ModuleExportName::Ident(ident) = &named.orig {
+                                ident.sym.as_str()
+                            } else {
+                                continue;
+                            }
+                        }
+                    };
+
+                    let orig_name = if let ModuleExportName::Ident(ident) = &named.orig {
+                        ident.sym.as_str()
+                    } else {
+                        continue;
+                    };
+
+                    let value = Box::new(Expr::Ident(Ident::new(
+                        orig_name.into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    )));
+                    stmts.push(self.create_module_exports_assignment(exported_name, value));
+                }
+            }
+        }
+
+        stmts
+    }
+
+    /// Transform built-in import declaration to use pre-imported variable
+    fn transform_builtin_import_decl(&self, import: &ImportDecl, builtin_var: &str) -> ModuleItem {
+        let mut declarators = Vec::new();
+
+        for spec in &import.specifiers {
+            match spec {
+                ImportSpecifier::Named(named) => {
+                    let imported_name = match &named.imported {
+                        Some(ModuleExportName::Ident(ident)) => ident.sym.as_str(),
+                        Some(ModuleExportName::Str(str_lit)) => str_lit.value.as_str(),
+                        None => named.local.sym.as_str(),
+                    };
+
+                    // const { imported_name } = __builtin_module
+                    declarators.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(named.local.clone().into()),
+                        init: Some(Box::new(Expr::Member(swc_core::ecma::ast::MemberExpr {
+                            span: DUMMY_SP,
+                            obj: Box::new(Expr::Ident(Ident::new(
+                                builtin_var.into(),
+                                DUMMY_SP,
+                                SyntaxContext::empty(),
+                            ))),
+                            prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                                imported_name.into(),
+                                DUMMY_SP,
+                            )),
+                        }))),
+                        definite: false,
+                    });
+                }
+                ImportSpecifier::Default(default) => {
+                    // const default_name = __builtin_module.default || __builtin_module
+                    declarators.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(default.local.clone().into()),
+                        init: Some(Box::new(Expr::Bin(swc_core::ecma::ast::BinExpr {
+                            span: DUMMY_SP,
+                            op: swc_core::ecma::ast::BinaryOp::LogicalOr,
+                            left: Box::new(Expr::Member(swc_core::ecma::ast::MemberExpr {
+                                span: DUMMY_SP,
+                                obj: Box::new(Expr::Ident(Ident::new(
+                                    builtin_var.into(),
+                                    DUMMY_SP,
+                                    SyntaxContext::empty(),
+                                ))),
+                                prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                                    "default".into(),
+                                    DUMMY_SP,
+                                )),
+                            })),
+                            right: Box::new(Expr::Ident(Ident::new(
+                                builtin_var.into(),
+                                DUMMY_SP,
+                                SyntaxContext::empty(),
+                            ))),
+                        }))),
+                        definite: false,
+                    });
+                }
+                ImportSpecifier::Namespace(namespace) => {
+                    // const namespace = __builtin_module
+                    declarators.push(VarDeclarator {
+                        span: DUMMY_SP,
+                        name: Pat::Ident(namespace.local.clone().into()),
+                        init: Some(Box::new(Expr::Ident(Ident::new(
+                            builtin_var.into(),
+                            DUMMY_SP,
+                            SyntaxContext::empty(),
+                        )))),
+                        definite: false,
+                    });
+                }
+            }
+        }
+
+        ModuleItem::Stmt(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+            span: DUMMY_SP,
+            ctxt: SyntaxContext::empty(),
+            kind: swc_core::ecma::ast::VarDeclKind::Const,
+            declare: false,
+            decls: declarators,
+        }))))
+    }
+
+    fn transform_export_default_decl(
+        &self,
+        export: &swc_core::ecma::ast::ExportDefaultDecl,
+    ) -> (Stmt, Stmt) {
+        match &export.decl {
+            swc_core::ecma::ast::DefaultDecl::Fn(fn_expr) => {
+                let fn_name = fn_expr
+                    .ident
+                    .as_ref()
+                    .map(|id| id.sym.as_str())
+                    .unwrap_or("__default");
+
+                let fn_stmt = Stmt::Decl(Decl::Fn(swc_core::ecma::ast::FnDecl {
+                    ident: Ident::new(fn_name.into(), DUMMY_SP, SyntaxContext::empty()),
+                    declare: false,
+                    function: fn_expr.function.clone(),
+                }));
+
+                let export_stmt = self.create_module_exports_assignment(
+                    "default",
+                    Box::new(Expr::Ident(Ident::new(
+                        fn_name.into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    ))),
+                );
+
+                (fn_stmt, export_stmt)
+            }
+            swc_core::ecma::ast::DefaultDecl::Class(class_expr) => {
+                let class_name = class_expr
+                    .ident
+                    .as_ref()
+                    .map(|id| id.sym.as_str())
+                    .unwrap_or("__default");
+
+                let class_stmt = Stmt::Decl(Decl::Class(swc_core::ecma::ast::ClassDecl {
+                    ident: Ident::new(class_name.into(), DUMMY_SP, SyntaxContext::empty()),
+                    declare: false,
+                    class: class_expr.class.clone(),
+                }));
+
+                let export_stmt = self.create_module_exports_assignment(
+                    "default",
+                    Box::new(Expr::Ident(Ident::new(
+                        class_name.into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    ))),
+                );
+
+                (class_stmt, export_stmt)
+            }
+            swc_core::ecma::ast::DefaultDecl::TsInterfaceDecl(_) => {
+                // TypeScript interfaces don't exist at runtime
+                (
+                    Stmt::Empty(swc_core::ecma::ast::EmptyStmt { span: DUMMY_SP }),
+                    Stmt::Empty(swc_core::ecma::ast::EmptyStmt { span: DUMMY_SP }),
+                )
+            }
+        }
+    }
+
+    fn transform_export_default_expr(
+        &self,
+        export: &swc_core::ecma::ast::ExportDefaultExpr,
+    ) -> Stmt {
+        self.create_module_exports_assignment("default", export.expr.clone())
+    }
+
+    fn transform_export_decl(&self, export: &swc_core::ecma::ast::ExportDecl) -> (Stmt, Stmt) {
+        match &export.decl {
+            Decl::Var(var_decl) => {
+                let mut export_stmts = Vec::new();
+                for decl in &var_decl.decls {
+                    if let Pat::Ident(ident) = &decl.name {
+                        let name = ident.id.sym.as_str();
+                        export_stmts.push(self.create_module_exports_assignment(
+                            name,
+                            Box::new(Expr::Ident(Ident::new(
+                                name.into(),
+                                DUMMY_SP,
+                                SyntaxContext::empty(),
+                            ))),
+                        ));
+                    }
+                }
+
+                let mut var_decl_clone = var_decl.clone();
+                var_decl_clone.ctxt = SyntaxContext::empty();
+                let var_stmt = Stmt::Decl(Decl::Var(var_decl_clone));
+                // Return the first export statement, others will be handled elsewhere
+                let export_stmt = export_stmts.into_iter().next().unwrap_or_else(|| {
+                    Stmt::Empty(swc_core::ecma::ast::EmptyStmt { span: DUMMY_SP })
+                });
+
+                (var_stmt, export_stmt)
+            }
+            Decl::Fn(fn_decl) => {
+                let name = fn_decl.ident.sym.as_str();
+                let fn_stmt = Stmt::Decl(Decl::Fn(fn_decl.clone()));
+                let export_stmt = self.create_module_exports_assignment(
+                    name,
+                    Box::new(Expr::Ident(Ident::new(
+                        name.into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    ))),
+                );
+
+                (fn_stmt, export_stmt)
+            }
+            Decl::Class(class_decl) => {
+                let name = class_decl.ident.sym.as_str();
+                let class_stmt = Stmt::Decl(Decl::Class(class_decl.clone()));
+                let export_stmt = self.create_module_exports_assignment(
+                    name,
+                    Box::new(Expr::Ident(Ident::new(
+                        name.into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    ))),
+                );
+
+                (class_stmt, export_stmt)
+            }
+            _ => (
+                Stmt::Decl(export.decl.clone()),
+                Stmt::Empty(swc_core::ecma::ast::EmptyStmt { span: DUMMY_SP }),
+            ),
+        }
+    }
+
+    fn transform_export_all(&self, export_all: &swc_core::ecma::ast::ExportAll) -> Stmt {
+        let require_call = self.create_require_call(export_all.src.value.as_str());
+
+        // Object.assign(module.exports, require('module'))
+        Stmt::Expr(swc_core::ecma::ast::ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::new(Expr::Call(swc_core::ecma::ast::CallExpr {
+                span: DUMMY_SP,
+                ctxt: SyntaxContext::empty(),
+                callee: swc_core::ecma::ast::Callee::Expr(Box::new(Expr::Member(
+                    swc_core::ecma::ast::MemberExpr {
+                        span: DUMMY_SP,
+                        obj: Box::new(Expr::Ident(Ident::new(
+                            "Object".into(),
+                            DUMMY_SP,
+                            SyntaxContext::empty(),
+                        ))),
+                        prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                            "assign".into(),
+                            DUMMY_SP,
+                        )),
+                    },
+                ))),
+                args: vec![
+                    swc_core::ecma::ast::ExprOrSpread {
+                        spread: None,
+                        expr: Box::new(Expr::Member(swc_core::ecma::ast::MemberExpr {
+                            span: DUMMY_SP,
+                            obj: Box::new(Expr::Ident(Ident::new(
+                                "module".into(),
+                                DUMMY_SP,
+                                SyntaxContext::empty(),
+                            ))),
+                            prop: swc_core::ecma::ast::MemberProp::Ident(IdentName::new(
+                                "exports".into(),
+                                DUMMY_SP,
+                            )),
+                        })),
+                    },
+                    swc_core::ecma::ast::ExprOrSpread {
+                        spread: None,
+                        expr: require_call,
+                    },
+                ],
+                type_args: None,
+            })),
+        })
+    }
+}
+
+impl VisitMut for ModuleTransformer {
+    fn visit_mut_module_item(&mut self, item: &mut ModuleItem) {
+        if let ModuleItem::ModuleDecl(decl) = item {
+            match decl {
+                ModuleDecl::Import(import_decl) => {
+                    *item = self.transform_import_decl(import_decl);
+                }
+                ModuleDecl::ExportNamed(export) => {
+                    let stmts = self.transform_export_named(export);
+                    if !stmts.is_empty() {
+                        *item = ModuleItem::Stmt(stmts[0].clone());
+                        // Store additional statements for later
+                        for stmt in stmts.into_iter().skip(1) {
+                            self.export_assignments.push(stmt);
+                        }
+                    } else {
+                        // Remove the export statement
+                        *item = ModuleItem::Stmt(Stmt::Empty(swc_core::ecma::ast::EmptyStmt {
+                            span: DUMMY_SP,
+                        }));
+                    }
+                }
+                ModuleDecl::ExportDefaultDecl(export) => {
+                    let (stmt, export_stmt) = self.transform_export_default_decl(export);
+                    *item = ModuleItem::Stmt(stmt);
+                    self.export_assignments.push(export_stmt);
+                }
+                ModuleDecl::ExportDefaultExpr(export) => {
+                    let stmt = self.transform_export_default_expr(export);
+                    *item = ModuleItem::Stmt(stmt);
+                }
+                ModuleDecl::ExportDecl(export) => {
+                    let (stmt, export_stmt) = self.transform_export_decl(export);
+                    *item = ModuleItem::Stmt(stmt);
+                    self.export_assignments.push(export_stmt);
+                }
+                ModuleDecl::ExportAll(export_all) => {
+                    let stmt = self.transform_export_all(export_all);
+                    *item = ModuleItem::Stmt(stmt);
+                }
+                _ => {}
+            }
+        }
+
+        item.visit_mut_children_with(self);
+    }
+}

--- a/crates/codemod-sandbox/src/utils/bundler/module_transformer_tests.rs
+++ b/crates/codemod-sandbox/src/utils/bundler/module_transformer_tests.rs
@@ -1,0 +1,546 @@
+#[cfg(test)]
+mod tests {
+    use super::super::module_transformer::ModuleTransformer;
+    use std::collections::HashMap;
+    use swc_core::{
+        common::{SyntaxContext, DUMMY_SP},
+        ecma::ast::{
+            AssignTarget, ExportAll, ExportDefaultExpr, ExportSpecifier, Expr, Ident, ImportDecl,
+            ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier, ImportStarAsSpecifier,
+            ModuleExportName, ModuleItem, NamedExport, Pat, Stmt, Str, VarDeclKind,
+        },
+    };
+
+    fn create_test_transformer() -> ModuleTransformer {
+        let mut dependency_map = HashMap::new();
+        dependency_map.insert("react".to_string(), "__dep_0".to_string());
+        dependency_map.insert("lodash".to_string(), "__dep_1".to_string());
+
+        ModuleTransformer::new(dependency_map)
+    }
+
+    fn create_import_decl(src: &str, specifiers: Vec<ImportSpecifier>) -> ImportDecl {
+        ImportDecl {
+            span: DUMMY_SP,
+            specifiers,
+            src: Box::new(Str {
+                span: DUMMY_SP,
+                value: src.into(),
+                raw: None,
+            }),
+            type_only: false,
+            with: None,
+            phase: Default::default(),
+        }
+    }
+
+    fn create_named_import(local_name: &str, imported_name: Option<&str>) -> ImportSpecifier {
+        ImportSpecifier::Named(ImportNamedSpecifier {
+            span: DUMMY_SP,
+            local: Ident::new(local_name.into(), DUMMY_SP, SyntaxContext::empty()),
+            imported: imported_name.map(|name| {
+                ModuleExportName::Ident(Ident::new(name.into(), DUMMY_SP, SyntaxContext::empty()))
+            }),
+            is_type_only: false,
+        })
+    }
+
+    fn create_default_import(local_name: &str) -> ImportSpecifier {
+        ImportSpecifier::Default(ImportDefaultSpecifier {
+            span: DUMMY_SP,
+            local: Ident::new(local_name.into(), DUMMY_SP, SyntaxContext::empty()),
+        })
+    }
+
+    fn create_namespace_import(local_name: &str) -> ImportSpecifier {
+        ImportSpecifier::Namespace(ImportStarAsSpecifier {
+            span: DUMMY_SP,
+            local: Ident::new(local_name.into(), DUMMY_SP, SyntaxContext::empty()),
+        })
+    }
+
+    #[test]
+    fn test_new_module_transformer() {
+        let mut dependency_map = HashMap::new();
+        dependency_map.insert("react".to_string(), "__dep_0".to_string());
+
+        let transformer = ModuleTransformer::new(dependency_map.clone());
+
+        assert_eq!(transformer.dependency_id_map, dependency_map);
+        assert!(transformer.export_assignments.is_empty());
+    }
+
+    #[test]
+    fn test_create_require_call_with_dependency_mapping() {
+        let transformer = create_test_transformer();
+        let require_call = transformer.create_require_call("react");
+
+        // The require call should use the mapped dependency ID
+        if let Expr::Call(call_expr) = require_call.as_ref() {
+            assert_eq!(call_expr.args.len(), 1);
+            if let Expr::Lit(swc_core::ecma::ast::Lit::Str(str_lit)) =
+                call_expr.args[0].expr.as_ref()
+            {
+                assert_eq!(str_lit.value.as_str(), "__dep_0");
+            } else {
+                panic!("Expected string literal argument");
+            }
+        } else {
+            panic!("Expected call expression");
+        }
+    }
+
+    #[test]
+    fn test_create_require_call_without_dependency_mapping() {
+        let transformer = create_test_transformer();
+        let require_call = transformer.create_require_call("unknown-module");
+
+        // The require call should use the original module path
+        if let Expr::Call(call_expr) = require_call.as_ref() {
+            if let Expr::Lit(swc_core::ecma::ast::Lit::Str(str_lit)) =
+                call_expr.args[0].expr.as_ref()
+            {
+                assert_eq!(str_lit.value.as_str(), "unknown-module");
+            } else {
+                panic!("Expected string literal argument");
+            }
+        } else {
+            panic!("Expected call expression");
+        }
+    }
+
+    #[test]
+    fn test_transform_named_import() {
+        let transformer = create_test_transformer();
+        let import_decl = create_import_decl(
+            "react",
+            vec![
+                create_named_import("useState", None),
+                create_named_import("useEffect", None),
+            ],
+        );
+
+        let result = transformer.transform_import_decl(&import_decl);
+
+        if let ModuleItem::Stmt(Stmt::Decl(swc_core::ecma::ast::Decl::Var(var_decl))) = result {
+            assert_eq!(var_decl.kind, VarDeclKind::Const);
+            assert_eq!(var_decl.decls.len(), 2);
+
+            // Check first declaration
+            if let Pat::Ident(ident) = &var_decl.decls[0].name {
+                assert_eq!(ident.id.sym.as_str(), "useState");
+            } else {
+                panic!("Expected identifier pattern");
+            }
+
+            // Check second declaration
+            if let Pat::Ident(ident) = &var_decl.decls[1].name {
+                assert_eq!(ident.id.sym.as_str(), "useEffect");
+            } else {
+                panic!("Expected identifier pattern");
+            }
+        } else {
+            panic!("Expected variable declaration");
+        }
+    }
+
+    #[test]
+    fn test_transform_named_import_with_alias() {
+        let transformer = create_test_transformer();
+        let import_decl = create_import_decl(
+            "react",
+            vec![create_named_import("localName", Some("useState"))],
+        );
+
+        let result = transformer.transform_import_decl(&import_decl);
+
+        if let ModuleItem::Stmt(Stmt::Decl(swc_core::ecma::ast::Decl::Var(var_decl))) = result {
+            assert_eq!(var_decl.decls.len(), 1);
+            if let Pat::Ident(ident) = &var_decl.decls[0].name {
+                assert_eq!(ident.id.sym.as_str(), "localName");
+            } else {
+                panic!("Expected identifier pattern");
+            }
+        } else {
+            panic!("Expected variable declaration");
+        }
+    }
+
+    #[test]
+    fn test_transform_default_import() {
+        let transformer = create_test_transformer();
+        let import_decl = create_import_decl("react", vec![create_default_import("React")]);
+
+        let result = transformer.transform_import_decl(&import_decl);
+
+        if let ModuleItem::Stmt(Stmt::Decl(swc_core::ecma::ast::Decl::Var(var_decl))) = result {
+            assert_eq!(var_decl.decls.len(), 1);
+            if let Pat::Ident(ident) = &var_decl.decls[0].name {
+                assert_eq!(ident.id.sym.as_str(), "React");
+            } else {
+                panic!("Expected identifier pattern");
+            }
+
+            // The init should be a binary expression (require().default || require())
+            if let Some(init) = &var_decl.decls[0].init {
+                if let Expr::Bin(bin_expr) = init.as_ref() {
+                    assert!(matches!(
+                        bin_expr.op,
+                        swc_core::ecma::ast::BinaryOp::LogicalOr
+                    ));
+                } else {
+                    panic!("Expected binary expression");
+                }
+            } else {
+                panic!("Expected init expression");
+            }
+        } else {
+            panic!("Expected variable declaration");
+        }
+    }
+
+    #[test]
+    fn test_transform_namespace_import() {
+        let transformer = create_test_transformer();
+        let import_decl = create_import_decl("react", vec![create_namespace_import("React")]);
+
+        let result = transformer.transform_import_decl(&import_decl);
+
+        if let ModuleItem::Stmt(Stmt::Decl(swc_core::ecma::ast::Decl::Var(var_decl))) = result {
+            assert_eq!(var_decl.decls.len(), 1);
+            if let Pat::Ident(ident) = &var_decl.decls[0].name {
+                assert_eq!(ident.id.sym.as_str(), "React");
+            } else {
+                panic!("Expected identifier pattern");
+            }
+        } else {
+            panic!("Expected variable declaration");
+        }
+    }
+
+    #[test]
+    fn test_transform_mixed_import() {
+        let transformer = create_test_transformer();
+        let import_decl = create_import_decl(
+            "react",
+            vec![
+                create_default_import("React"),
+                create_named_import("useState", None),
+                create_named_import("Component", None),
+            ],
+        );
+
+        let result = transformer.transform_import_decl(&import_decl);
+
+        if let ModuleItem::Stmt(Stmt::Decl(swc_core::ecma::ast::Decl::Var(var_decl))) = result {
+            assert_eq!(var_decl.decls.len(), 3);
+        } else {
+            panic!("Expected variable declaration");
+        }
+    }
+
+    #[test]
+    fn test_transform_export_named_local() {
+        let transformer = create_test_transformer();
+        let export = NamedExport {
+            span: DUMMY_SP,
+            specifiers: vec![ExportSpecifier::Named(
+                swc_core::ecma::ast::ExportNamedSpecifier {
+                    span: DUMMY_SP,
+                    orig: ModuleExportName::Ident(Ident::new(
+                        "localVar".into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    )),
+                    exported: None,
+                    is_type_only: false,
+                },
+            )],
+            src: None,
+            type_only: false,
+            with: None,
+        };
+
+        let stmts = transformer.transform_export_named(&export);
+
+        assert_eq!(stmts.len(), 1);
+        // Should create module.exports.localVar = localVar
+        if let Stmt::Expr(expr_stmt) = &stmts[0] {
+            if let Expr::Assign(assign_expr) = expr_stmt.expr.as_ref() {
+                // Check that it's assigning to module.exports.localVar
+                if let AssignTarget::Simple(swc_core::ecma::ast::SimpleAssignTarget::Member(
+                    member_expr,
+                )) = &assign_expr.left
+                {
+                    if let swc_core::ecma::ast::MemberProp::Ident(prop) = &member_expr.prop {
+                        assert_eq!(prop.sym.as_str(), "localVar");
+                    } else {
+                        panic!("Expected property identifier");
+                    }
+                } else {
+                    panic!("Expected member expression");
+                }
+            } else {
+                panic!("Expected assignment expression");
+            }
+        } else {
+            panic!("Expected expression statement");
+        }
+    }
+
+    #[test]
+    fn test_transform_export_named_with_alias() {
+        let transformer = create_test_transformer();
+        let export = NamedExport {
+            span: DUMMY_SP,
+            specifiers: vec![ExportSpecifier::Named(
+                swc_core::ecma::ast::ExportNamedSpecifier {
+                    span: DUMMY_SP,
+                    orig: ModuleExportName::Ident(Ident::new(
+                        "localVar".into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    )),
+                    exported: Some(ModuleExportName::Ident(Ident::new(
+                        "exportedName".into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    ))),
+                    is_type_only: false,
+                },
+            )],
+            src: None,
+            type_only: false,
+            with: None,
+        };
+
+        let stmts = transformer.transform_export_named(&export);
+
+        assert_eq!(stmts.len(), 1);
+        // Should create module.exports.exportedName = localVar
+        if let Stmt::Expr(expr_stmt) = &stmts[0] {
+            if let Expr::Assign(assign_expr) = expr_stmt.expr.as_ref() {
+                if let AssignTarget::Simple(swc_core::ecma::ast::SimpleAssignTarget::Member(
+                    member_expr,
+                )) = &assign_expr.left
+                {
+                    if let swc_core::ecma::ast::MemberProp::Ident(prop) = &member_expr.prop {
+                        assert_eq!(prop.sym.as_str(), "exportedName");
+                    } else {
+                        panic!("Expected property identifier");
+                    }
+                } else {
+                    panic!("Expected member expression");
+                }
+            } else {
+                panic!("Expected assignment expression");
+            }
+        } else {
+            panic!("Expected expression statement");
+        }
+    }
+
+    #[test]
+    fn test_transform_export_named_re_export() {
+        let transformer = create_test_transformer();
+        let export = NamedExport {
+            span: DUMMY_SP,
+            specifiers: vec![ExportSpecifier::Named(
+                swc_core::ecma::ast::ExportNamedSpecifier {
+                    span: DUMMY_SP,
+                    orig: ModuleExportName::Ident(Ident::new(
+                        "useState".into(),
+                        DUMMY_SP,
+                        SyntaxContext::empty(),
+                    )),
+                    exported: None,
+                    is_type_only: false,
+                },
+            )],
+            src: Some(Box::new(Str {
+                span: DUMMY_SP,
+                value: "react".into(),
+                raw: None,
+            })),
+            type_only: false,
+            with: None,
+        };
+
+        let stmts = transformer.transform_export_named(&export);
+
+        assert_eq!(stmts.len(), 1);
+        // Should create module.exports.useState = require('react').useState
+        if let Stmt::Expr(expr_stmt) = &stmts[0] {
+            if let Expr::Assign(assign_expr) = expr_stmt.expr.as_ref() {
+                // Right side should be a member expression accessing the required module
+                if let Expr::Member(_member_expr) = assign_expr.right.as_ref() {
+                    // This is expected
+                } else {
+                    panic!("Expected member expression on right side");
+                }
+            } else {
+                panic!("Expected assignment expression");
+            }
+        } else {
+            panic!("Expected expression statement");
+        }
+    }
+
+    #[test]
+    fn test_transform_export_all() {
+        let transformer = create_test_transformer();
+        let export_all = ExportAll {
+            span: DUMMY_SP,
+            src: Box::new(Str {
+                span: DUMMY_SP,
+                value: "react".into(),
+                raw: None,
+            }),
+            type_only: false,
+            with: None,
+        };
+
+        let stmt = transformer.transform_export_all(&export_all);
+
+        // Should create Object.assign(module.exports, require('react'))
+        if let Stmt::Expr(expr_stmt) = stmt {
+            if let Expr::Call(call_expr) = expr_stmt.expr.as_ref() {
+                assert_eq!(call_expr.args.len(), 2);
+                // First argument should be module.exports
+                // Second argument should be require('react')
+            } else {
+                panic!("Expected call expression");
+            }
+        } else {
+            panic!("Expected expression statement");
+        }
+    }
+
+    #[test]
+    fn test_transform_export_default_expression() {
+        let transformer = create_test_transformer();
+        let export = ExportDefaultExpr {
+            span: DUMMY_SP,
+            expr: Box::new(Expr::Ident(Ident::new(
+                "myVar".into(),
+                DUMMY_SP,
+                SyntaxContext::empty(),
+            ))),
+        };
+
+        let stmt = transformer.transform_export_default_expr(&export);
+
+        // Should create module.exports.default = myVar
+        if let Stmt::Expr(expr_stmt) = stmt {
+            if let Expr::Assign(assign_expr) = expr_stmt.expr.as_ref() {
+                if let AssignTarget::Simple(swc_core::ecma::ast::SimpleAssignTarget::Member(
+                    member_expr,
+                )) = &assign_expr.left
+                {
+                    if let swc_core::ecma::ast::MemberProp::Ident(prop) = &member_expr.prop {
+                        assert_eq!(prop.sym.as_str(), "default");
+                    } else {
+                        panic!("Expected 'default' property");
+                    }
+                } else {
+                    panic!("Expected member expression");
+                }
+
+                if let Expr::Ident(ident) = assign_expr.right.as_ref() {
+                    assert_eq!(ident.sym.as_str(), "myVar");
+                } else {
+                    panic!("Expected identifier on right side");
+                }
+            } else {
+                panic!("Expected assignment expression");
+            }
+        } else {
+            panic!("Expected expression statement");
+        }
+    }
+
+    #[test]
+    fn test_create_module_exports_assignment() {
+        let transformer = create_test_transformer();
+        let value = Box::new(Expr::Ident(Ident::new(
+            "myVar".into(),
+            DUMMY_SP,
+            SyntaxContext::empty(),
+        )));
+        let stmt = transformer.create_module_exports_assignment("exportName", value);
+
+        if let Stmt::Expr(expr_stmt) = stmt {
+            if let Expr::Assign(assign_expr) = expr_stmt.expr.as_ref() {
+                // Check left side: module.exports.exportName
+                if let AssignTarget::Simple(swc_core::ecma::ast::SimpleAssignTarget::Member(
+                    member_expr,
+                )) = &assign_expr.left
+                {
+                    if let Expr::Member(parent_member) = member_expr.obj.as_ref() {
+                        if let Expr::Ident(module_ident) = parent_member.obj.as_ref() {
+                            assert_eq!(module_ident.sym.as_str(), "module");
+                        } else {
+                            panic!("Expected 'module' identifier");
+                        }
+                        if let swc_core::ecma::ast::MemberProp::Ident(exports_prop) =
+                            &parent_member.prop
+                        {
+                            assert_eq!(exports_prop.sym.as_str(), "exports");
+                        } else {
+                            panic!("Expected 'exports' property");
+                        }
+                    } else {
+                        panic!("Expected member expression for module.exports");
+                    }
+                    if let swc_core::ecma::ast::MemberProp::Ident(prop) = &member_expr.prop {
+                        assert_eq!(prop.sym.as_str(), "exportName");
+                    } else {
+                        panic!("Expected 'exportName' property");
+                    }
+                } else {
+                    panic!("Expected member expression");
+                }
+
+                // Check right side: myVar
+                if let Expr::Ident(ident) = assign_expr.right.as_ref() {
+                    assert_eq!(ident.sym.as_str(), "myVar");
+                } else {
+                    panic!("Expected identifier on right side");
+                }
+            } else {
+                panic!("Expected assignment expression");
+            }
+        } else {
+            panic!("Expected expression statement");
+        }
+    }
+
+    #[test]
+    fn test_empty_import_specifiers() {
+        let transformer = create_test_transformer();
+        let import_decl = create_import_decl("react", vec![]);
+
+        let result = transformer.transform_import_decl(&import_decl);
+
+        if let ModuleItem::Stmt(Stmt::Decl(swc_core::ecma::ast::Decl::Var(var_decl))) = result {
+            assert!(var_decl.decls.is_empty());
+        } else {
+            panic!("Expected variable declaration");
+        }
+    }
+
+    #[test]
+    fn test_empty_export_specifiers() {
+        let transformer = create_test_transformer();
+        let export = NamedExport {
+            span: DUMMY_SP,
+            specifiers: vec![],
+            src: None,
+            type_only: false,
+            with: None,
+        };
+
+        let stmts = transformer.transform_export_named(&export);
+        assert!(stmts.is_empty());
+    }
+}

--- a/crates/codemod-sandbox/src/utils/bundler/runtime_commonjs.tpl
+++ b/crates/codemod-sandbox/src/utils/bundler/runtime_commonjs.tpl
@@ -1,0 +1,37 @@
+(function () {
+  var modules = {};
+  var cache = {};
+  var builtinModules = {};
+
+  function __codemod_require(id) {
+    // Check if it's a built-in module first
+    if (builtinModules[id]) {
+      return builtinModules[id];
+    }
+    
+    if (cache[id]) {
+      return cache[id].exports;
+    }
+
+    var module = { exports: {} };
+    cache[id] = module;
+
+    if (modules[id]) {
+      modules[id].call(module, module, module.exports, __codemod_require);
+    }
+
+    return module.exports;
+  }
+
+  function __codemod_define(id, factory) {
+    modules[id] = factory;
+  }
+  
+  function __codemod_register_builtin(id, module) {
+    builtinModules[id] = module;
+  }
+
+  globalThis.__codemod_require = __codemod_require;
+  globalThis.__codemod_define = __codemod_define;
+  globalThis.__codemod_register_builtin = __codemod_register_builtin;
+})();

--- a/crates/codemod-sandbox/src/utils/bundler/runtime_custom.tpl
+++ b/crates/codemod-sandbox/src/utils/bundler/runtime_custom.tpl
@@ -1,0 +1,37 @@
+(function() {
+  var modules = {};
+  var cache = {};
+  var builtinModules = {};
+  
+  function __codemod_require(id) {
+    // Check if it's a built-in module first
+    if (builtinModules[id]) {
+      return builtinModules[id];
+    }
+    
+    if (cache[id]) {
+      return cache[id];
+    }
+    
+    var exports = {};
+    cache[id] = exports;
+    
+    if (modules[id]) {
+      modules[id](exports, __codemod_require);
+    }
+    
+    return exports;
+  }
+  
+  function __codemod_define(id, factory) {
+    modules[id] = factory;
+  }
+  
+  function __codemod_register_builtin(id, module) {
+    builtinModules[id] = module;
+  }
+  
+  globalThis.__codemod_require = __codemod_require;
+  globalThis.__codemod_define = __codemod_define;
+  globalThis.__codemod_register_builtin = __codemod_register_builtin;
+})();

--- a/crates/codemod-sandbox/src/utils/mod.rs
+++ b/crates/codemod-sandbox/src/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod bundler;
 pub mod project_discovery;
 
 #[cfg(feature = "wasm")]


### PR DESCRIPTION


<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
- Introduced a new `bundle` command in the JSSG CLI for bundling JSSG codemods and their dependencies.
- Implemented a bundler utility that processes and bundles JS files, integrating with existing module resolution.
- Refactored existing commands to accommodate the new bundling functionality.
- Auto bundle JSSG codemods on publish

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
