### PR TITLE
feat: add jssg-utils package with import manipulation utilities

### DIFF
--- a/crates/codemod-sandbox/package.json
+++ b/crates/codemod-sandbox/package.json
@@ -36,7 +36,7 @@
     "@types/node": "^22.0.0",
     "eslint": "^8.57.1",
     "tsx": "^4.19.3",
-    "typescript": "^5.8.3"
+    "typescript": "catalog:"
   },
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.4.1",

--- a/crates/scheduler/npm/package.json
+++ b/crates/scheduler/npm/package.json
@@ -24,7 +24,7 @@
   "packageManager": "pnpm@10.4.0+sha512.6b849d0787d97f8f4e1f03a9b8ff8f038e79e153d6f11ae539ae7c435ff9e796df6a862c991502695c7f9e8fac8aeafc1ac5a8dab47e36148d183832d886dd52",
   "devDependencies": {
     "@types/node": "*",
-    "typescript": "^5.8.3",
+    "typescript": "catalog:",
     "vitest": "^1.6.0"
   }
 }

--- a/packages/jssg-types/package.json
+++ b/packages/jssg-types/package.json
@@ -38,6 +38,6 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "typescript": "5.5.4"
+    "typescript": "catalog:"
   }
 }

--- a/packages/jssg-utils/README.md
+++ b/packages/jssg-utils/README.md
@@ -1,0 +1,88 @@
+# @jssg/utils
+
+Utilities used by the JSSG codemod engine.
+
+## JavaScript import helpers
+
+Import from:
+
+```ts
+import { getImport, addImport, removeImport } from "@jssg/utils/javascript/imports";
+```
+
+These helpers work on a `program` AST node (from `codemod:ast-grep` / `@codemod.com/jssg-types`) and return either **lookup info** (`getImport`) or a single **text edit** you can apply with `program.commitEdits([edit])`.
+
+### `getImport(program, options)`
+
+Finds a binding for an import and returns:
+
+- **`alias`**: the identifier you should use at call sites (resolves `as` aliases)
+- **`isNamespace`**: `true` for `import * as ns from 'mod'`
+- **`moduleType`**: `'esm'` for `import ...` / `import()` and `'cjs'` for `require(...)`
+- **`node`**: the underlying identifier node
+
+Supported shapes (for a given `from`):
+
+- ESM default: `import foo from 'mod'`
+- ESM named: `import { bar as baz } from 'mod'`
+- ESM namespace: `import * as ns from 'mod'`
+- CJS default: `const foo = require('mod')`
+- CJS destructured: `const { bar: baz } = require('mod')`
+- Dynamic import (assigned): `const foo = await import('mod')`
+- Dynamic import (destructured): `const { bar } = await import('mod')`
+
+Note: **side-effect-only imports** like `import 'mod'` don’t produce a binding, so `getImport` returns `null`.
+
+### `addImport(program, options)`
+
+Creates an import/require edit or returns `null` if it’s already present.
+
+Options:
+
+- **Default**: `{ type: 'default', name, from, moduleType?: 'esm' | 'cjs' }`
+- **Namespace**: `{ type: 'namespace', name, from }` (always ESM)
+- **Named**: `{ type: 'named', specifiers: { name; alias? }[], from, moduleType?: 'esm' | 'cjs' }`
+
+Behavior:
+
+- Skips if already imported (for named imports: skips only the specifiers that already exist)
+- For ESM named imports, merges new specifiers into an existing `import { ... } from 'mod'` when possible
+- Inserts new imports **after the last existing import/require**, otherwise at file start
+
+Example:
+
+```ts
+import { parse } from "codemod:ast-grep";
+import type TS from "@codemod.com/jssg-types/langs/typescript";
+import { addImport } from "@jssg/utils/javascript/imports";
+
+const program = parse<TS>("typescript", "console.log('hello')\n").root();
+
+const edit = addImport(program, {
+  type: "named",
+  from: "mod",
+  specifiers: [{ name: "foo" }, { name: "bar", alias: "baz" }],
+});
+
+if (edit) {
+  const next = program.commitEdits([edit]);
+  // import { foo, bar as baz } from 'mod';
+}
+```
+
+### `removeImport(program, options)`
+
+Removes an import/require and returns an edit, or `null` if nothing matches.
+
+Options:
+
+- **Default**: `{ type: 'default', from }`
+- **Namespace**: `{ type: 'namespace', from }`
+- **Named**: `{ type: 'named', specifiers: string[], from }`
+
+Behavior:
+
+- Default/namespace: removes the entire statement
+- Named: removes a specifier; if you’re removing the last specifier(s), removes the entire statement
+
+Note: this function returns a **single edit**. For named removals, it removes the first matching specifier it finds unless it can remove the whole statement.

