### PR TITLE
Doc: update semantic analysis support for enterprise

### DIFF
--- a/apps/docs/jssg/semantic-analysis.mdx
+++ b/apps/docs/jssg/semantic-analysis.mdx
@@ -7,17 +7,15 @@ Semantic analysis enables your codemods to understand symbol relationships in co
 
 ## Supported Languages
 
-<Info>
-  Semantic analysis is currently supported for **JavaScript/TypeScript** and
-  **Python** only. For other languages, the semantic methods return no-op
-  results (null for definitions, empty arrays for references).
-</Info>
+| Language              | Provider                             | Features                                                                            |
+| --------------------- | ------------------------------------ | ----------------------------------------------------------------------------------- |
+| JavaScript/TypeScript | [oxc](https://oxc.rs/)               | Definitions, references, cross-file resolution                                      |
+| Python                | [ruff](https://docs.astral.sh/ruff/) | Definitions, references, cross-file resolution                                      |
+| Other languages       | Codemod                              | Enterprise features available.<br />For JSSG open-source, it returns no-op results. |
 
-| Language              | Provider                             | Features                                       |
-| --------------------- | ------------------------------------ | ---------------------------------------------- |
-| JavaScript/TypeScript | [oxc](https://oxc.rs/)               | Definitions, references, cross-file resolution |
-| Python                | [ruff](https://docs.astral.sh/ruff/) | Definitions, references, cross-file resolution |
-| Other languages       | —                                    | Returns null/empty (no-op)                     |
+<Info>
+  **Enterprise customers** can get semantic analysis for Go, Rust, Java, C, C++, C Sharp, Ruby, PHP, Swift, Kotlin, Haskell, and Elixir. [Contact us](https://codemod.com/contact) to learn more.
+</Info>
 
 ## Analysis Modes
 

--- a/biome.json
+++ b/biome.json
@@ -1,35 +1,37 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
-  "assist": { "actions": { "source": { "organizeImports": "off" } } },
+  "organizeImports": {
+    "enabled": false
+  },
   "files": {
-    "includes": [
-      "**",
-      "!**/__testfixtures__/**",
-      "!**/schemas/**",
-      "!**/submodules/**",
-      "!crates/cli/src/templates/**",
-      "!**/target/**",
-      "!**/build/**",
-      "!**/.next/**",
-      "!**/dist/**"
+    "include": ["**"],
+    "ignore": [
+      "**/__testfixtures__/**",
+      "**/schemas/**",
+      "**/submodules/**",
+      "crates/cli/src/templates/**",
+      "**/target/**",
+      "**/build/**",
+      "**/.next/**",
+      "**/dist/**"
     ]
   },
   "linter": {
-    "includes": [
-      "!packages",
-      "!**/*.d.ts",
-      "!**/*.js",
-      "!**/dist",
-      "!**/cdmd_dist",
-      "!**/build",
-      "!**/pnpm-lock.yaml",
-      "!**/node_modules",
-      "!**/.eslint*",
-      "!**/.next",
-      "!**/.vscode",
-      "!**/build-ncc",
-      "!**/generated",
-      "!**/target"
+    "ignore": [
+      "packages",
+      "**/*.d.ts",
+      "**/*.js",
+      "**/dist",
+      "**/cdmd_dist",
+      "**/build",
+      "**/pnpm-lock.yaml",
+      "**/node_modules",
+      "**/.eslint*",
+      "**/.next",
+      "**/.vscode",
+      "**/build-ncc",
+      "**/generated",
+      "**/target"
     ],
     "rules": {
       "suspicious": {
@@ -56,7 +58,7 @@
         "noExplicitAny": "warn",
         "noUnsafeDeclarationMerging": "warn",
         "noArrayIndexKey": "off",
-        "noWith": "warn"
+        "useValidTypeof": "warn"
       },
       "correctness": {
         "noUndeclaredVariables": "off",
@@ -74,18 +76,15 @@
         "useYield": "warn",
         "useIsNan": "warn",
         "useHookAtTopLevel": "error",
-        "useJsxKeyInIterable": "warn",
-        "useValidTypeof": "warn",
-        "noInvalidBuiltinInstantiation": "warn"
+        "useJsxKeyInIterable": "warn"
       },
       "complexity": {
         "noUselessConstructor": "off",
         "noUselessLabel": "warn",
         "noUselessRename": "warn",
         "noForEach": "off",
-        "noAdjacentSpacesInRegex": "warn",
-        "noArguments": "warn",
-        "noCommaOperator": "warn"
+        "noMultipleSpacesInRegularExpressionLiterals": "warn",
+        "noWith": "warn"
       },
       "style": {
         "noUnusedTemplateLiteral": "off",
@@ -116,33 +115,32 @@
       },
       "performance": { "noDelete": "off", "noAccumulatingSpread": "warn" },
       "security": {
-        "noDangerouslySetInnerHtml": "warn",
-        "noBlankTarget": "warn"
+        "noDangerouslySetInnerHtml": "warn"
       }
     }
   },
   "formatter": {
     "formatWithErrors": true,
     "indentStyle": "space",
-    "includes": [
-      "**",
-      "!**/*.d.ts",
-      "!**/input.js",
-      "!**/output.js",
-      "!**/dist",
-      "!**/cdmd_dist",
-      "!**/build",
-      "!**/pnpm-lock.yaml",
-      "!**/node_modules",
-      "!**/build-ncc",
-      "!**/.next",
-      "!**/.vscode",
-      "!**/generated",
-      "!**/*.py",
-      "!apps/ai/**",
-      "!**/.all-contributorsrc",
-      "!**/__testfixtures__/**",
-      "!**/target"
+    "include": ["**"],
+    "ignore": [
+      "**/*.d.ts",
+      "**/input.js",
+      "**/output.js",
+      "**/dist",
+      "**/cdmd_dist",
+      "**/build",
+      "**/pnpm-lock.yaml",
+      "**/node_modules",
+      "**/build-ncc",
+      "**/.next",
+      "**/.vscode",
+      "**/generated",
+      "**/*.py",
+      "apps/ai/**",
+      "**/.all-contributorsrc",
+      "**/__testfixtures__/**",
+      "**/target"
     ]
   }
 }


### PR DESCRIPTION
- Update the semantic analysis support for enterprise
- Update the biome.json file to ignore the apps/docs/jssg/semantic-analysis.mdx file
- Update the .vscode/settings.json file to ignore the apps/docs/jssg/semantic-analysis.mdx file