### PR TITLE
chore(docs): remove duplicated line cli reference

### DIFF
--- a/apps/docs/cli/cli-reference.mdx
+++ b/apps/docs/cli/cli-reference.mdx
@@ -390,7 +390,6 @@ npx codemod@next jssg test <codemod_file> [options]
 
     - It's built into the CLI, so you can run it directly without needing to install it separately.
     - It's built for speed and simplicity, making ast-grep codemods a first-class experience.
-    - It's built for speed and simplicity, making ast-grep codemods a first-class experience.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
#### 📚 Description

The line `It’s built for speed and simplicity, making ast-grep codemods a first-class experience.` was duplicated in the doc. This PR removes the duplicate line.

<img width="714" height="707" alt="Screenshot 2025-08-08 at 19 34 16" src="https://github.com/user-attachments/assets/b496468b-e98e-4021-952f-b7af4ac9de0c" />