### PR TITLE
feat(jssg-utils): extend removeImport for var require and side-effect forms

### DIFF
--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -753,7 +753,8 @@ function countSpecifiersInStatement<T extends Language>(statement: SgNode<T>): n
 }
 
 /**
- * Find the full range of a statement including trailing newline.
+ * Find the full range of a statement including one trailing line ending, if present.
+ * Handles CRLF, LF, and legacy lone CR so removal edits stay consistent across platforms.
  */
 function getStatementRangeWithNewline<T extends Language>(
   statement: SgNode<T>,
@@ -762,8 +763,11 @@ function getStatementRangeWithNewline<T extends Language>(
   const range = statement.range();
   let end = range.end.index;
 
-  // Include trailing newline if present
-  if (programText[end] === "\n") {
+  if (programText.slice(end, end + 2) === "\r\n") {
+    end += 2;
+  } else if (programText[end] === "\n") {
+    end++;
+  } else if (programText[end] === "\r") {
     end++;
   }
 
@@ -997,6 +1001,47 @@ export function addImport<T extends Language>(
 }
 
 /**
+ * First argument to `require(...)`, after stripping redundant parentheses.
+ * Does not recurse into nested calls — only literal module specifiers match.
+ */
+function unwrapParentheses(node: SgNode<TS>): SgNode<TS> {
+  let current = node;
+  while (current.kind() === "parenthesized_expression") {
+    const inner = current.child(1);
+    if (!inner) break;
+    current = inner as SgNode<TS>;
+  }
+  return current;
+}
+
+function requireCallFirstArgIsLiteralSpecifier(
+  requireCall: SgNode<TS>,
+  packageName: string,
+): boolean {
+  const args = requireCall.field("arguments");
+  if (!args) return false;
+  let firstArg: SgNode<TS> | null = null;
+  for (const child of args.children()) {
+    const k = child.kind();
+    if (k === "(" || k === ")" || k === ",") continue;
+    firstArg = child as SgNode<TS>;
+    break;
+  }
+  if (!firstArg) return false;
+  const arg = unwrapParentheses(firstArg);
+  if (arg.kind() !== "string") {
+    return false;
+  }
+  const frag = arg.find({
+    rule: {
+      kind: "string_fragment",
+      regex: stringToExactRegexString(packageName),
+    },
+  });
+  return frag != null;
+}
+
+/**
  * `require('pkg');` as a standalone expression statement (e.g. polyfill registration).
  */
 function removeBareRequireSideEffectEdit(
@@ -1015,29 +1060,21 @@ function removeBareRequireSideEffectEdit(
     if (fn?.text() !== "require") {
       continue;
     }
-    const str = expr.find({
-      rule: {
-        kind: "string_fragment",
-        regex: stringToExactRegexString(packageName),
-      },
-    });
-    if (!str) {
+    if (!requireCallFirstArgIsLiteralSpecifier(expr as SgNode<TS>, packageName)) {
       continue;
     }
-    const range = stmt.range();
-    let end = range.end.index;
-    if (programText[end] === "\n") {
-      end++;
-    } else if (programText.slice(end, end + 2) === "\r\n") {
-      end += 2;
-    }
-    return { startPos: range.start.index, endPos: end, insertedText: "" };
+    const { start, end } = getStatementRangeWithNewline(
+      stmt as unknown as SgNode<Language>,
+      programText,
+    );
+    return { startPos: start, endPos: end, insertedText: "" };
   }
   return null;
 }
 
 /**
  * Side-effect only: `import 'pkg'` / `import "pkg"` (no binding clause in grammar).
+ * The module id is matched only on the statement’s `source` field (not other strings, e.g. import attributes).
  */
 function removeSideEffectImportStatementEdit(
   program: SgNode<TS, "program">,
@@ -1047,13 +1084,17 @@ function removeSideEffectImportStatementEdit(
   for (const stmt of program.findAll({
     rule: { kind: "import_statement" },
   })) {
-    const src = stmt.find({
+    const sourceNode = stmt.field("source");
+    if (!sourceNode) {
+      continue;
+    }
+    const frag = sourceNode.find({
       rule: {
         kind: "string_fragment",
         regex: stringToExactRegexString(packageName),
       },
     });
-    if (!src) {
+    if (!frag) {
       continue;
     }
     const hasBinding = stmt.find({
@@ -1062,14 +1103,11 @@ function removeSideEffectImportStatementEdit(
     if (hasBinding) {
       continue;
     }
-    const range = stmt.range();
-    let end = range.end.index;
-    if (programText[end] === "\n") {
-      end++;
-    } else if (programText.slice(end, end + 2) === "\r\n") {
-      end += 2;
-    }
-    return { startPos: range.start.index, endPos: end, insertedText: "" };
+    const { start, end } = getStatementRangeWithNewline(
+      stmt as unknown as SgNode<Language>,
+      programText,
+    );
+    return { startPos: start, endPos: end, insertedText: "" };
   }
   return null;
 }

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -43,7 +43,15 @@ type AddImportOptions =
     };
 
 type RemoveImportOptions =
-  | { type: "default"; from: string }
+  | {
+      type: "default";
+      from: string;
+      /**
+       * When `getImport` finds no binding, also remove side-effect-only lines:
+       * `import 'module'` and `require('module');`. Default false.
+       */
+      removeSideEffectForms?: boolean;
+    }
   | { type: "namespace"; from: string }
   | { type: "named"; specifiers: string[]; from: string };
 
@@ -387,7 +395,7 @@ function findAllImportStatements<T extends Language>(program: SgNode<T, "program
     rule: { kind: "import_statement" },
   });
 
-  // Find CJS require declarations (const x = require(...))
+  // Find CJS require declarations (`const`/`let` and `var`: x = require(...))
   // Restricted to single-declarator declarations only - if a second variable_declarator
   // exists in the same declaration, we skip it entirely rather than risk removing
   // unrelated bindings during whole-statement removal.
@@ -430,7 +438,46 @@ function findAllImportStatements<T extends Language>(program: SgNode<T, "program
     },
   });
 
-  return [...esmImports, ...cjsImports] as unknown as SgNode<T>[];
+  // `var foo = require(...)` uses variable_declaration, not lexical_declaration
+  const cjsVarImports = tsProgram.findAll({
+    rule: {
+      kind: "variable_declaration",
+      has: {
+        kind: "variable_declarator",
+        has: {
+          field: "value",
+          any: [
+            {
+              kind: "call_expression",
+              has: {
+                field: "function",
+                kind: "identifier",
+                regex: "^require$",
+              },
+            },
+            {
+              kind: "await_expression",
+              has: {
+                kind: "call_expression",
+                has: {
+                  field: "function",
+                  regex: "^import$",
+                },
+              },
+            },
+          ],
+        },
+      },
+      not: {
+        has: {
+          kind: "variable_declarator",
+          nthChild: 2,
+        },
+      },
+    },
+  });
+
+  return [...esmImports, ...cjsImports, ...cjsVarImports] as unknown as SgNode<T>[];
 }
 
 /**
@@ -950,10 +997,90 @@ export function addImport<T extends Language>(
 }
 
 /**
+ * `require('pkg');` as a standalone expression statement (e.g. polyfill registration).
+ */
+function removeBareRequireSideEffectEdit(
+  program: SgNode<TS, "program">,
+  packageName: string,
+): Edit | null {
+  const programText = program.text();
+  for (const stmt of program.findAll({
+    rule: { kind: "expression_statement" },
+  })) {
+    const expr = stmt.child(0);
+    if (!expr || expr.kind() !== "call_expression") {
+      continue;
+    }
+    const fn = expr.field("function");
+    if (fn?.text() !== "require") {
+      continue;
+    }
+    const str = expr.find({
+      rule: {
+        kind: "string_fragment",
+        regex: stringToExactRegexString(packageName),
+      },
+    });
+    if (!str) {
+      continue;
+    }
+    const range = stmt.range();
+    let end = range.end.index;
+    if (programText[end] === "\n") {
+      end++;
+    } else if (programText.slice(end, end + 2) === "\r\n") {
+      end += 2;
+    }
+    return { startPos: range.start.index, endPos: end, insertedText: "" };
+  }
+  return null;
+}
+
+/**
+ * Side-effect only: `import 'pkg'` / `import "pkg"` (no binding clause in grammar).
+ */
+function removeSideEffectImportStatementEdit(
+  program: SgNode<TS, "program">,
+  packageName: string,
+): Edit | null {
+  const programText = program.text();
+  for (const stmt of program.findAll({
+    rule: { kind: "import_statement" },
+  })) {
+    const src = stmt.find({
+      rule: {
+        kind: "string_fragment",
+        regex: stringToExactRegexString(packageName),
+      },
+    });
+    if (!src) {
+      continue;
+    }
+    const hasBinding = stmt.find({
+      rule: { kind: "import_clause" },
+    });
+    if (hasBinding) {
+      continue;
+    }
+    const range = stmt.range();
+    let end = range.end.index;
+    if (programText[end] === "\n") {
+      end++;
+    } else if (programText.slice(end, end + 2) === "\r\n") {
+      end += 2;
+    }
+    return { startPos: range.start.index, endPos: end, insertedText: "" };
+  }
+  return null;
+}
+
+/**
  * Remove an import from the program. Smart behavior:
  * - Default/namespace: Removes entire import statement
  * - Named (multiple specifiers exist): Removes only the specified specifiers
  * - Named (removing last specifiers): Removes entire import statement
+ * - Default + `var` + `require()`: removed (same as `const`/`let`)
+ * - Default + `removeSideEffectForms`: also removes bare `require('m')` and `import 'm'` when there is no binding import
  *
  * Note: removeImport returns null for multi-declarator CJS declarations
  * (e.g. `const foo = require('mod'), x = 1`). These are not tracked by
@@ -969,36 +1096,52 @@ export function removeImport<T extends Language>(
   const allStatements = findAllImportStatements(program);
 
   if (options.type === "default") {
+    const stripSideEffects = options.removeSideEffectForms === true;
     const existing = getImport(program, { type: "default", from: options.from });
-    if (!existing || existing.isNamespace) return null;
 
-    const statement =
-      allStatements.find((stmt) => {
-        const tsStmt = stmt as unknown as SgNode<TS>;
-        const matchesAlias = tsStmt.has({
-          rule: {
-            any: [{ kind: "identifier", regex: stringToExactRegexString(existing.alias) }],
-          },
-        });
-        const matchesSource = tsStmt.has({
-          rule: {
-            any: [
-              { regex: stringToExactRegexString(options.from) },
-              {
-                has: {
-                  kind: "string_fragment",
-                  regex: stringToExactRegexString(options.from),
+    if (existing?.isNamespace) {
+      return null;
+    }
+
+    if (existing) {
+      const statement =
+        allStatements.find((stmt) => {
+          const tsStmt = stmt as unknown as SgNode<TS>;
+          const matchesAlias = tsStmt.has({
+            rule: {
+              any: [{ kind: "identifier", regex: stringToExactRegexString(existing.alias) }],
+            },
+          });
+          const matchesSource = tsStmt.has({
+            rule: {
+              any: [
+                { regex: stringToExactRegexString(options.from) },
+                {
+                  has: {
+                    kind: "string_fragment",
+                    regex: stringToExactRegexString(options.from),
+                  },
                 },
-              },
-            ],
-          },
-        });
-        return matchesAlias && matchesSource;
-      }) ?? null;
+              ],
+            },
+          });
+          return matchesAlias && matchesSource;
+        }) ?? null;
 
-    if (!statement) return null;
-    const { start, end } = getStatementRangeWithNewline(statement, programText);
-    return { startPos: start, endPos: end, insertedText: "" };
+      if (!statement) return null;
+      const { start, end } = getStatementRangeWithNewline(statement, programText);
+      return { startPos: start, endPos: end, insertedText: "" };
+    }
+
+    if (stripSideEffects) {
+      const tsProgram = program as unknown as SgNode<TS, "program">;
+      return (
+        removeBareRequireSideEffectEdit(tsProgram, options.from) ??
+        removeSideEffectImportStatementEdit(tsProgram, options.from)
+      );
+    }
+
+    return null;
   }
 
   if (options.type === "namespace") {

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -717,6 +717,54 @@ function testRemoveDefault_MultiDeclarator_UnrelatedModuleUnaffected() {
   assert(result.includes("require('mod')"), "Should leave the multi-declarator require intact");
 }
 
+/** Before removeImport supported `variable_declaration`, this returned null (only lexical_declaration was matched). */
+function testRemoveDefaultVarCJS() {
+  const program = parseProgram("javascript", "var foo = require('mod');\nconsole.log(foo);\n");
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit for var + require");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("require"), "Should remove var require statement");
+  assert(result.includes("console.log(foo)"), "Should keep usage");
+}
+
+/** Bare `require('mod')` has no binding, so getImport is null; removal required `removeSideEffectForms`. */
+function testRemoveBareRequireOnlyWithSideEffectFlag() {
+  const src = "require('mod');\nconsole.log(1);\n";
+  const program = parseProgram("javascript", src);
+  assert(
+    removeImport(program, { type: "default", from: "mod" }) === null,
+    "Without removeSideEffectForms, bare require should not be removed (backward compatible)",
+  );
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: true,
+  });
+  assert(edit !== null, "With removeSideEffectForms, bare require should be removed");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("require('mod')"), "Should strip bare require");
+  assert(result.includes("console.log(1)"), "Should keep other statements");
+}
+
+/** Side-effect `import 'mod'` — same as bare require: needs removeSideEffectForms. */
+function testRemoveSideEffectImportWithFlag() {
+  const src = "import 'mod';\nconsole.log(1);\n";
+  const program = parseProgram("javascript", src);
+  assert(
+    removeImport(program, { type: "default", from: "mod" }) === null,
+    "Without flag, side-effect import should not be removed",
+  );
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: true,
+  });
+  assert(edit !== null, "With removeSideEffectForms, side-effect import should be removed");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("import 'mod'"), "Should strip side-effect import");
+  assert(result.includes("console.log(1)"), "Should keep other statements");
+}
+
 function run() {
   // getAllImports tests
   testReturnsEmptyArrayWhenNoImports();
@@ -777,6 +825,9 @@ function run() {
   testRemoveDefault_MultiDeclarator_ReturnsNull();
   testRemoveDefault_MultiDeclarator_SourceCodeUnchanged();
   testRemoveDefault_MultiDeclarator_UnrelatedModuleUnaffected();
+  testRemoveDefaultVarCJS();
+  testRemoveBareRequireOnlyWithSideEffectFlag();
+  testRemoveSideEffectImportWithFlag();
 
   console.log("imports.test.ts: all assertions passed");
 }

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -746,6 +746,36 @@ function testRemoveBareRequireOnlyWithSideEffectFlag() {
   assert(result.includes("console.log(1)"), "Should keep other statements");
 }
 
+/** Do not strip `require` when the module id only appears nested (not the direct specifier). */
+function testRemoveBareRequireNestedStringNotRemoved() {
+  const src = "require(getName('mod'));\nconsole.log(1);\n";
+  const program = parseProgram("javascript", src);
+  assert(
+    removeImport(program, {
+      type: "default",
+      from: "mod",
+      removeSideEffectForms: true,
+    }) === null,
+    "Nested string literal must not be treated as require('mod')",
+  );
+  assert(program.text() === src, "Source must be unchanged");
+}
+
+/** Parenthesized string literal is still a direct specifier. */
+function testRemoveBareRequireParenthesizedLiteralStillRemoved() {
+  const src = "require(('mod'));\nconsole.log(1);\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: true,
+  });
+  assert(edit !== null, "Parenthesized literal should still count as direct specifier");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("require"), "Should strip bare require");
+  assert(result.includes("console.log(1)"), "Should keep other statements");
+}
+
 /** Side-effect `import 'mod'` — same as bare require: needs removeSideEffectForms. */
 function testRemoveSideEffectImportWithFlag() {
   const src = "import 'mod';\nconsole.log(1);\n";
@@ -763,6 +793,21 @@ function testRemoveSideEffectImportWithFlag() {
   const result = program.commitEdits([edit!]);
   assert(!result.includes("import 'mod'"), "Should strip side-effect import");
   assert(result.includes("console.log(1)"), "Should keep other statements");
+}
+
+/** Only the module source string counts — not other string literals (e.g. import attributes). */
+function testRemoveSideEffectImportOnlyMatchesSourceField() {
+  const src = "import 'foo' assert { type: 'mod' };\nconsole.log(1);\n";
+  const program = parseProgram("typescript", src);
+  assert(
+    removeImport(program, {
+      type: "default",
+      from: "mod",
+      removeSideEffectForms: true,
+    }) === null,
+    "Package name only in import attributes must not remove the statement",
+  );
+  assert(program.text() === src, "Source must be unchanged");
 }
 
 function run() {
@@ -827,7 +872,10 @@ function run() {
   testRemoveDefault_MultiDeclarator_UnrelatedModuleUnaffected();
   testRemoveDefaultVarCJS();
   testRemoveBareRequireOnlyWithSideEffectFlag();
+  testRemoveBareRequireNestedStringNotRemoved();
+  testRemoveBareRequireParenthesizedLiteralStillRemoved();
   testRemoveSideEffectImportWithFlag();
+  testRemoveSideEffectImportOnlyMatchesSourceField();
 
   console.log("imports.test.ts: all assertions passed");
 }


### PR DESCRIPTION
## Summary

Extends `removeImport` in `@jssg/utils` so default-import removal behaves correctly for more real-world patterns.

### Changes

- **`var foo = require('pkg')`**: `findAllImportStatements` now collects `variable_declaration` nodes (single declarator, require/dynamic import) in addition to `lexical_declaration`, so removal matches `const`/`let` behavior.
- **Optional `removeSideEffectForms`** (default branch of `RemoveImportOptions`): when `getImport` finds no binding, you can opt in to removing side-effect-only lines: bare `require('pkg');` and `import 'pkg'` / `import "pkg"`.
- **Tests**: keeps upstream multi-declarator safety tests and adds coverage for `var` + require, bare require, and side-effect import.

### Backward compatibility

- `removeSideEffectForms` defaults to `false`; existing callers are unchanged.

### How tested

`pnpm test` in `packages/jssg-utils` (jssg exec `imports.test.ts`).

Made with [Cursor](https://cursor.com)