### PR TITLE
[SAL-286] docs: Update bg color

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -7,6 +7,12 @@
     "light": "#91c500",
     "dark": "#0B151E"
   },
+  "background": {
+    "color": {
+      "dark": "#0b141e",
+      "light": "#FFF"
+    }
+  },
   "favicon": "/favicon.svg",
   "styling": {
     "eyebrows": "breadcrumbs"


### PR DESCRIPTION
[Merging is optional] See if you like how this more than the darker background we currently have. If you like the darker background, we can change the background of the illustration on the intro page to use the same color.

Updates docs background color to brand dark blue

<img width="1512" height="859" alt="Screenshot 2025-07-28 at 7 28 19 PM" src="https://github.com/user-attachments/assets/f19af2a3-a557-4dd2-b4dd-72511c1149f9" />
