### PR TITLE
chore(docs): Changelog update July 24

### DIFF
--- a/apps/docs/more-resources/changelog.mdx
+++ b/apps/docs/more-resources/changelog.mdx
@@ -5,7 +5,19 @@ icon: 'scroll'
 mode: "center"
 ---
 
-<Update label="2025-06-03">
+<Update label="July 24, 2025">
+
+- **API Keys Management**: Generate, rotate, and revoke keys with per-package permissions and automatic expiry.
+- **Package Registry Overhaul**: Publish, search, and download codemods with version pinning, download stats, and scoped visibility.
+- **Create Workflows From Registry**: Launch campaigns directly from any published package; version stays locked for reproducible runs.
+- **Studio Interface Redesign**: Tabbed rule editor, mobile-friendly layout, and streamlined action bar improve focus and navigation.
+- **Performance & Build**: Next.js 15.4 + Turbopack and React 19 Compiler deliver faster builds and lower memory use.
+- **Security Hardening**: Dynamic CSP, secure cookies, and rate-limited API endpoints keep projects safe.
+- **Under-the-hood Improvements**: bug fixes, dependency upgrades, and refactors for better stability.
+
+</Update>
+
+<Update label="June 3, 2025">
 
 - **Faster, lighter Codemod Studio**: the underlying runtime was rebuilt, cutting load times when you switch languages and adding support for several new languages.
 - **GitLab integration reliability**: improved token handling makes CI workflows and branch pushes smoother.


### PR DESCRIPTION
Changelog update for July 24, 2025

<img width="1008" height="466" alt="Screenshot 2025-07-24 at 8 39 05 PM" src="https://github.com/user-attachments/assets/dfba48fe-73d4-4a39-8a0f-2acb1424e5ba" />
