### PR TITLE
Update cli-reference.mdx

### DIFF
--- a/apps/docs/cli/cli-reference.mdx
+++ b/apps/docs/cli/cli-reference.mdx
@@ -29,7 +29,7 @@ import { APIKeyDemo } from "/snippets/api-key-demo.mdx";
     npx codemod@next publish my-codemod
     ```
 
-    This publishes your codemod to the registry (you may need to [login](#codemod%40next-login) first).
+    This publishes your codemod to the registry (you may need to <a href="#codemod%40next-login">login</a> first).
   </Step>
   <Step title="Run your codemod">
     <Tabs>
@@ -58,8 +58,8 @@ For more details on building and running workflows, see the [Workflows documenta
 
 ## Advanced Concepts
 
-- **Workflows:** Orchestrate complex, multi-step codemod processes.
-- **jssg:** Run JavaScript/TypeScript codemods using the high-performance ast-grep engine.
+- <a href="#codemod%40next-workflow">**Workflows:**</a> Orchestrate complex, multi-step codemod processes.
+- <a href="#codemod%40next-jssg">**jssg:**</a> Run JavaScript/TypeScript codemods using the high-performance ast-grep engine.
 
 ---
 


### PR DESCRIPTION
found an undocumented workaround for the bug in mintlify when linking to headings with special chars. apply the workaround to CLI reference