### PR TITLE
feat: add options for GitHub Actions workflow and monorepo workspace structure in codemod init

### DIFF
--- a/crates/cli/src/templates/common/publish-workspace.yml
+++ b/crates/cli/src/templates/common/publish-workspace.yml
@@ -1,0 +1,27 @@
+name: Publish Codemod
+on:
+  push:
+    tags:
+      - "*@v*"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract codemod name from tag
+        id: extract
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          CODEMOD_NAME="${TAG%@v*}"
+          echo "codemod_name=$CODEMOD_NAME" >> $GITHUB_OUTPUT
+
+      - name: Publish codemod
+        uses: codemod-com/publish-action@v1
+        with:
+          path: codemods/${{ steps.extract.outputs.codemod_name }}

--- a/crates/cli/src/templates/common/publish.yml
+++ b/crates/cli/src/templates/common/publish.yml
@@ -1,0 +1,18 @@
+name: Publish Codemod
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Publish codemod
+        uses: codemod-com/publish-action@v1


### PR DESCRIPTION

<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
It adds an option to set up github actions as well as a monorepo structure when using `codemod init`

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
