### PR TITLE
docs: deprecate @next specifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ This repo houses the **Codemod CLI** and its underlying **workflow engine** – 
 ## Key Features
 
 - **Workflows** – Scaffold, test, and orchestrate complex, multi-step migrations with ast-grep YAML or JavaScipt ast-grep (jssg).
-- **Codemod Registry** – Share or discover community codemods via `npx codemod@next publish` or `npx codemod@next search`.
+- **Codemod Registry** – Share or discover community codemods via `npx codemod publish` or `npx codemod search`.
 
 ## Getting Started
 
 ```bash
 # 1) Scaffold a new codemod project
-npx codemod@next init my-codemod
+npx codemod init my-codemod
 
 # 2) Test it locally
-npx codemod@next workflow run -w my-codemod/workflow.yaml
+npx codemod workflow run -w my-codemod/workflow.yaml
 
 # 3) Publish it when you're ready
-npx codemod@next publish my-codemod
+npx codemod publish my-codemod
 
 # 4) Run it from the Registry
-npx codemod@next @codemod-com/my-codemod
+npx codemod @codemod-com/my-codemod
 ```
 
 See the full [CLI reference](https://docs.codemod.com/cli/cli-reference) for every command and option.

--- a/apps/docs/api-reference/transformation/astgrep/reference.mdx
+++ b/apps/docs/api-reference/transformation/astgrep/reference.mdx
@@ -42,7 +42,7 @@ Replaces code found with `ast-grep` pattern using instructions provided to LLM.
 ```
 
 ```bash running codemod
-npx codemod@latest codemod-name --OPENAI_API_KEY=$OPENAI_API_KEY
+npx codemod codemod-name --OPENAI_API_KEY=$OPENAI_API_KEY
 ```
 </CodeGroup>
 

--- a/apps/docs/building-codemods/codemod2.mdx
+++ b/apps/docs/building-codemods/codemod2.mdx
@@ -20,7 +20,7 @@ import NiceIcon from '@mui/icons-material/ThreeDRotation';
 
 ### Step 1: Initialize a new codemod.
 
-Run `npx codemod@latest init` in your desired location to store the codemod folder, and select `workflow` as your engine. This sets up the scaffolding for your codemod, making it easy to provide configuration and metadata. While optional for building and running a codemod, this step enhances discoverability and sharing.
+Run `npx codemod init` in your desired location to store the codemod folder, and select `workflow` as your engine. This sets up the scaffolding for your codemod, making it easy to provide configuration and metadata. While optional for building and running a codemod, this step enhances discoverability and sharing.
 
 ![Initializing codemod](/images/guides/codemod2/initializing.png)
 
@@ -95,7 +95,7 @@ export async function workflow({ files }: Api) {
 Let's check it out:
 
 ```bash
-npx codemod@latest mui-named-import-to-direct-import/src/index.ts \
+npx codemod mui-named-import-to-direct-import/src/index.ts \
 --OPENAI_API_KEY=$OPEN_API_KEY \
 --engine=workflow
 ```
@@ -130,7 +130,7 @@ Now that our codemod is ready, we can publish it to Codemod Registry. This allow
 
 ```bash
 cd mui-named-import-to-direct-import
-npx codemod@latest publish
+npx codemod publish
 ```
 
 ![Publishing the codemod to Codemod Registry](/images/guides/codemod2/publish-codemod.png)
@@ -138,7 +138,7 @@ npx codemod@latest publish
 Now that the codemod is published, you can easily run it from Codemode Registry:
 
 ```bash
-npx codemod@latest mui/named-import-to-direct-import --OPENAI_API_KEY=$OPENAI_API_KEY
+npx codemod mui/named-import-to-direct-import --OPENAI_API_KEY=$OPENAI_API_KEY
 ```
 
 ![Codemod Diff View](/images/guides/codemod2/diff-view.png)

--- a/apps/docs/cli/cli-reference.mdx
+++ b/apps/docs/cli/cli-reference.mdx
@@ -12,14 +12,10 @@ import { APIKeyDemo } from "/snippets/api-key-demo.mdx";
   <CLIDemo />
 </Frame>
 
-<Warning>
-  Codemod CLI is currently released under the `@next` tag while in alpha. Core commands and schema may change as we gather feedback. Check the CLI reference for updates until we publish a stable `@latest`.
-</Warning>
-
 <Steps>
   <Step title="Initialize a new codemod project">
     ```bash
-    npx codemod@next init
+    npx codemod init
     ```
 
     This scaffolds a new codemod project in the current directory.
@@ -28,21 +24,21 @@ import { APIKeyDemo } from "/snippets/api-key-demo.mdx";
     ```bash
     cd /path/to/project-to-migrate
 
-    npx codemod@next workflow run -w /path/to/my-codemod/workflow.yaml
+    npx codemod workflow run -w /path/to/my-codemod/workflow.yaml
     ```
 
     This runs your local codemod workflow on your codebase to test it before publishing.
   </Step>
   <Step title="Publish your codemod">
     ```bash
-    npx codemod@next publish
+    npx codemod publish
     ```
 
-    This publishes your codemod to the registry (you may need to <a href="#codemod%40next-login">login</a> first).
+    This publishes your codemod to the registry (you may need to <a href="#codemod-login">login</a> first).
   </Step>
   <Step title="Run the published codemod">
     ```bash
-    npx codemod@next @codemod-com/my-test-pkg
+    npx codemod @codemod-com/my-test-pkg
     ```
 
     Run your published codemod directly from the [Codemod Registry](https://app.codemod.com/registry).
@@ -55,16 +51,16 @@ For more details on building and running workflows, see the [Workflows documenta
 
 ## Advanced Concepts
 
-- <a href="#codemod%40next-workflow">**Workflows:**</a> Orchestrate complex, multi-step codemod processes.
-- <a href="#codemod%40next-jssg">**JS ast-grep (jssg):**</a> Run codemods written in JavaScript/TypeScript to transform code in any language using the high-performance ast-grep engine.
+- <a href="#codemod-workflow">**Workflows:**</a> Orchestrate complex, multi-step codemod processes.
+- <a href="#codemod-jssg">**JS ast-grep (jssg):**</a> Run codemods written in JavaScript/TypeScript to transform code in any language using the high-performance ast-grep engine.
 
 ---
 
 # CLI Command Reference
 
-Codemod CLI (new) is accessible using the `npx codemod@next` command. The following commands and options are available:
+Codemod CLI is accessible using the `npx codemod` command. The following commands and options are available:
 
-### `codemod@next workflow`
+### `codemod workflow`
 
 Manage and execute workflow YAMLs.
 
@@ -75,19 +71,19 @@ Run a workflow.
 <CodeGroup>
 
 ```bash Running a local workflow
-npx codemod@next workflow run -w <workflow.yaml|directory> [--param key=value]
+npx codemod workflow run -w <workflow.yaml|directory> [--param key=value]
 ```
 
 ```bash Running a workflow from Codemod Registry
-npx codemod@next workflow run <package-name> [--param key=value]
+npx codemod workflow run <package-name> [--param key=value]
 ```
 
 </CodeGroup>
 
 <Info>
 **Local workflows vs. Registry packages:** 
-- Use `npx codemod@next workflow run -w <path>` for local workflow files and directories
-- Use `npx codemod@next <package-name>` to run packages directly from the [Codemod Registry](https://app.codemod.com/registry)
+- Use `npx codemod workflow run -w <path>` for local workflow files and directories
+- Use `npx codemod <package-name>` to run packages directly from the [Codemod Registry](https://app.codemod.com/registry)
 </Info>
 
 <ResponseField name="-w, --workflow <PATH>" type="string" required>
@@ -105,23 +101,23 @@ npx codemod@next workflow run <package-name> [--param key=value]
 
 ```bash
 # Run a local workflow file
-npx codemod@next workflow run -w ./my-workflow.yaml
+npx codemod workflow run -w ./my-workflow.yaml
 
 # Run a workflow from a local directory
-npx codemod@next workflow run -w ./my-codemod
+npx codemod workflow run -w ./my-codemod
 
 # Run with parameters
-npx codemod@next workflow run -w ./my-codemod --param version=latest --param target=src
+npx codemod workflow run -w ./my-codemod --param version=latest --param target=src
 ```
 
 **Running a workflow from the registry**:
 
 ```bash
 # Run a workflow package from the registry
-npx codemod@next @codemod-com/my-test-pkg
+npx codemod @codemod-com/my-test-pkg
 
 # Run with parameters
-npx codemod@next @codemod-com/my-test-pkg --param version=latest --param target=src
+npx codemod @codemod-com/my-test-pkg --param version=latest --param target=src
 ```
 
 Explore available packages on [Codemod Registry](https://app.codemod.com/registry).
@@ -133,7 +129,7 @@ Explore available packages on [Codemod Registry](https://app.codemod.com/registr
 Resume a paused workflow.
 
 ```bash
-npx codemod@next workflow resume -i <ID> [-t <TASK>] [--trigger-all]
+npx codemod workflow resume -i <ID> [-t <TASK>] [--trigger-all]
 ```
 
 <ResponseField name="-i, --id <ID>" type="string" required>
@@ -153,7 +149,7 @@ npx codemod@next workflow resume -i <ID> [-t <TASK>] [--trigger-all]
 Validate a workflow file.
 
 ```bash
-npx codemod@next workflow validate -w <workflow.yaml>
+npx codemod workflow validate -w <workflow.yaml>
 ```
 
 <ResponseField name="-w, --workflow <FILE>" type="string" required>
@@ -191,7 +187,7 @@ npx codemod@next workflow validate -w <workflow.yaml>
 Show workflow run status.
 
 ```bash
-npx codemod@next workflow status -i <ID>
+npx codemod workflow status -i <ID>
 ```
 
 <ResponseField name="-i, --id <ID>" type="string" required>
@@ -203,7 +199,7 @@ npx codemod@next workflow status -i <ID>
 List workflow runs.
 
 ```bash
-npx codemod@next workflow list [-l <LIMIT>]
+npx codemod workflow list [-l <LIMIT>]
 ```
 
 <ResponseField name="-l, --limit <LIMIT>" type="number">
@@ -215,18 +211,18 @@ npx codemod@next workflow list [-l <LIMIT>]
 Cancel a workflow run.
 
 ```bash
-npx codemod@next workflow cancel -i <ID>
+npx codemod workflow cancel -i <ID>
 ```
 
 <ResponseField name="-i, --id <ID>" type="string" required>
   Workflow run ID.
 </ResponseField>
 
-### `codemod@next jssg`
+### `codemod jssg`
 
 JS ast-grep (jssg) is a toolkit for running JavaScript/TypeScript codemods using the high-performance ast-grep engine. It enables fast, large-scale code transformations with a familiar API and robust language support.
 
-`codemod@next jssg` lets you run ast-grep codemods directly from the CLI, without needing to define a workflow. It's built for speed and simplicity, making ast-grep codemods a first-class experience.
+`codemod jssg` lets you run ast-grep codemods directly from the CLI, without needing to define a workflow. It's built for speed and simplicity, making ast-grep codemods a first-class experience.
 
 <Tip>
   **When should I use JS ast-grep (jssg)?**
@@ -241,7 +237,7 @@ JS ast-grep (jssg) is a toolkit for running JavaScript/TypeScript codemods using
   </Step>
   <Step title="Run your codemod">
     ```bash
-    npx codemod@next jssg run my-codemod.js ./src --language javascript
+    npx codemod jssg run my-codemod.js ./src --language javascript
     ```
   </Step>
   <Step title="Test your codemod">
@@ -264,7 +260,7 @@ JS ast-grep (jssg) is a toolkit for running JavaScript/TypeScript codemods using
     Then run:
 
     ```bash
-    npx codemod@next jssg test my-codemod.js --language javascript
+    npx codemod jssg test my-codemod.js --language javascript
     ```
   </Step>
 </Steps>
@@ -274,7 +270,7 @@ JS ast-grep (jssg) is a toolkit for running JavaScript/TypeScript codemods using
 Run a JS ast-grep (jssg) codemod.
 
 ```bash
-npx codemod@next jssg run <codemod_file> <target_directory> [options]
+npx codemod jssg run <codemod_file> <target_directory> [options]
 ```
 
 <ResponseField name="codemod_file" type="string" required>
@@ -314,7 +310,7 @@ npx codemod@next jssg run <codemod_file> <target_directory> [options]
 Test a JS ast-grep(jssg) codemod using before/after fixtures.
 
 ```bash
-npx codemod@next jssg test <codemod_file> [options]
+npx codemod jssg test <codemod_file> [options]
 ```
 
 <ResponseField name="codemod_file" type="string" required>
@@ -395,12 +391,12 @@ npx codemod@next jssg test <codemod_file> [options]
 
 ---
 
-### `codemod@next init`
+### `codemod init`
 
 Initialize a new workflow project.
 
 ```bash
-npx codemod@next init [PATH] [options]
+npx codemod init [PATH] [options]
 ```
 
 <ResponseField name="[PATH]" type="string">
@@ -443,12 +439,12 @@ npx codemod@next init [PATH] [options]
   Use defaults without prompts.
 </ResponseField>
 
-### `codemod@next login`
+### `codemod login`
 
 Login to a registry.
 
 ```bash
-npx codemod@next login [--api-key <API_KEY>] [--registry <REGISTRY>] [--scope <SCOPE>]
+npx codemod login [--api-key <API_KEY>] [--registry <REGISTRY>] [--scope <SCOPE>]
 ```
 
 <ResponseField name="--api-key <API_KEY>" type="string">
@@ -467,12 +463,12 @@ npx codemod@next login [--api-key <API_KEY>] [--registry <REGISTRY>] [--scope <S
   Need a key? Generate one in the Codemod app [here ->](https://app.codemod.com/api-keys).
 </Tip>
 
-### `codemod@next logout`
+### `codemod logout`
 
 Logout from a registry.
 
 ```bash
-npx codemod@next logout [--registry <REGISTRY>] [--all]
+npx codemod logout [--registry <REGISTRY>] [--all]
 ```
 
 <ResponseField name="--registry <REGISTRY>" type="string">
@@ -483,12 +479,12 @@ npx codemod@next logout [--registry <REGISTRY>] [--all]
   Logout from all registries.
 </ResponseField>
 
-### `codemod@next whoami`
+### `codemod whoami`
 
 Show current authentication status.
 
 ```bash
-npx codemod@next whoami [--registry <REGISTRY>] [--detailed]
+npx codemod whoami [--registry <REGISTRY>] [--detailed]
 ```
 
 <ResponseField name="--registry <REGISTRY>" type="string">
@@ -499,12 +495,12 @@ npx codemod@next whoami [--registry <REGISTRY>] [--detailed]
   Show detailed information including token scopes.
 </ResponseField>
 
-### `codemod@next publish`
+### `codemod publish`
 
 Publish a workflow to a registry.
 
 ```bash
-npx codemod@next publish [PATH] [options]
+npx codemod publish [PATH] [options]
 ```
 
 <ResponseField name="[PATH]" type="string">
@@ -547,7 +543,7 @@ npx codemod@next publish [PATH] [options]
         steps:
           - uses: actions/checkout@v4
           - name: Publish to Codemod Registry
-            run: npx codemod@next publish . --scope your-org --access public --tag ${{ github.sha }}
+            run: npx codemod publish . --scope your-org --access public --tag ${{ github.sha }}
             env:
               CODEMOD_TOKEN: ${{ secrets.CODEMOD_TOKEN }} # generated by GitHub App installation
     ```
@@ -570,37 +566,37 @@ npx codemod@next publish [PATH] [options]
         steps:
           - uses: actions/checkout@v4
           - name: Login to Codemod Registry with API key
-            run: npx codemod@next login --api-key ${{ secrets.CODEMOD_API_KEY }}
+            run: npx codemod login --api-key ${{ secrets.CODEMOD_API_KEY }}
           - name: Publish codemod
-            run: npx codemod@next publish . --scope your-org --access public --tag ${{ github.sha }}
+            run: npx codemod publish . --scope your-org --access public --tag ${{ github.sha }}
     ```
   </Accordion>
   <Accordion title="Examples">
     ```bash
     # Dry-run to verify bundle
-    npx codemod@next publish ./my-codemod --dry-run
+    npx codemod publish ./my-codemod --dry-run
     
     # Publish a private package tagged beta
-    npx codemod@next publish ./my-codemod --access private --tag beta
+    npx codemod publish ./my-codemod --access private --tag beta
     
     # Override version and custom registry
-    npx codemod@next publish ./my-codemod --version 1.2.0 --registry https://registry.example.com
+    npx codemod publish ./my-codemod --version 1.2.0 --registry https://registry.example.com
     
     # Publish under an organization scope (requires GitHub App installation)
-    npx codemod@next publish ./my-codemod --scope nodejs
+    npx codemod publish ./my-codemod --scope nodejs
     
     # After publishing, run your package from the registry
-    npx codemod@next @your-scope/my-codemod
+    npx codemod @your-scope/my-codemod
     ```
   </Accordion>
 </AccordionGroup>
 
-### `codemod@next unpublish`
+### `codemod unpublish`
 
 Remove a package or selected version from the registry.
 
 ```bash
-npx codemod@next unpublish <PACKAGE> [options]
+npx codemod unpublish <PACKAGE> [options]
 ```
 
 <ResponseField name="<PACKAGE>" type="string" required>
@@ -630,25 +626,25 @@ npx codemod@next unpublish <PACKAGE> [options]
 <Accordion title="Examples">
   ```bash
   # Preview removal of a single version
-  npx codemod@next unpublish my-codemod --version 0.1.0 --dry-run
+  npx codemod unpublish my-codemod --version 0.1.0 --dry-run
   
   # Remove a single version (will prompt)
-  npx codemod@next unpublish my-codemod --version 0.1.0
+  npx codemod unpublish my-codemod --version 0.1.0
   
   # Remove all versions (will prompt)
-  npx codemod@next unpublish my-codemod --force
+  npx codemod unpublish my-codemod --force
   
   # Unpublish from a custom registry
-  npx codemod@next unpublish my-codemod --force --registry https://registry.example.com
+  npx codemod unpublish my-codemod --force --registry https://registry.example.com
   ```
 </Accordion>
 
-### `codemod@next search`
+### `codemod search`
 
 Search for packages in the registry.
 
 ```bash
-npx codemod@next search [OPTIONS] [QUERY]
+npx codemod search [OPTIONS] [QUERY]
 ```
 
 <ResponseField name="[QUERY]" type="string">
@@ -691,23 +687,23 @@ npx codemod@next search [OPTIONS] [QUERY]
   Search for codemods related to React:
 
   ```bash
-  npx codemod@next search react
+  npx codemod search react
   ```
 
   Filter by language and category:
 
   ```bash
-  npx codemod@next search --language typescript --category migration
+  npx codemod search --language typescript --category migration
   ```
 
   Get results in JSON format:
 
   ```bash
-  npx codemod@next search --format json next
+  npx codemod search --format json next
   ```
 </Accordion>
 
-### `codemod@next cache`
+### `codemod cache`
 
 Manage the local package cache for codemod packages.
 
@@ -716,7 +712,7 @@ Manage the local package cache for codemod packages.
 Show cache information and statistics.
 
 ```bash
-npx codemod@next cache info
+npx codemod cache info
 ```
 
 **`cache list`**
@@ -724,7 +720,7 @@ npx codemod@next cache info
 List cached packages.
 
 ```bash
-npx codemod@next cache list [--detailed]
+npx codemod cache list [--detailed]
 ```
 
 <ResponseField name="--detailed" type="boolean">
@@ -736,7 +732,7 @@ npx codemod@next cache list [--detailed]
 Clear cache for a specific package, or all packages.
 
 ```bash
-npx codemod@next cache clear [PACKAGE] [--all]
+npx codemod cache clear [PACKAGE] [--all]
 ```
 
 <ResponseField name="[PACKAGE]" type="string">
@@ -752,7 +748,7 @@ npx codemod@next cache clear [PACKAGE] [--all]
 Prune old or unused cache entries.
 
 ```bash
-npx codemod@next cache prune [--max-age <MAX_AGE>] [--dry-run]
+npx codemod cache prune [--max-age <MAX_AGE>] [--dry-run]
 ```
 
 <ResponseField name="--max-age <MAX_AGE>" type="number">

--- a/apps/docs/cli/workflows.mdx
+++ b/apps/docs/cli/workflows.mdx
@@ -31,7 +31,7 @@ Codemod Workflows can be run using [Codemod CLI](/cli/cli-reference) or [Codemod
 <Steps>
   <Step title="Create a new codemod project">
     ```bash
-    npx codemod@next init
+    npx codemod init
     ```
 
     When creating a new codemod project, you'll be prompted for:
@@ -243,8 +243,8 @@ Codemod Workflows can be run using [Codemod CLI](/cli/cli-reference) or [Codemod
   </Step>
   <Step title="Validate & run your workflow">
     ```bash
-    npx codemod@next workflow validate -w workflow.yaml
-    npx codemod@next workflow run -w workflow.yaml
+    npx codemod workflow validate -w workflow.yaml
+    npx codemod workflow run -w workflow.yaml
     ```
 
     This will check your workflow for errors and then run it locally.
@@ -268,7 +268,7 @@ my-workflow/
 └─ rules/
 ```
 
-The folder—called a **workflow bundle**—is the root when you run `npx codemod@next workflow run ./my-workflow/`. `$CODEMOD_PATH` points here inside every task.
+The folder—called a **workflow bundle**—is the root when you run `npx codemod workflow run ./my-workflow/`. `$CODEMOD_PATH` points here inside every task.
 
 <Accordion title="Workflow Bundle & Loading Workflows">
   A workflow bundle is a directory containing your `workflow.yaml` and any scripts, rules, or assets referenced by your workflow.
@@ -276,7 +276,7 @@ The folder—called a **workflow bundle**—is the root when you run `npx codemo
   - When you run
 
     ```bash
-    npx codemod@next workflow run ./my-workflow/
+    npx codemod workflow run ./my-workflow/
     ```
 
     the directory is used as the root for all relative paths.
@@ -285,7 +285,7 @@ The folder—called a **workflow bundle**—is the root when you run `npx codemo
     <br />
 
     ```bash
-    npx codemod@next workflow run -w workflow.yaml
+    npx codemod workflow run -w workflow.yaml
     ```
 
   <Info>
@@ -485,12 +485,12 @@ nodes:
   - All paused tasks:
 
     ```bash
-    npx codemod@next workflow resume -i <run-id> --trigger-all
+    npx codemod workflow resume -i <run-id> --trigger-all
     ```
   - A specific task:
 
     ```bash
-    npx codemod@next workflow resume -i <run-id> -t <task-uuid>
+    npx codemod workflow resume -i <run-id> -t <task-uuid>
     ```
 </Accordion>
 
@@ -557,7 +557,7 @@ nodes:
     ```
 
     <Info>
-      This error is shown when you run `npx codemod@next workflow validate` or `npx codemod@next workflow run` on a workflow with a cyclic dependency.
+      This error is shown when you run `npx codemod workflow validate` or `npx codemod workflow run` on a workflow with a cyclic dependency.
     </Info>
   </Accordion>
 </AccordionGroup>

--- a/apps/docs/deploying-codemods/cli.mdx
+++ b/apps/docs/deploying-codemods/cli.mdx
@@ -11,7 +11,7 @@ description: "Get started with using the Codemod command-line interface."
   **To use the new CLI:**
 
   ```
-  npx codemod@next
+  npx codemod
   ```
 
   Read the new CLI docs [here -\>](/cli)
@@ -99,10 +99,10 @@ This command has special flags available to it that can be combined together to 
   To publish new codemods, use the new CLI:
 
   ```
-  npx codemod@next publish
+  npx codemod publish
   ```
 
-  Learn more [here -\>](/cli/workflows#codemod%40next-publish)
+  Learn more [here -\>](/cli/workflows#codemod-publish)
 </Warning>
 
 Can be used to publish a codemod to Codemod Registry.

--- a/apps/docs/guides/migrations/msw-v1-v2.mdx
+++ b/apps/docs/guides/migrations/msw-v1-v2.mdx
@@ -48,7 +48,7 @@ Codemod supports a mostly automated MSW v2 upgrade experience. This page provide
         Inside your project's root directory, run the [MSW v2 upgrade recipe](https://codemod.com/registry/msw-2-upgrade-recipe):
 
         ```bash
-        npx codemod@latest msw/2/upgrade-recipe
+        npx codemod msw/2/upgrade-recipe
         ```
     </Step>
     <Step title="Fix false negatives">

--- a/apps/docs/guides/migrations/nuxt-3-4.mdx
+++ b/apps/docs/guides/migrations/nuxt-3-4.mdx
@@ -53,7 +53,7 @@ Codemod supports a mostly automated Nuxt 4 upgrade experience. This page provide
     </Step>
     <Step title="Run migration codemods">
         ```bash
-        npx codemod@latest nuxt/4/migration-recipe
+        npx codemod nuxt/4/migration-recipe
         ``` 
 
         The recipe includes the following codemods:

--- a/apps/docs/guides/migrations/react-18-19.mdx
+++ b/apps/docs/guides/migrations/react-18-19.mdx
@@ -81,7 +81,7 @@ Codemod supports a mostly automated React 19 upgrade experience. This page provi
     Run the React 19 upgrade recipe:
 
     ```bash
-    npx codemod@latest react/19/migration-recipe
+    npx codemod react/19/migration-recipe
     ```
 
     This recipe is a set of codemods that will fix some of React 19 breaking changes.  

--- a/apps/docs/guides/migrations/zod-3-4.mdx
+++ b/apps/docs/guides/migrations/zod-3-4.mdx
@@ -47,7 +47,7 @@ Codemod provides an automated Zod 3 → 4 upgrade experience. This page walks yo
         Launch the codemod recipe to automatically rewrite common breaking changes:
 
         ```bash
-        npx codemod@next jssg run zod-3-4
+        npx codemod jssg run zod-3-4
         ```
 
         <Tip>

--- a/crates/cli/README.md
+++ b/crates/cli/README.md
@@ -24,7 +24,7 @@ cargo build --release
 ### From npm registry
 
 ```bash
-npm install -g codemod@next
+npm install -g codemod
 ```
 
 ## Quick Start


### PR DESCRIPTION
- deprecates `@next` specifier, making the `@next` CLI the stable version.
- removes remaining mentions of the legacy CLI.