### PR TITLE
chore(docs): fix github link in website footer

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -130,7 +130,7 @@
   "footer": {
     "socials": {
       "twitter": "https://twitter.com/codemod",
-      "github": "https://github.com/codemod-com",
+      "github": "https://github.com/codemod",
       "linkedin": "https://www.linkedin.com/company/codemod"
     }
   },


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod-com/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->

This changes the link in the website to point to https://github.com/codemod rather than `https://github.com/codemod-com`

I'm guessing that at some point, the github repo used to live at https://github.com/codemod-com, but this changed to be https://github.com/codemod. Github seems to redirect the direct repo links, but not links to the org/user.

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
