### PR TITLE
fix(codemod-sandbox): Replace row with line in JsPosition to match the types from @ast-grep/napi

### DIFF
--- a/crates/codemod-sandbox/src/ast_grep/sg_node.rs
+++ b/crates/codemod-sandbox/src/ast_grep/sg_node.rs
@@ -153,12 +153,12 @@ impl<'js> SgNodeRjs<'js> {
 
         let result = JsNodeRange {
             start: crate::ast_grep::types::JsPosition {
-                row: start_pos_obj.line(),
+                line: start_pos_obj.line(),
                 column: start_pos_obj.column(&self.inner_node),
                 index: byte_range.start,
             },
             end: crate::ast_grep::types::JsPosition {
-                row: end_pos_obj.line(),
+                line: end_pos_obj.line(),
                 column: end_pos_obj.column(&self.inner_node),
                 index: byte_range.end,
             },

--- a/crates/codemod-sandbox/src/ast_grep/types.rs
+++ b/crates/codemod-sandbox/src/ast_grep/types.rs
@@ -3,7 +3,7 @@ use crate::rquickjs_compat::{Ctx, Error, FromJs, IntoJs, Object, Result, Value};
 use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct JsPosition {
-    pub row: usize,
+    pub line: usize,
     pub column: usize,
     pub index: usize,
 }
@@ -14,17 +14,21 @@ impl<'js> FromJs<'js> for JsPosition {
         let obj = value
             .as_object()
             .ok_or(Error::new_from_js(ty_name, "Object"))?;
-        let row = obj.get("row")?;
+        let line = obj.get("line")?;
         let column = obj.get("column")?;
         let index = obj.get("index")?;
-        Ok(Self { row, column, index })
+        Ok(Self {
+            line,
+            column,
+            index,
+        })
     }
 }
 
 impl<'js> IntoJs<'js> for JsPosition {
     fn into_js(self, ctx: &Ctx<'js>) -> Result<Value<'js>> {
         let obj = Object::new(ctx.clone())?;
-        obj.set("row", self.row)?;
+        obj.set("line", self.line)?;
         obj.set("column", self.column)?;
         obj.set("index", self.index)?;
         obj.into_js(ctx)


### PR DESCRIPTION
### 📚 Description
The type `Position` in @codemod.com/jssg-types differs from what is returned in Range objects in JavaScript.

Looking at the ast-grep Rust implementation, the line is returned as row there. If this change needs to be made in the Rust code rather than in the type definitions, please let me know, I’d be happy to contribute to the Rust code (I tried to run it but had some issues setting up the development environment, so I’ll need some help with it. I can also use this opportunity to document how to setup development environment in the CONTRIBUTING.md).

https://github.com/codemod-com/codemod/blob/6578c1672bde74559c341e8adf89556c7bc464c5/crates/codemod-sandbox/src/ast_grep/sg_node.rs#L154-L165

#### 🔗 Linked Issue
https://github.com/nodejs/userland-migrations/pull/136
