### PR TITLE
fix: prevent publishing codemods when jssg module resolution fails

### DIFF
--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -302,7 +302,7 @@ fn bundle_js_file(package_path: &Path, js_file: &str) -> Result<String> {
         Bundler::new(config).map_err(|e| anyhow!("Failed to create bundler: {}", e))?;
     let bundle_result = bundler
         .bundle(&js_file_path.to_string_lossy())
-        .map_err(|e| anyhow!("Failed to bundle {}: {}", js_file, e))?;
+        .map_err(|e| anyhow!("Failed to bundle {js_file}:\n{e}"))?;
 
     info!(
         "Successfully bundled {} ({} modules)",
@@ -393,15 +393,7 @@ fn create_package_bundle(
     // Bundle JS files first and prepare replacements
     let mut bundled_files = HashMap::new();
     for js_file in js_files_to_bundle {
-        match bundle_js_file(package_path, js_file) {
-            Ok(bundled_code) => {
-                bundled_files.insert(js_file.clone(), bundled_code);
-                info!("Successfully bundled: {js_file}");
-            }
-            Err(e) => {
-                warn!("Failed to bundle {js_file}: {e}. Using original file.");
-            }
-        }
+        bundled_files.insert(js_file.clone(), bundle_js_file(package_path, js_file)?);
     }
 
     // Create tar.gz archive

--- a/crates/codemod-sandbox/src/sandbox/errors.rs
+++ b/crates/codemod-sandbox/src/sandbox/errors.rs
@@ -18,7 +18,7 @@ pub enum FsError {
 
 #[derive(Debug, Error)]
 pub enum ResolverError {
-    #[error("Module resolution failed: base='{base}', name='{name}'")]
+    #[error("Module resolution failed:\nCannot resolve {name} from {base}")]
     ResolutionFailed { base: String, name: String },
 
     #[error("Invalid module path: {path}")]


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->

Previously, the _bundler errors_ on publish were getting swallowed. We should stop the publish process when jssg entry file cannot be bundled.

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
