### PR TITLE
fix(cli): add shorthand for --update-snapshot arg

### DIFF
--- a/crates/cli/src/commands/jssg/test.rs
+++ b/crates/cli/src/commands/jssg/test.rs
@@ -24,7 +24,7 @@ pub struct Command {
     pub filter: Option<String>,
 
     /// Update expected outputs with actual results
-    #[arg(long)]
+    #[arg(long, short)]
     pub update_snapshots: bool,
 
     /// Show detailed output for each test


### PR DESCRIPTION
#### 📚 Description

The [docs for the command](https://docs.codemod.com/cli/cli-reference#param-update-snapshots-u) `codemod jssg test` specify that the argument `--update-snapshots` has the shorthand `-u`.
However, it doesn’t actually exist, so this PR adds the shorthand.