--- a/packages/jssg-utils/package.json
+++ b/packages/jssg-utils/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@jssg/utils",
+  "version": "0.0.1",
+  "description": "Codemod utils for jssg engine",
+  "author": "Mohebifar <mo@codemod.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/codemod/arc-codemods",
+  "repository": "https://github.com/codemod/arc-codemods",
+  "publishConfig": {
+    "access": "public"
+  },
+  "exports": {
+    "./javascript/*": {
+      "types": "./src/javascript/exports/*.ts",
+      "default": "./src/javascript/exports/*.ts"
+    }
+  },
+  "scripts": {
+    "test": "pnpx codemod jssg exec ./tests/imports.test.ts",
+    "check-types": "npx tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "catalog:",
+    "@codemod.com/jssg-types": "workspace:*"
+  }
+}

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -1,0 +1,1298 @@
+import type JS from "@codemod.com/jssg-types/langs/javascript";
+import type TSX from "@codemod.com/jssg-types/langs/tsx";
+import type TS from "@codemod.com/jssg-types/langs/typescript";
+import type { SgNode } from "@codemod.com/jssg-types/main";
+import { stringToExactRegexString } from "../../utils";
+
+type GetImportOptions =
+  | {
+      type: "default";
+      from: string;
+    }
+  | {
+      type: "named";
+      name: string;
+      from: string;
+    };
+
+type GetImportResult<T extends Language> = {
+  alias: string;
+  isNamespace: boolean; // This means the import is like `import * as xyz from 'express';` which means we later need to access with `xyz.something`
+  moduleType: "esm" | "cjs"; // "esm" for import statements (static or dynamic), "cjs" for require() calls
+  node: SgNode<T, "identifier">;
+} | null;
+
+type Language = JS | TS | TSX;
+
+/**
+ * Determines whether an import match is ESM or CJS based on the AST node type.
+ * - ESM: import statements (static or dynamic import())
+ * - CJS: require() calls
+ */
+function getModuleType<T extends Language>(match: SgNode<T>): "esm" | "cjs" {
+  const kind = match.kind();
+
+  // ESM-only kinds (static imports)
+  if (kind === "import_specifier" || kind === "import_statement") {
+    return "esm";
+  }
+
+  const tsMatch = match as unknown as SgNode<TS>;
+
+  // Find the variable_declarator (either the match itself or an ancestor)
+  // For pattern matching variable_declarator directly, it's the match itself
+  // For shorthand_property_identifier_pattern/pair_pattern, need to find ancestor
+  let varDeclarator: SgNode<TS> | null = null;
+  if (kind === "variable_declarator") {
+    varDeclarator = tsMatch;
+  } else {
+    varDeclarator =
+      (tsMatch
+        .ancestors()
+        .find((a) => a.kind() === "variable_declarator") as SgNode<TS>) ?? null;
+  }
+
+  if (!varDeclarator) {
+    return "esm"; // Fallback for edge cases
+  }
+
+  // Check if the variable_declarator has a call_expression with function "require"
+  const hasRequireCall = varDeclarator.has({
+    rule: {
+      kind: "call_expression",
+      has: {
+        field: "function",
+        kind: "identifier",
+        regex: "^require$",
+      },
+    },
+  });
+
+  return hasRequireCall ? "cjs" : "esm";
+}
+
+/**
+ * Locate an import of a given module in a JS/TS program and return its alias/identifier node.
+ *
+ * The search supports multiple import styles for a specific source (options.from):
+ * - Default ESM import: `import foo from "module"`
+ * - Named ESM import: `import { bar as baz } from "module"`
+ * - Bare ESM import: `import "module"`
+ * - CommonJS: `const foo = require("module")` or `const { bar: baz } = require("module")`
+ * - Dynamic import: `const foo = await import("module")`
+ *
+ * When options.type is "default", the function returns the identifier for the default import name
+ * or the variable name bound from require/import calls. When options.type is "named", it returns
+ * the identifier for the requested named specifier (using the alias if present).
+ *
+ * The returned object contains the resolved alias (the name to use at call sites), whether it was a
+ * namespace import (currently always false in this implementation), and the underlying identifier node.
+ *
+ * @template T extends Language
+ * @param program - The program node to search within.
+ * @param options - Import lookup options. Use `{ type: "default", from }` for default/var forms, or `{ type: "named", name, from }` for a specific named specifier.
+ * @returns The resolved import information or null if not found.
+ */
+export const getImport = <T extends Language>(
+  program: SgNode<T, "program">,
+  options: GetImportOptions
+): GetImportResult<T> => {
+  const tsProgram = program as unknown as SgNode<TS, "program">;
+
+  const imports = tsProgram.findAll({
+    rule: {
+      any: [
+        {
+          all: [
+            {
+              kind: "import_specifier",
+            },
+            {
+              has: {
+                field: "alias",
+                pattern: "$ALIAS",
+              },
+            },
+            {
+              has: {
+                field: "name",
+                pattern: "$ORIGINAL",
+              },
+            },
+            {
+              inside: {
+                stopBy: "end",
+                kind: "import_statement",
+                has: {
+                  field: "source",
+                  pattern: "$SOURCE",
+                },
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "import_statement",
+            },
+            {
+              has: {
+                kind: "import_clause",
+                has: {
+                  kind: "identifier",
+                  pattern: "$DEFAULT_NAME",
+                },
+              },
+            },
+            {
+              has: {
+                field: "source",
+                pattern: "$SOURCE",
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "import_specifier",
+            },
+            {
+              has: {
+                field: "name",
+                pattern: "$ORIGINAL",
+              },
+            },
+            {
+              inside: {
+                stopBy: "end",
+                kind: "import_statement",
+                has: {
+                  field: "source",
+                  pattern: "$SOURCE",
+                },
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "variable_declarator",
+            },
+            {
+              has: {
+                field: "name",
+                kind: "identifier",
+                pattern: "$VAR_NAME",
+              },
+            },
+            {
+              has: {
+                field: "value",
+                any: [
+                  {
+                    all: [
+                      {
+                        kind: "call_expression",
+                      },
+                      {
+                        has: {
+                          field: "function",
+                          regex: "^(require|import)$",
+                        },
+                      },
+                      {
+                        has: {
+                          field: "arguments",
+                          has: {
+                            kind: "string",
+                            pattern: "$SOURCE",
+                          },
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    kind: "await_expression",
+                    has: {
+                      all: [
+                        {
+                          kind: "call_expression",
+                        },
+                        {
+                          has: {
+                            field: "function",
+                            regex: "^(require|import)$",
+                          },
+                        },
+                        {
+                          has: {
+                            field: "arguments",
+                            has: {
+                              kind: "string",
+                              pattern: "$SOURCE",
+                            },
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "shorthand_property_identifier_pattern",
+            },
+            {
+              pattern: "$ORIGINAL",
+            },
+            {
+              inside: {
+                kind: "object_pattern",
+                inside: {
+                  kind: "variable_declarator",
+                  has: {
+                    field: "value",
+                    any: [
+                      {
+                        all: [
+                          {
+                            kind: "call_expression",
+                          },
+                          {
+                            has: {
+                              field: "function",
+                              regex: "^(require|import)$",
+                            },
+                          },
+                          {
+                            has: {
+                              field: "arguments",
+                              has: {
+                                kind: "string",
+                                pattern: "$SOURCE",
+                              },
+                            },
+                          },
+                        ],
+                      },
+                      {
+                        kind: "await_expression",
+                        has: {
+                          all: [
+                            {
+                              kind: "call_expression",
+                            },
+                            {
+                              has: {
+                                field: "function",
+                                regex: "^(require|import)$",
+                              },
+                            },
+                            {
+                              has: {
+                                field: "arguments",
+                                has: {
+                                  kind: "string",
+                                  pattern: "$SOURCE",
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  stopBy: "end",
+                },
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "pair_pattern",
+            },
+            {
+              has: {
+                field: "key",
+                kind: "property_identifier",
+                pattern: "$ORIGINAL",
+              },
+            },
+            {
+              has: {
+                field: "value",
+                kind: "identifier",
+                pattern: "$ALIAS",
+              },
+            },
+            {
+              inside: {
+                kind: "object_pattern",
+                inside: {
+                  kind: "variable_declarator",
+                  has: {
+                    field: "value",
+                    any: [
+                      {
+                        all: [
+                          {
+                            kind: "call_expression",
+                          },
+                          {
+                            has: {
+                              field: "function",
+                              regex: "^(require|import)$",
+                            },
+                          },
+                          {
+                            has: {
+                              field: "arguments",
+                              has: {
+                                kind: "string",
+                                pattern: "$SOURCE",
+                              },
+                            },
+                          },
+                        ],
+                      },
+                      {
+                        kind: "await_expression",
+                        has: {
+                          all: [
+                            {
+                              kind: "call_expression",
+                            },
+                            {
+                              has: {
+                                field: "function",
+                                regex: "^(require|import)$",
+                              },
+                            },
+                            {
+                              has: {
+                                field: "arguments",
+                                has: {
+                                  kind: "string",
+                                  pattern: "$SOURCE",
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                  stopBy: "end",
+                },
+                stopBy: "end",
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "string",
+            },
+            {
+              pattern: "$SOURCE",
+            },
+            {
+              inside: {
+                kind: "arguments",
+                inside: {
+                  kind: "call_expression",
+                  has: {
+                    field: "function",
+                    regex: "^(require|import)$",
+                  },
+                },
+                stopBy: "end",
+              },
+            },
+            {
+              not: {
+                inside: {
+                  kind: "lexical_declaration",
+                  stopBy: "end",
+                },
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "import_statement",
+            },
+            {
+              has: {
+                kind: "import_clause",
+                has: {
+                  kind: "namespace_import",
+                  has: {
+                    kind: "identifier",
+                    pattern: "$NAMESPACE_ALIAS",
+                  },
+                },
+              },
+            },
+            {
+              has: {
+                field: "source",
+                pattern: "$SOURCE",
+              },
+            },
+          ],
+        },
+        {
+          all: [
+            {
+              kind: "import_statement",
+            },
+            {
+              not: {
+                has: {
+                  kind: "import_clause",
+                },
+              },
+            },
+            {
+              has: {
+                field: "source",
+                pattern: "$SOURCE",
+              },
+            },
+          ],
+        },
+      ],
+    },
+    constraints: {
+      SOURCE: {
+        any: [
+          {
+            regex: stringToExactRegexString(options.from),
+          },
+          {
+            has: {
+              kind: "string_fragment",
+              regex: stringToExactRegexString(options.from),
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  if (imports.length === 0) {
+    return null;
+  }
+
+  if (options.type === "default") {
+    const foundMatch = imports.find((m) => {
+      return !!(m.getMatch("DEFAULT_NAME") ?? m.getMatch("VAR_NAME"));
+    });
+    if (foundMatch) {
+      const defaultName = foundMatch.getMatch("DEFAULT_NAME");
+      const varName = foundMatch.getMatch("VAR_NAME");
+      const name = defaultName?.text() ?? varName?.text() ?? "";
+      return {
+        alias: name,
+        isNamespace: false,
+        moduleType: getModuleType(foundMatch),
+        node: (defaultName ?? varName)! as unknown as SgNode<T, "identifier">,
+      };
+    }
+  }
+
+  if (options.type === "named") {
+    const foundMatch = imports.find((m) => {
+      return m.getMatch("ORIGINAL")?.text() === options.name;
+    });
+
+    if (foundMatch) {
+      const original = foundMatch.getMatch("ORIGINAL");
+      const alias = foundMatch.getMatch("ALIAS");
+      return {
+        alias: alias?.text() ?? original?.text() ?? "",
+        isNamespace: false,
+        moduleType: getModuleType(foundMatch),
+        node: (alias ?? original)! as unknown as SgNode<T, "identifier">,
+      };
+    }
+  }
+
+  const namespaceImport = imports.find((m) => {
+    return m.getMatch("NAMESPACE_ALIAS");
+  });
+  if (namespaceImport) {
+    return {
+      alias: namespaceImport.getMatch("NAMESPACE_ALIAS")?.text() ?? "",
+      isNamespace: true,
+      moduleType: "esm" as const, // Namespace imports are always ESM
+      node: namespaceImport.getMatch("NAMESPACE_ALIAS")! as unknown as SgNode<
+        T,
+        "identifier"
+      >,
+    };
+  }
+
+  return null;
+};
+
+// ============================================================================
+// Import Manipulation Types
+// ============================================================================
+
+type ImportSpecifier = { name: string; alias?: string };
+
+type AddImportOptions =
+  | { type: "default"; name: string; from: string; moduleType?: "esm" | "cjs" }
+  | { type: "namespace"; name: string; from: string }
+  | {
+      type: "named";
+      specifiers: ImportSpecifier[];
+      from: string;
+      moduleType?: "esm" | "cjs";
+    };
+
+type RemoveImportOptions =
+  | { type: "default"; from: string }
+  | { type: "namespace"; from: string }
+  | { type: "named"; specifiers: string[]; from: string };
+
+interface Edit {
+  startPos: number;
+  endPos: number;
+  insertedText: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Find all import statements and require declarations in the program.
+ */
+function findAllImportStatements<T extends Language>(
+  program: SgNode<T, "program">
+): SgNode<T>[] {
+  const tsProgram = program as unknown as SgNode<TS, "program">;
+
+  // Find ESM import statements
+  const esmImports = tsProgram.findAll({
+    rule: { kind: "import_statement" },
+  });
+
+  // Find CJS require declarations (const x = require(...))
+  const cjsImports = tsProgram.findAll({
+    rule: {
+      kind: "lexical_declaration",
+      has: {
+        kind: "variable_declarator",
+        has: {
+          field: "value",
+          any: [
+            {
+              kind: "call_expression",
+              has: {
+                field: "function",
+                kind: "identifier",
+                regex: "^require$",
+              },
+            },
+            {
+              kind: "await_expression",
+              has: {
+                kind: "call_expression",
+                has: {
+                  field: "function",
+                  regex: "^import$",
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  return [...esmImports, ...cjsImports] as unknown as SgNode<T>[];
+}
+
+/**
+ * Find an existing ESM import statement from a specific source.
+ */
+function findExistingEsmImport<T extends Language>(
+  program: SgNode<T, "program">,
+  source: string
+): SgNode<T, "import_statement"> | null {
+  const tsProgram = program as unknown as SgNode<TS, "program">;
+
+  const importStmt = tsProgram.find({
+    rule: {
+      kind: "import_statement",
+      has: {
+        field: "source",
+        has: {
+          kind: "string_fragment",
+          regex: stringToExactRegexString(source),
+        },
+      },
+    },
+  });
+
+  return importStmt as unknown as SgNode<T, "import_statement"> | null;
+}
+
+/**
+ * Find the named_imports node within an import statement.
+ */
+function findNamedImports<T extends Language>(
+  importStmt: SgNode<T>
+): SgNode<T> | null {
+  const tsImport = importStmt as unknown as SgNode<TS>;
+  const namedImports = tsImport.find({
+    rule: { kind: "named_imports" },
+  });
+  return namedImports as unknown as SgNode<T> | null;
+}
+
+/**
+ * Generate a specifier string like "foo" or "foo as bar".
+ */
+function formatSpecifier(spec: ImportSpecifier): string {
+  if (spec.alias && spec.alias !== spec.name) {
+    return `${spec.name} as ${spec.alias}`;
+  }
+  return spec.name;
+}
+
+/**
+ * Generate ESM import statement text.
+ */
+function generateEsmImport(options: AddImportOptions): string {
+  const source = options.from;
+
+  if (options.type === "default") {
+    return `import ${options.name} from '${source}';\n`;
+  }
+
+  if (options.type === "namespace") {
+    return `import * as ${options.name} from '${source}';\n`;
+  }
+
+  // Named imports
+  const specifierStr = options.specifiers.map(formatSpecifier).join(", ");
+  return `import { ${specifierStr} } from '${source}';\n`;
+}
+
+/**
+ * Generate CJS require statement text.
+ */
+function generateCjsRequire(options: AddImportOptions): string {
+  const source = options.from;
+
+  if (options.type === "default") {
+    return `const ${options.name} = require('${source}');\n`;
+  }
+
+  if (options.type === "namespace") {
+    // Namespace-like for CJS
+    return `const ${options.name} = require('${source}');\n`;
+  }
+
+  // Named imports (destructured require)
+  const specifierStr = options.specifiers
+    .map((spec) => {
+      if (spec.alias && spec.alias !== spec.name) {
+        return `${spec.name}: ${spec.alias}`;
+      }
+      return spec.name;
+    })
+    .join(", ");
+  return `const { ${specifierStr} } = require('${source}');\n`;
+}
+
+// ============================================================================
+// addImport
+// ============================================================================
+
+/**
+ * Add an import to the program. Smart behavior:
+ * - Skip if the import already exists
+ * - Merge into existing import statement for named imports
+ * - Create new import statement otherwise
+ *
+ * @returns Edit to apply, or null if import already exists
+ */
+export function addImport<T extends Language>(
+  program: SgNode<T, "program">,
+  options: AddImportOptions
+): Edit | null {
+  const moduleType =
+    options.type === "namespace"
+      ? "esm"
+      : (options.moduleType ?? "esm");
+
+  // Check if import already exists
+  if (options.type === "default") {
+    const existing = getImport(program, { type: "default", from: options.from });
+    if (existing && !existing.isNamespace) {
+      return null; // Already has default import
+    }
+  } else if (options.type === "namespace") {
+    const existing = getImport(program, { type: "default", from: options.from });
+    if (existing && existing.isNamespace) {
+      return null; // Already has namespace import
+    }
+  } else if (options.type === "named") {
+    // Filter out specifiers that already exist
+    const newSpecifiers: ImportSpecifier[] = [];
+    for (const spec of options.specifiers) {
+      const existing = getImport(program, {
+        type: "named",
+        name: spec.name,
+        from: options.from,
+      });
+      if (!existing) {
+        newSpecifiers.push(spec);
+      }
+    }
+
+    if (newSpecifiers.length === 0) {
+      return null; // All specifiers already exist
+    }
+
+    // For ESM named imports, try to merge into existing import
+    if (moduleType === "esm") {
+      const existingImport = findExistingEsmImport(program, options.from);
+      if (existingImport) {
+        const namedImports = findNamedImports(existingImport);
+        if (namedImports) {
+          // Add to existing named_imports: insert before the closing brace
+          const namedImportsText = namedImports.text();
+          const closingBraceIdx = namedImportsText.lastIndexOf("}");
+          if (closingBraceIdx > 0) {
+            const insertPos =
+              namedImports.range().start.index + closingBraceIdx;
+            const specifierStr = newSpecifiers.map(formatSpecifier).join(", ");
+            // Check if there are existing specifiers (need comma)
+            const hasExistingSpecifiers =
+              namedImportsText.slice(1, closingBraceIdx).trim().length > 0;
+            const insertText = hasExistingSpecifiers
+              ? `, ${specifierStr}`
+              : ` ${specifierStr} `;
+
+            return {
+              startPos: insertPos,
+              endPos: insertPos,
+              insertedText: insertText,
+            };
+          }
+        } else {
+          // Import exists but has no named_imports (e.g., default import only)
+          // Add named imports to it: import foo from 'mod' -> import foo, { bar } from 'mod'
+          const importClause = (existingImport as unknown as SgNode<TS>).find({
+            rule: { kind: "import_clause" },
+          });
+          if (importClause) {
+            const specifierStr = newSpecifiers.map(formatSpecifier).join(", ");
+            const insertPos = importClause.range().end.index;
+            return {
+              startPos: insertPos,
+              endPos: insertPos,
+              insertedText: `, { ${specifierStr} }`,
+            };
+          }
+        }
+      }
+    }
+
+    // Update options with filtered specifiers for new import creation
+    options = { ...options, specifiers: newSpecifiers };
+  }
+
+  // Find insertion position (after last import, or at file start)
+  const allImports = findAllImportStatements(program);
+  let insertPos = 0;
+  let prefix = "";
+
+  const lastImport = allImports[allImports.length - 1];
+  if (lastImport) {
+    insertPos = lastImport.range().end.index;
+    // Check if there's a newline after the last import
+    const programText = program.text();
+    if (programText[insertPos] !== "\n") {
+      prefix = "\n";
+    }
+  }
+
+  // Generate import text
+  const importText =
+    moduleType === "esm"
+      ? generateEsmImport(options)
+      : generateCjsRequire(options);
+
+  return {
+    startPos: insertPos,
+    endPos: insertPos,
+    insertedText: prefix + importText,
+  };
+}
+
+// ============================================================================
+// removeImport
+// ============================================================================
+
+/**
+ * Find the import statement containing a specific specifier.
+ */
+function findImportStatementForSpecifier<T extends Language>(
+  program: SgNode<T, "program">,
+  specifierName: string,
+  source: string
+): { statement: SgNode<T>; specifier: SgNode<T> } | null {
+  const tsProgram = program as unknown as SgNode<TS, "program">;
+
+  // Find ESM import specifier
+  const esmSpecifier = tsProgram.find({
+    rule: {
+      kind: "import_specifier",
+      has: {
+        field: "name",
+        regex: stringToExactRegexString(specifierName),
+      },
+      inside: {
+        kind: "import_statement",
+        has: {
+          field: "source",
+          any: [
+            { regex: stringToExactRegexString(source) },
+            {
+              has: {
+                kind: "string_fragment",
+                regex: stringToExactRegexString(source),
+              },
+            },
+          ],
+        },
+        stopBy: "end",
+      },
+    },
+  });
+
+  if (esmSpecifier) {
+    // Find the parent import_statement
+    const importStmt = esmSpecifier
+      .ancestors()
+      .find((a) => a.kind() === "import_statement");
+    if (importStmt) {
+      return {
+        statement: importStmt as unknown as SgNode<T>,
+        specifier: esmSpecifier as unknown as SgNode<T>,
+      };
+    }
+  }
+
+  // Find CJS destructured require
+  const cjsSpecifier = tsProgram.find({
+    rule: {
+      any: [
+        {
+          kind: "shorthand_property_identifier_pattern",
+          regex: stringToExactRegexString(specifierName),
+          inside: {
+            kind: "object_pattern",
+            inside: {
+              kind: "variable_declarator",
+              has: {
+                field: "value",
+                all: [
+                  { kind: "call_expression" },
+                  {
+                    has: {
+                      field: "function",
+                      kind: "identifier",
+                      regex: "^require$",
+                    },
+                  },
+                  {
+                    has: {
+                      field: "arguments",
+                      has: {
+                        kind: "string",
+                        any: [
+                          { regex: stringToExactRegexString(source) },
+                          {
+                            has: {
+                              kind: "string_fragment",
+                              regex: stringToExactRegexString(source),
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+              stopBy: "end",
+            },
+            stopBy: "end",
+          },
+        },
+        {
+          kind: "pair_pattern",
+          has: {
+            field: "key",
+            regex: stringToExactRegexString(specifierName),
+          },
+          inside: {
+            kind: "object_pattern",
+            inside: {
+              kind: "variable_declarator",
+              has: {
+                field: "value",
+                all: [
+                  { kind: "call_expression" },
+                  {
+                    has: {
+                      field: "function",
+                      kind: "identifier",
+                      regex: "^require$",
+                    },
+                  },
+                  {
+                    has: {
+                      field: "arguments",
+                      has: {
+                        kind: "string",
+                        any: [
+                          { regex: stringToExactRegexString(source) },
+                          {
+                            has: {
+                              kind: "string_fragment",
+                              regex: stringToExactRegexString(source),
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+              stopBy: "end",
+            },
+            stopBy: "end",
+          },
+        },
+      ],
+    },
+  });
+
+  if (cjsSpecifier) {
+    // Find the parent lexical_declaration
+    const lexicalDecl = cjsSpecifier
+      .ancestors()
+      .find((a) => a.kind() === "lexical_declaration");
+    if (lexicalDecl) {
+      return {
+        statement: lexicalDecl as unknown as SgNode<T>,
+        specifier: cjsSpecifier as unknown as SgNode<T>,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Count the number of specifiers in an import statement.
+ */
+function countSpecifiersInStatement<T extends Language>(
+  statement: SgNode<T>
+): number {
+  const tsStmt = statement as unknown as SgNode<TS>;
+
+  if (tsStmt.kind() === "import_statement") {
+    return tsStmt.findAll({ rule: { kind: "import_specifier" } }).length;
+  }
+
+  // CJS: count in object_pattern
+  const objectPattern = tsStmt.find({ rule: { kind: "object_pattern" } });
+  if (objectPattern) {
+    const shorthand = objectPattern.findAll({
+      rule: { kind: "shorthand_property_identifier_pattern" },
+    });
+    const pairs = objectPattern.findAll({ rule: { kind: "pair_pattern" } });
+    return shorthand.length + pairs.length;
+  }
+
+  return 0;
+}
+
+/**
+ * Find the full range of a statement including leading/trailing whitespace.
+ */
+function getStatementRangeWithNewline<T extends Language>(
+  statement: SgNode<T>,
+  programText: string
+): { start: number; end: number } {
+  const range = statement.range();
+  let end = range.end.index;
+
+  // Include trailing newline if present
+  if (programText[end] === "\n") {
+    end++;
+  }
+
+  return { start: range.start.index, end };
+}
+
+/**
+ * Find the range of a specifier including comma/whitespace for clean removal.
+ */
+function getSpecifierRangeWithSeparator<T extends Language>(
+  specifier: SgNode<T>,
+  programText: string
+): { start: number; end: number } {
+  const range = specifier.range();
+  let start = range.start.index;
+  let end = range.end.index;
+
+  // Check for trailing comma and whitespace
+  let i = end;
+  while (i < programText.length && /\s/.test(programText[i] ?? "")) {
+    i++;
+  }
+  if (i < programText.length && programText[i] === ",") {
+    end = i + 1;
+    // Also consume whitespace after comma
+    while (end < programText.length && /\s/.test(programText[end] ?? "")) {
+      end++;
+    }
+  } else {
+    // Check for leading comma (if this is the last specifier)
+    let j = start - 1;
+    while (j >= 0 && /\s/.test(programText[j] ?? "")) {
+      j--;
+    }
+    if (j >= 0 && programText[j] === ",") {
+      start = j;
+    }
+  }
+
+  return { start, end };
+}
+
+/**
+ * Remove an import from the program. Smart behavior:
+ * - Default/namespace: Removes entire import statement
+ * - Named (multiple specifiers exist): Removes only the specified specifiers
+ * - Named (removing last specifiers): Removes entire import statement
+ *
+ * @returns Edit to apply, or null if import not found
+ */
+export function removeImport<T extends Language>(
+  program: SgNode<T, "program">,
+  options: RemoveImportOptions
+): Edit | null {
+  const programText = program.text();
+
+  if (options.type === "default") {
+    // Find default import and remove entire statement
+    const existing = getImport(program, { type: "default", from: options.from });
+    if (!existing || existing.isNamespace) {
+      return null;
+    }
+
+    // Find the import statement containing this default import
+    const tsProgram = program as unknown as SgNode<TS, "program">;
+    const importStmt = tsProgram.find({
+      rule: {
+        kind: "import_statement",
+        all: [
+          {
+            has: {
+              kind: "import_clause",
+              has: {
+                kind: "identifier",
+                regex: stringToExactRegexString(existing.alias),
+              },
+            },
+          },
+          {
+            has: {
+              field: "source",
+              any: [
+                { regex: stringToExactRegexString(options.from) },
+                {
+                  has: {
+                    kind: "string_fragment",
+                    regex: stringToExactRegexString(options.from),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    if (importStmt) {
+      const { start, end } = getStatementRangeWithNewline(
+        importStmt as unknown as SgNode<T>,
+        programText
+      );
+      return { startPos: start, endPos: end, insertedText: "" };
+    }
+
+    // Check for CJS require
+    const cjsDecl = tsProgram.find({
+      rule: {
+        kind: "lexical_declaration",
+        has: {
+          kind: "variable_declarator",
+          all: [
+            {
+              has: {
+                field: "name",
+                kind: "identifier",
+                regex: stringToExactRegexString(existing.alias),
+              },
+            },
+            {
+              has: {
+                field: "value",
+                any: [
+                  {
+                    kind: "call_expression",
+                    has: {
+                      field: "function",
+                      kind: "identifier",
+                      regex: "^require$",
+                    },
+                  },
+                  {
+                    kind: "await_expression",
+                    has: {
+                      kind: "call_expression",
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    if (cjsDecl) {
+      const { start, end } = getStatementRangeWithNewline(
+        cjsDecl as unknown as SgNode<T>,
+        programText
+      );
+      return { startPos: start, endPos: end, insertedText: "" };
+    }
+
+    return null;
+  }
+
+  if (options.type === "namespace") {
+    // Find namespace import and remove entire statement
+    const existing = getImport(program, { type: "default", from: options.from });
+    if (!existing || !existing.isNamespace) {
+      return null;
+    }
+
+    const tsProgram = program as unknown as SgNode<TS, "program">;
+    const importStmt = tsProgram.find({
+      rule: {
+        kind: "import_statement",
+        all: [
+          {
+            has: {
+              kind: "import_clause",
+              has: {
+                kind: "namespace_import",
+                has: {
+                  kind: "identifier",
+                  regex: stringToExactRegexString(existing.alias),
+                },
+              },
+            },
+          },
+          {
+            has: {
+              field: "source",
+              any: [
+                { regex: stringToExactRegexString(options.from) },
+                {
+                  has: {
+                    kind: "string_fragment",
+                    regex: stringToExactRegexString(options.from),
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    if (importStmt) {
+      const { start, end } = getStatementRangeWithNewline(
+        importStmt as unknown as SgNode<T>,
+        programText
+      );
+      return { startPos: start, endPos: end, insertedText: "" };
+    }
+
+    return null;
+  }
+
+  // Named imports: remove specific specifiers
+  if (options.type === "named") {
+    // Find the first specifier to remove
+    for (const specName of options.specifiers) {
+      const found = findImportStatementForSpecifier(
+        program,
+        specName,
+        options.from
+      );
+
+      if (found) {
+        const specifierCount = countSpecifiersInStatement(found.statement);
+
+        // If this is the last specifier, remove the entire statement
+        if (specifierCount <= options.specifiers.length) {
+          const { start, end } = getStatementRangeWithNewline(
+            found.statement,
+            programText
+          );
+          return { startPos: start, endPos: end, insertedText: "" };
+        }
+
+        // Otherwise, just remove this specifier
+        const { start, end } = getSpecifierRangeWithSeparator(
+          found.specifier,
+          programText
+        );
+        return { startPos: start, endPos: end, insertedText: "" };
+      }
+    }
+
+    return null;
+  }
+
+  return null;
+}

--- a/packages/jssg-utils/src/utils.ts
+++ b/packages/jssg-utils/src/utils.ts
@@ -1,0 +1,3 @@
+export function stringToExactRegexString(string: string) {
+  return `^${string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`;
+}

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -1,0 +1,459 @@
+import { ok as assert } from "assert";
+import { parse } from "codemod:ast-grep";
+import {
+  getImport,
+  addImport,
+  removeImport,
+} from "../src/javascript/exports/imports.ts";
+import type JS from "@codemod.com/jssg-types/langs/javascript";
+import type TS from "@codemod.com/jssg-types/langs/typescript";
+import type TSX from "@codemod.com/jssg-types/langs/tsx";
+
+type Language = JS | TS | TSX;
+
+function parseProgram<T extends Language>(lang: string, src: string) {
+  const root = parse<T>(lang, src);
+  return root.root();
+}
+
+function testReturnsNullWhenNoMatches() {
+  const program = parseProgram("javascript", "const x = 1;\nconsole.log(x);\n");
+  const resDefault = getImport(program, {
+    type: "default",
+    from: "mod",
+  });
+  assert(resDefault === null, "Expected null for default when no matches");
+
+  const resNamed = getImport(program, {
+    type: "named",
+    name: "x",
+    from: "mod",
+  });
+  assert(resNamed === null, "Expected null for named when no matches");
+}
+
+function testDefaultImportFromDEFAULT_NAME() {
+  const program = parseProgram(
+    "javascript",
+    "import foo from 'mod';\nconsole.log(foo);\n"
+  );
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Expected a result for default import");
+  assert(res!.alias === "foo", "Alias should be DEFAULT_NAME value");
+  assert(res!.isNamespace === false, "isNamespace should be false");
+  assert(
+    res!.moduleType === "esm",
+    "moduleType should be esm for import statement"
+  );
+  assert(
+    typeof res!.node.text === "function" && res!.node.text() === "foo",
+    "Node should reflect identifier"
+  );
+}
+
+function testDefaultImportFromVAR_NAME() {
+  const program = parseProgram(
+    "javascript",
+    "const bar = require('mod');\nconsole.log(bar);\n"
+  );
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Expected a result for var-based import");
+  assert(res!.alias === "bar", "Alias should be VAR_NAME value");
+  assert(res!.moduleType === "cjs", "moduleType should be cjs for require()");
+}
+
+function testNamedImportWithAlias() {
+  const program = parseProgram(
+    "javascript",
+    "import { baz as qux } from 'mod';\nconsole.log(qux);\n"
+  );
+  const res = getImport(program, {
+    type: "named",
+    name: "baz",
+    from: "mod",
+  });
+  assert(res !== null, "Expected a result for named import with alias");
+  assert(res!.alias === "qux", "Alias should use ALIAS when present");
+  assert(
+    res!.moduleType === "esm",
+    "moduleType should be esm for named import"
+  );
+  assert(
+    res!.node.text() === "qux",
+    "Node should be alias identifier when aliased"
+  );
+}
+
+function testNamedImportWithoutAlias() {
+  const program = parseProgram(
+    "javascript",
+    "import { q } from 'mod';\nconsole.log(q);\n"
+  );
+  const res = getImport(program, {
+    type: "named",
+    name: "q",
+    from: "mod",
+  });
+  assert(res !== null, "Expected a result for named import without alias");
+  assert(res!.alias === "q", "Alias should fallback to ORIGINAL when no alias");
+  assert(
+    res!.moduleType === "esm",
+    "moduleType should be esm for named import"
+  );
+  assert(
+    res!.node.text() === "q",
+    "Node should be original identifier when no alias"
+  );
+}
+
+function testNamedImportNotFound() {
+  const program = parseProgram(
+    "javascript",
+    "import { alpha } from 'mod';\nconsole.log(alpha);\n"
+  );
+  const res = getImport(program, {
+    type: "named",
+    name: "beta",
+    from: "mod",
+  });
+  assert(
+    res === null,
+    "Expected null when requested named import does not exist"
+  );
+}
+
+function testDynamicImportModuleType() {
+  const program = parseProgram(
+    "javascript",
+    "const foo = await import('mod');\nconsole.log(foo);\n"
+  );
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Expected a result for dynamic import");
+  assert(res!.alias === "foo", "Alias should be variable name");
+  assert(
+    res!.moduleType === "esm",
+    "moduleType should be esm for dynamic import()"
+  );
+}
+
+function testDestructuredRequireModuleType() {
+  const program = parseProgram(
+    "javascript",
+    "const { bar } = require('mod');\nconsole.log(bar);\n"
+  );
+  const res = getImport(program, { type: "named", name: "bar", from: "mod" });
+  assert(res !== null, "Expected a result for destructured require");
+  assert(res!.alias === "bar", "Alias should be destructured name");
+  assert(
+    res!.moduleType === "cjs",
+    "moduleType should be cjs for destructured require()"
+  );
+}
+
+function testDestructuredDynamicImportModuleType() {
+  const program = parseProgram(
+    "javascript",
+    "const { baz } = await import('mod');\nconsole.log(baz);\n"
+  );
+  const res = getImport(program, { type: "named", name: "baz", from: "mod" });
+  assert(res !== null, "Expected a result for destructured dynamic import");
+  assert(res!.alias === "baz", "Alias should be destructured name");
+  assert(
+    res!.moduleType === "esm",
+    "moduleType should be esm for destructured dynamic import()"
+  );
+}
+
+function testNamespaceImportModuleType() {
+  const program = parseProgram(
+    "javascript",
+    "import * as ns from 'mod';\nconsole.log(ns);\n"
+  );
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Expected a result for namespace import");
+  assert(res!.alias === "ns", "Alias should be namespace name");
+  assert(res!.isNamespace === true, "isNamespace should be true");
+  assert(
+    res!.moduleType === "esm",
+    "moduleType should be esm for namespace import"
+  );
+}
+
+// ============================================================================
+// addImport tests
+// ============================================================================
+
+function testAddDefaultImportESM() {
+  const program = parseProgram("javascript", "console.log('hello');\n");
+  const edit = addImport(program, {
+    type: "default",
+    name: "foo",
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result.includes("import foo from 'mod'"),
+    "Should add ESM default import"
+  );
+}
+
+function testAddDefaultImportCJS() {
+  const program = parseProgram("javascript", "console.log('hello');\n");
+  const edit = addImport(program, {
+    type: "default",
+    name: "bar",
+    from: "mod",
+    moduleType: "cjs",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result.includes("const bar = require('mod')"),
+    "Should add CJS require"
+  );
+}
+
+function testAddNamespaceImport() {
+  const program = parseProgram("javascript", "console.log('hello');\n");
+  const edit = addImport(program, {
+    type: "namespace",
+    name: "ns",
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result.includes("import * as ns from 'mod'"),
+    "Should add namespace import"
+  );
+}
+
+function testAddNamedImportESM() {
+  const program = parseProgram("javascript", "console.log('hello');\n");
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "foo" }, { name: "bar", alias: "baz" }],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result.includes("import { foo, bar as baz } from 'mod'"),
+    "Should add ESM named import with alias"
+  );
+}
+
+function testAddNamedImportCJS() {
+  const program = parseProgram("javascript", "console.log('hello');\n");
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "x" }, { name: "y", alias: "z" }],
+    from: "mod",
+    moduleType: "cjs",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result.includes("const { x, y: z } = require('mod')"),
+    "Should add CJS destructured require"
+  );
+}
+
+function testAddImportSkipsExistingDefault() {
+  const program = parseProgram(
+    "javascript",
+    "import foo from 'mod';\nconsole.log(foo);\n"
+  );
+  const edit = addImport(program, {
+    type: "default",
+    name: "bar",
+    from: "mod",
+  });
+  assert(edit === null, "Should return null when default import exists");
+}
+
+function testAddImportSkipsExistingNamed() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo } from 'mod';\nconsole.log(foo);\n"
+  );
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "foo" }],
+    from: "mod",
+  });
+  assert(edit === null, "Should return null when named import exists");
+}
+
+function testAddImportMergesNamedSpecifiers() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo } from 'mod';\nconsole.log(foo);\n"
+  );
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "bar" }],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit to merge");
+  const result = program.commitEdits([edit!]);
+  // Check that both foo and bar are in the same import statement
+  assert(
+    result.includes("foo") && result.includes("bar") && result.includes("from 'mod'"),
+    "Should merge bar into existing named imports"
+  );
+  // Make sure we didn't create a new import statement
+  assert(
+    (result.match(/import/g) || []).length === 1,
+    "Should have only one import statement"
+  );
+}
+
+function testAddImportAfterExisting() {
+  const program = parseProgram(
+    "javascript",
+    "import x from 'other';\nconsole.log(x);\n"
+  );
+  const edit = addImport(program, {
+    type: "default",
+    name: "foo",
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  // The new import should come after the existing one
+  const otherIdx = result.indexOf("import x from 'other'");
+  const modIdx = result.indexOf("import foo from 'mod'");
+  assert(modIdx > otherIdx, "New import should be after existing import");
+}
+
+// ============================================================================
+// removeImport tests
+// ============================================================================
+
+function testRemoveDefaultImportESM() {
+  const program = parseProgram(
+    "javascript",
+    "import foo from 'mod';\nconsole.log(foo);\n"
+  );
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    !result.includes("import foo from 'mod'"),
+    "Should remove the import statement"
+  );
+  assert(result.includes("console.log"), "Should keep other code");
+}
+
+function testRemoveNamespaceImport() {
+  const program = parseProgram(
+    "javascript",
+    "import * as ns from 'mod';\nconsole.log(ns);\n"
+  );
+  const edit = removeImport(program, { type: "namespace", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    !result.includes("import * as ns from 'mod'"),
+    "Should remove namespace import"
+  );
+}
+
+function testRemoveNamedImportSpecific() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo, bar } from 'mod';\nconsole.log(foo, bar);\n"
+  );
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["foo"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  // Check that foo is not in the import statement (it's still used in console.log)
+  assert(!result.includes("import { foo"), "Should remove foo from import");
+  assert(
+    result.includes("bar") && result.includes("from 'mod'"),
+    "Should keep bar specifier in import"
+  );
+}
+
+function testRemoveNamedImportLast() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo } from 'mod';\nconsole.log(foo);\n"
+  );
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["foo"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    !result.includes("import"),
+    "Should remove entire import when last specifier removed"
+  );
+}
+
+function testRemoveImportNotFound() {
+  const program = parseProgram("javascript", "console.log('hello');\n");
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit === null, "Should return null when import not found");
+}
+
+function testRemoveDefaultCJS() {
+  const program = parseProgram(
+    "javascript",
+    "const foo = require('mod');\nconsole.log(foo);\n"
+  );
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit for CJS");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("require"), "Should remove require statement");
+}
+
+function run() {
+  // getImport tests
+  testReturnsNullWhenNoMatches();
+  testDefaultImportFromDEFAULT_NAME();
+  testDefaultImportFromVAR_NAME();
+  testNamedImportWithAlias();
+  testNamedImportWithoutAlias();
+  testNamedImportNotFound();
+  testDynamicImportModuleType();
+  testDestructuredRequireModuleType();
+  testDestructuredDynamicImportModuleType();
+  testNamespaceImportModuleType();
+
+  // addImport tests
+  testAddDefaultImportESM();
+  testAddDefaultImportCJS();
+  testAddNamespaceImport();
+  testAddNamedImportESM();
+  testAddNamedImportCJS();
+  testAddImportSkipsExistingDefault();
+  testAddImportSkipsExistingNamed();
+  testAddImportMergesNamedSpecifiers();
+  testAddImportAfterExisting();
+
+  // removeImport tests
+  testRemoveDefaultImportESM();
+  testRemoveNamespaceImport();
+  testRemoveNamedImportSpecific();
+  testRemoveNamedImportLast();
+  testRemoveImportNotFound();
+  testRemoveDefaultCJS();
+
+  console.log("imports.test.ts: all assertions passed");
+}
+
+try {
+  run();
+} catch (error) {
+  console.error(error);
+  process.exit(1);
+}

--- a/packages/jssg-utils/tsconfig.json
+++ b/packages/jssg-utils/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["@codemod.com/jssg-types"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": false,
+    "erasableSyntaxOnly": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true
+  },
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    typescript:
+      specifier: ^5.9.3
+      version: 5.9.3
+
 importers:
 
   .: {}
@@ -36,7 +42,7 @@ importers:
         specifier: ^4.19.3
         version: 4.21.0
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.9.3
 
   crates/scheduler/npm:
@@ -45,7 +51,7 @@ importers:
         specifier: '*'
         version: 22.16.0
       typescript:
-        specifier: ^5.8.3
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
         specifier: ^1.6.0
@@ -1109,10 +1115,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  source-map-js@1.2.0:
-    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
-    engines: {node: '>=0.10.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1786,7 +1788,7 @@ snapshots:
   css-tree@2.3.1:
     dependencies:
       mdn-data: 2.0.30
-      source-map-js: 1.2.0
+      source-map-js: 1.2.1
     optional: true
 
   cssstyle@4.0.1:
@@ -2351,9 +2353,6 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
-
-  source-map-js@1.2.0:
-    optional: true
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ packages:
   - crates/cli/npm
   - crates/scheduler/npm
   - crates/codemod-sandbox
+
+catalog:
+  typescript: "^5.9.3"


### PR DESCRIPTION

<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

Adds `@jssg/utils`, a utility package for JSSG codemods. Currently provides helpers for querying and manipulating JS/TS imports (ESM, CJS, dynamic imports) via `@jssg/utils/javascript/imports`. Includes `getImport` for finding existing imports, `addImport` for smart insertion with merging, and `removeImport` for clean removal.


#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
