### PR TITLE
add group drilldown & bring back intro doc nav item

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -17,14 +17,20 @@
   "styling": {
     "eyebrows": "breadcrumbs"
   },
+  "interaction": {
+    "drilldown": true
+  },
   "navigation": {
     "dropdowns": [
       {
         "dropdown": "Getting Started",
         "icon": "book",
         "description": "Get started with Codemod",
-        "pages": ["introduction"],
         "groups": [
+          {
+            "group": "First steps",
+            "pages": ["introduction"]
+          },
           {
             "group": "Enterprise",
             "pages": [

--- a/apps/docs/introduction.mdx
+++ b/apps/docs/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction
+sidebarTitle: 'Intro to Codemod'
 ---
 
 Codemod provides tools and infrastructure to automate repetitive or large-scale codebase remediation from end to end. You can deploy task-specific codemods or micro-agents—workflows that combine codemods and AI—to handle complex migrations and upgrades. Codemod supports every stage of the process: planning, reliable code transformations, orchestrating changes across teams, safe deployments across repositories, and tracking progress with leadership dashboards.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables grouped drilldown navigation and restores the Intro entry in the docs sidebar.
> 
> - Turn on `interaction.drilldown` in `docs.json` for hierarchical navigation
> - Restructure "Getting Started" to add a `First steps` group containing `introduction`
> - Add `sidebarTitle` to `introduction.mdx` to control its sidebar label
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20b98da2d364438c900b50aa590390168a03cead. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->