### PR TITLE
refactor: rename Transform type to Codemod across all codemod scripts and documentation

### DIFF
--- a/.changeset/floppy-lies-fetch.md
+++ b/.changeset/floppy-lies-fetch.md
@@ -1,0 +1,5 @@
+---
+"@codemod.com/jssg-types": patch
+---
+
+Rename Transform type to Codemod

--- a/crates/cli/npm/README.md
+++ b/crates/cli/npm/README.md
@@ -104,10 +104,10 @@ Packages can be as simple as a single transformation or as complex as multi-step
 
 ```typescript
 // Example: Replace console.log with logger.info
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = (root) => {
+const codemod: Codemod<TSX> = (root) => {
   const rootNode = root.root();
 
   // Find all console.log calls
@@ -128,7 +128,7 @@ const transform: Transform<TSX> = (root) => {
   return rootNode.commitEdits(edits);
 };
 
-export default transform;
+export default codemod;
 ```
 
 jssg combines the power of AST transformations with the flexibility of JavaScript, making complex transformations intuitive and testable.

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.angular.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.angular.ts
@@ -1,7 +1,7 @@
 import type { Codemod } from "codemod:ast-grep";
 import type Angular from "codemod:ast-grep/langs/angular";
 
-export const codemod: Codemod<Angular> = async (root) => {
+const codemod: Codemod<Angular> = async (root) => {
   const rootNode = root.root();
 
   // Find all ngClass array bindings

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.angular.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.angular.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Angular from "codemod:ast-grep/langs/angular";
 
-async function transform(root: SgRoot<Angular>): Promise<string> {
+export const codemod: Codemod<Angular> = async (root) => {
   const rootNode = root.root();
 
   // Find all ngClass array bindings
@@ -67,4 +67,4 @@ async function transform(root: SgRoot<Angular>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.c.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.c.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
-import type TS from "codemod:ast-grep/langs/typescript";
+import type { Codemod } from "codemod:ast-grep";
+import type C from "codemod:ast-grep/langs/c";
 
-async function transform(root: SgRoot<TS>): Promise<string> {
+const codemod: Codemod<C> = async (root) => {
   const rootNode = root.root();
 
   const nodes = rootNode.findAll({
@@ -22,4 +22,4 @@ async function transform(root: SgRoot<TS>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.cpp.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.cpp.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
-import type CPP from "codemod:ast-grep/langs/cpp";
+import type { Codemod } from "codemod:ast-grep";
+import type Cpp from "codemod:ast-grep/langs/cpp";
 
-async function transform(root: SgRoot<CPP>): Promise<string> {
+export const codemod: Codemod<Cpp> = async (root) => {
   const rootNode = root.root();
 
   // Find raw pointer declarations with new
@@ -58,4 +58,4 @@ async function transform(root: SgRoot<CPP>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.cpp.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.cpp.ts
@@ -1,7 +1,7 @@
 import type { Codemod } from "codemod:ast-grep";
 import type Cpp from "codemod:ast-grep/langs/cpp";
 
-export const codemod: Codemod<Cpp> = async (root) => {
+const codemod: Codemod<Cpp> = async (root) => {
   const rootNode = root.root();
 
   // Find raw pointer declarations with new

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.cs.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.cs.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type CSharp from "codemod:ast-grep/langs/c_sharp";
 
-async function transform(root: SgRoot<CSharp>): Promise<string> {
+const codemod: Codemod<CSharp> = async (root) => {
   const rootNode = root.root();
 
   const nodes = rootNode.findAll({
@@ -22,4 +22,4 @@ async function transform(root: SgRoot<CSharp>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.css.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.css.ts
@@ -1,6 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
+import type CSS from "codemod:ast-grep/langs/css";
 
-async function transform(root: SgRoot): Promise<string> {
+const codemod: Codemod<CSS> = async (root) => {
   const rootNode = root.root();
 
   // Find vendor-prefixed properties that have standard equivalents
@@ -36,4 +37,4 @@ async function transform(root: SgRoot): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.ex.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.ex.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Elixir from "codemod:ast-grep/langs/elixir";
 
-async function transform(root: SgRoot<Elixir>): Promise<string> {
+const codemod: Codemod<Elixir> = async (root) => {
   const rootNode = root.root();
 
   // Find IO.puts calls
@@ -37,4 +37,4 @@ async function transform(root: SgRoot<Elixir>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.go.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.go.ts
@@ -1,7 +1,7 @@
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Go from "codemod:ast-grep/langs/go";
 
-const transform: Transform<Go> = async (root) => {
+const codemod: Codemod<Go> = async (root) => {
   const rootNode = root.root();
 
   // Find all fmt.Println calls
@@ -84,4 +84,4 @@ const transform: Transform<Go> = async (root) => {
   return newSource;
 };
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.html.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.html.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Html from "codemod:ast-grep/langs/html";
 
-async function transform(root: SgRoot<Html>): Promise<string> {
+const codemod: Codemod<Html> = async (root) => {
   const rootNode = root.root();
 
   // Replace <center> tags with styled div
@@ -54,4 +54,4 @@ async function transform(root: SgRoot<Html>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.java.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.java.ts
@@ -1,7 +1,7 @@
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Java from "codemod:ast-grep/langs/java";
 
-const transform: Transform<Java> = async (root) => {
+const codemod: Codemod<Java> = async (root) => {
   const rootNode = root.root();
 
   // Find for-each loops that iterate over a collection and add items to another collection
@@ -63,4 +63,4 @@ const transform: Transform<Java> = async (root) => {
   return newSource;
 };
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.json.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.json.ts
@@ -1,6 +1,7 @@
-import type { Edit, SgRoot } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
+import type Json from "codemod:ast-grep/langs/json";
 
-async function transform(root: SgRoot): Promise<string | null> {
+const codemod: Codemod<Json> = async (root) => {
   const rootNode = root.root();
   
   // Find all string keys (property names)
@@ -48,4 +49,4 @@ async function transform(root: SgRoot): Promise<string | null> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.kt.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.kt.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Kotlin from "codemod:ast-grep/langs/kotlin";
 
-async function transform(root: SgRoot<Kotlin>): Promise<string> {
+const codemod: Codemod<Kotlin> = async (root) => {
   const rootNode = root.root();
 
   // Find simple null checks followed by return
@@ -62,4 +62,4 @@ async function transform(root: SgRoot<Kotlin>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.php.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.php.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type PHP from "codemod:ast-grep/langs/php";
 
-async function transform(root: SgRoot<PHP>): Promise<string> {
+const codemod: Codemod<PHP> = async (root) => {
   const rootNode = root.root();
 
   // Find all mysql_query function calls
@@ -77,4 +77,4 @@ async function transform(root: SgRoot<PHP>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.py.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.py.ts
@@ -1,7 +1,7 @@
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Python from "codemod:ast-grep/langs/python";
 
-const transform: Transform<Python> = async (root) => {
+const codemod: Codemod<Python> = async (root) => {
   const rootNode = root.root();
 
   // Find all Python 2-style exception handlers (using comma instead of 'as')
@@ -24,4 +24,4 @@ const transform: Transform<Python> = async (root) => {
   return newSource;
 };
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.rb.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.rb.ts
@@ -1,7 +1,7 @@
-import type { SgRoot } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Ruby from "codemod:ast-grep/langs/ruby";
 
-async function transform(root: SgRoot<Ruby>): Promise<string> {
+const codemod: Codemod<Ruby> = async (root) => {
   const rootNode = root.root();
 
   const nodes = rootNode.findAll({
@@ -19,4 +19,4 @@ async function transform(root: SgRoot<Ruby>): Promise<string> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.rs.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.rs.ts
@@ -1,7 +1,7 @@
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type Rust from "codemod:ast-grep/langs/rust";
 
-const transform: Transform<Rust> = async (root) => {
+const codemod: Codemod<Rust> = async (root) => {
   const rootNode = root.root();
 
   // Find all println! macro calls
@@ -69,4 +69,4 @@ ${firstItem.text()}`),
   return newSource;
 };
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.ts.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.ts.ts
@@ -1,9 +1,18 @@
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type JS from "codemod:ast-grep/langs/javascript";
 import type TS from "codemod:ast-grep/langs/typescript";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TS | TSX | JS> = async (root) => {
+// You can change the language to JS, TS, or TSX depending on your needs. Here we use a union type to support all three.
+// Please note that TSX is different from TS in that it supports JSX syntax and treats type generics differently, so make sure to choose the one that best fits your codebase.
+// - If you are targetting JSX files, use TSX.
+// - If you are targetting plain TypeScript files without JSX, use TS.
+// - If you do not care about TypeScript features and want to target plain JavaScript files, use JS.
+//
+// Make sure this is in sync with workflow.yaml where you specify the language for the codemod.
+type JSOrTS = JS | TS | TSX;
+
+const codemod: Codemod<JSOrTS> = async (root) => {
   const rootNode = root.root();
 
   const nodes = rootNode.findAll({
@@ -22,4 +31,4 @@ const transform: Transform<TS | TSX | JS> = async (root) => {
   return newSource;
 };
 
-export default transform;
+export default codemod;

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.ts.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.ts.ts
@@ -5,8 +5,8 @@ import type TSX from "codemod:ast-grep/langs/tsx";
 
 // You can change the language to JS, TS, or TSX depending on your needs. Here we use a union type to support all three.
 // Please note that TSX is different from TS in that it supports JSX syntax and treats type generics differently, so make sure to choose the one that best fits your codebase.
-// - If you are targetting JSX files, use TSX.
-// - If you are targetting plain TypeScript files without JSX, use TS.
+// - If you are targeting JSX files, use TSX.
+// - If you are targeting plain TypeScript files without JSX, use TS.
 // - If you do not care about TypeScript features and want to target plain JavaScript files, use JS.
 //
 // Make sure this is in sync with workflow.yaml where you specify the language for the codemod.

--- a/crates/cli/src/templates/js-astgrep/scripts/codemod.yaml.ts
+++ b/crates/cli/src/templates/js-astgrep/scripts/codemod.yaml.ts
@@ -1,6 +1,7 @@
-import type { Edit, SgRoot } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
+import type Yaml from "codemod:ast-grep/langs/yaml";
 
-async function transform(root: SgRoot): Promise<string | null> {
+const codemod: Codemod<Yaml> = async (root) => {
   const rootNode = root.root();
 
   // Find version field with value '2' or '2.x'
@@ -104,4 +105,4 @@ async function transform(root: SgRoot): Promise<string | null> {
   return newSource;
 }
 
-export default transform;
+export default codemod;

--- a/crates/mcp/src/data/prompts/jssg-instructions.md
+++ b/crates/mcp/src/data/prompts/jssg-instructions.md
@@ -216,23 +216,22 @@ const node: SgNode<TSX> = rootNode.find({
 });
 ```
 
-## Transform Function
+## Codemod Function
 
-Your main transformation logic with proper type annotations:
+Your main transformation/detection logic with proper type annotations:
 
 ```typescript
 import type { SgRoot, SgNode } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-// Main transformation function - return null to skip file
-async function transform(root: SgRoot<TSX>): Promise<string | null> {
+// Main codemod function - return null to skip file
+const codemod: Codemod<TSX> = (root) => {
   const rootNode = root.root();
 
   // Your transformation logic here
   const edits: Edit[] = [];
 
   // Collect edits...
-
   if (edits.length === 0) {
     return null; // No changes needed
   }
@@ -240,7 +239,7 @@ async function transform(root: SgRoot<TSX>): Promise<string | null> {
   return rootNode.commitEdits(edits);
 }
 
-export default transform;
+export default codemod;
 ```
 
 ## Pattern Matching
@@ -795,7 +794,7 @@ Use `root.rename()` to rename a file alongside content changes. This is useful f
 
 ```typescript
 // Rename .less → .css
-const codemod: Transform<CSS> = async (root) => {
+const codemod: Codemod<CSS> = async (root) => {
   root.rename(root.filename().replace('.less', '.css'));
   return transformedContent; // or null for rename-only
 };
@@ -820,19 +819,19 @@ Use `jssgTransform()` to apply a transform function to a secondary file from wit
 
 ```typescript
 import { jssgTransform } from "codemod:ast-grep";
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import type CSS from "codemod:ast-grep/langs/css";
 
 // A secondary transform that converts .less → .css
-const lessToCSS: Transform<CSS> = async (root) => {
+const lessToCSS: Codemod<CSS> = async (root) => {
   root.rename(root.filename().replace('.less', '.css'));
   // Transform LESS-specific syntax to CSS...
   return transformedCSS;
 };
 
 // Main transform: update imports and trigger the .less → .css conversion
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -854,7 +853,7 @@ const transform: Transform<TSX> = async (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 **Key behavior:**
@@ -993,13 +992,13 @@ const changeCount = useMetricAtom("changes");
 ### 1. Count matches before transforming
 
 ```typescript
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { useMetricAtom } from "codemod:metrics";
 
 const migrationMetric = useMetricAtom("api-migrations");
 
-const codemod: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -1039,7 +1038,7 @@ componentMetric.increment({
 Sometimes you just want to gather data without changing code. Return `null` from your transform and only collect metrics:
 
 ```typescript
-const codemod: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
 
   const patterns = rootNode.findAll({

--- a/crates/mcp/src/data/prompts/jssg-utils-instructions.md
+++ b/crates/mcp/src/data/prompts/jssg-utils-instructions.md
@@ -60,11 +60,11 @@ Returns `null` if the import is not found.
 ### Example
 
 ```typescript
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { getImport } from "@jssg/utils/javascript/imports";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
 
   // Find the default import of "express"
@@ -84,7 +84,7 @@ const transform: Transform<TSX> = async (root) => {
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ---
@@ -112,11 +112,11 @@ Add an import to the program. Smart behavior:
 ### Example
 
 ```typescript
-import type { Transform, Edit } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { addImport } from "@jssg/utils/javascript/imports";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -148,7 +148,7 @@ const transform: Transform<TSX> = async (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ---
@@ -176,11 +176,11 @@ Remove an import from the program. Smart behavior:
 ### Example
 
 ```typescript
-import type { Transform, Edit } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { removeImport } from "@jssg/utils/javascript/imports";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -195,7 +195,7 @@ const transform: Transform<TSX> = async (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ---

--- a/docs/jssg/advanced.mdx
+++ b/docs/jssg/advanced.mdx
@@ -9,14 +9,14 @@ This guide covers advanced JSSG features that enable you to build more sophistic
 Every JSSG codemod must export a default function with this exact signature:
 
 ```ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = async (root, options) => {
+const codemod: Codemod<TSX> = async (root, options) => {
   // Your transformation logic
 };
 
-export default transform;
+export default codemod;
 ```
 
 ### Transform Options
@@ -29,10 +29,10 @@ The `options` object provides execution context:
 - `options.matrixValues?: Record<string, unknown>` — values from matrix strategy execution. Use for sharding, multi‑variant runs, or team‑scoped processing.
 
 ```ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = async (root, options) => {
+const codemod: Codemod<TSX> = async (root, options) => {
   const lang = options.language;
   const params = options.params;
   const preFilteredMatches = options.matches; // may be undefined if no selector
@@ -40,7 +40,7 @@ const transform: Transform<TSX> = async (root, options) => {
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 <Info>
@@ -57,7 +57,7 @@ Use dynamic parsing when your codemod needs to analyze multiple languages or whe
 import type { parseAsync, GetParser, Transform } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   // Find all styled-component template literals
   const styledComponents = root.root().findAll({
     rule: { pattern: "styled.$COMPONENT`$ARG`" }
@@ -101,7 +101,7 @@ const transform: Transform<TSX> = async (root) => {
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ### Return Semantics
@@ -126,7 +126,7 @@ You can access parameters via `options.params`.
 import type { parseAsync, GetParser, Transform } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = async (root, options) => {
+const codemod: Codemod<TSX> = async (root, options) => {
   // Access user-configured parameters
   const library = options.params?.library || "next-intl";
   const shardingMethod = options.params?.shardingMethod || "directory";
@@ -138,7 +138,7 @@ const transform: Transform<TSX> = async (root, options) => {
   }
 };
 
-export default transform;
+export default codemod;
 ```
 
 ```yaml workflow.yaml
@@ -198,7 +198,7 @@ Access matrix values via `options.matrixValues`:
 import type { parseAsync, GetParser, Transform } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";    
 
-const transform: Transform<TSX> = async (root, options) => {
+const codemod: Codemod<TSX> = async (root, options) => {
   // Access matrix values passed from the workflow (if matrix strategy is used)
   const team = (options.matrixValues as any)?.team;
   const shardId = (options.matrixValues as any)?.shardId;
@@ -218,7 +218,7 @@ const transform: Transform<TSX> = async (root, options) => {
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 <Info>
@@ -305,11 +305,11 @@ import { setState, getState, unsetState, acquireLock } from "codemod:workflow";
 State is shared across all files processed in parallel within a single step:
 
 ```ts codemod.ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { setState, getState, acquireLock } from "codemod:workflow";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const imports = rootNode.findAll({ rule: { kind: "import_statement" } });
 
@@ -326,7 +326,7 @@ const transform: Transform<TSX> = async (root) => {
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ### When to Use Locks
@@ -377,11 +377,11 @@ nodes:
 ```
 
 ```ts scripts/scan.ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { setState, getState, acquireLock } from "codemod:workflow";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   // Collect file paths that match criteria
   const release = acquireLock("files");
   try {
@@ -394,7 +394,7 @@ const transform: Transform<TSX> = async (root) => {
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ```ts scripts/process.ts
@@ -459,11 +459,11 @@ Use runtime hooks when you want to:
 ### Example: Report progress and fail explicitly
 
 ```ts codemod.ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import runtime from "codemod:runtime";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const relativeFile = root.filename();
 
   runtime.setCurrentUnit(relativeFile);
@@ -481,7 +481,7 @@ const transform: Transform<TSX> = async (root) => {
   }
 };
 
-export default transform;
+export default codemod;
 ```
 
 ### When to use hooks vs exceptions
@@ -500,10 +500,10 @@ export default transform;
 Use multi-repo orchestration when your codemod must coordinate changes across multiple repositories—such as updating shared libraries, enforcing consistency, or applying repo-specific logic. This approach streamlines large-scale migrations and ensures changes are applied uniformly.
 
 ```ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = async (root, options) => {
+const codemod: Codemod<TSX> = async (root, options) => {
   const filePath = root.filename();
   const repoName = options.matrixValues?.repo_name;
   
@@ -515,7 +515,7 @@ const transform: Transform<TSX> = async (root, options) => {
   }
 };
 
-export default transform;
+export default codemod;
 ```
 
 ## Multi-File Transforms
@@ -528,18 +528,18 @@ Use `jssgTransform()` to apply a transform function to another file from within 
 
 ```ts
 import { jssgTransform } from "codemod:ast-grep";
-import type { Transform, Edit } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import type CSS from "codemod:ast-grep/langs/css";
 
-const migrateStyles: Transform<CSS> = async (root) => {
+const migrateStyles: Codemod<CSS> = async (root) => {
   // Rename the file from .less to .css
   root.rename(root.filename().replace('.less', '.css'));
   // Optionally transform the content
   return transformedContent;
 };
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -564,7 +564,7 @@ const transform: Transform<TSX> = async (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 <Info>
@@ -576,7 +576,7 @@ export default transform;
 Use `root.rename(newPath)` to rename the file currently being processed. This is useful for file extension conversions (`.js` → `.ts`, `.less` → `.css`, `.cjs` → `.mjs`).
 
 ```ts
-const transform: Transform<CSS> = async (root) => {
+const codemod: Codemod<CSS> = async (root) => {
   // Rename .less → .css
   root.rename(root.filename().replace('.less', '.css'));
 
@@ -676,7 +676,7 @@ Use `stopBy` to bound relational searches (e.g., to immediate neighbors or the e
 
 ### Consistent Patterns
 
-1. **Use `const transform: Transform<TSX> = async (root, options) => {}` with `export default transform`**
+1. **Use `const codemod: Codemod<TSX> = async (root, options) => {}` with `export default codemod`**
 2. **Import proper types** - use `Transform`, `GetSelector`, and language-specific types from `codemod:ast-grep`
 3. **Handle edge cases** - always check for null/undefined values and use try-catch for async operations
 4. **Use early returns** - skip processing when possible, especially for sharding

--- a/docs/jssg/advanced.mdx
+++ b/docs/jssg/advanced.mdx
@@ -54,7 +54,8 @@ Dynamic parsing allows you to parse and analyze different types of code within a
 Use dynamic parsing when your codemod needs to analyze multiple languages or when you're working with template literals containing different syntax.
 
 ```ts
-import type { parseAsync, GetParser, Transform } from "codemod:ast-grep";
+import { parseAsync } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
 const codemod: Codemod<TSX> = async (root) => {
@@ -123,7 +124,7 @@ You can access parameters via `options.params`.
 
 <CodeGroup>
 ```ts codemod.ts
-import type { parseAsync, GetParser, Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
 const codemod: Codemod<TSX> = async (root, options) => {
@@ -195,7 +196,7 @@ Matrix values are particularly useful for:
 Access matrix values via `options.matrixValues`:
 
 ```ts
-import type { parseAsync, GetParser, Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";    
 
 const codemod: Codemod<TSX> = async (root, options) => {
@@ -677,7 +678,7 @@ Use `stopBy` to bound relational searches (e.g., to immediate neighbors or the e
 ### Consistent Patterns
 
 1. **Use `const codemod: Codemod<TSX> = async (root, options) => {}` with `export default codemod`**
-2. **Import proper types** - use `Transform`, `GetSelector`, and language-specific types from `codemod:ast-grep`
+2. **Import proper types** - use `Codemod`, `GetSelector`, and language-specific types from `codemod:ast-grep`
 3. **Handle edge cases** - always check for null/undefined values and use try-catch for async operations
 4. **Use early returns** - skip processing when possible, especially for sharding
 5. **Batch operations** - collect edits before committing

--- a/docs/jssg/intro.mdx
+++ b/docs/jssg/intro.mdx
@@ -32,11 +32,11 @@ You can author rules as plain JavaScript objects. See the [ast‑grep rule confi
 Below is a sample JSSG codemod that moves React components declared inside other components up to module scope.
 
 ```ts scripts/codemod.ts expandable
-import type { Transform, Edit } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
 import type { SgNode } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -147,7 +147,7 @@ const transform: Transform<TSX> = async (root) => {
   return rootNode.commitEdits(edits);
 };
 
-export default transform;
+export default codemod;
 ```
 
 ## How JSSG differs

--- a/docs/jssg/metrics.mdx
+++ b/docs/jssg/metrics.mdx
@@ -52,13 +52,13 @@ Use cardinality to capture context about what you're counting. For example, when
 This read-only codemod counts how many times each prop is used on `Button` components:
 
 ```typescript
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { useMetricAtom } from "codemod:metrics";
 
 const propUsageMetric = useMetricAtom("prop-usage");
 
-const codemod: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
 
   const jsxAttrs = rootNode.findAll({

--- a/docs/jssg/reference.mdx
+++ b/docs/jssg/reference.mdx
@@ -35,15 +35,15 @@ Built-in codemod modules:
 Every JSSG codemod exports a transform function:
 
 ```ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = (root, options) => {
+const codemod: Codemod<TSX> = (root, options) => {
   // Your transformation logic
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 <Info>
@@ -318,10 +318,10 @@ When a selector is provided, the engine pre‑computes matches; if none are foun
 Here's a complete example that replaces `console.*` calls with `logger.*`:
 
 ```ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = (root) => {
+const codemod: Codemod<TSX> = (root) => {
   const rootNode = root.root();
   
   // Find all console.* calls
@@ -482,7 +482,7 @@ Match only the pre-change shape to avoid re-editing:
 For large codebases:
 
 ```ts
-const transform: Transform<TSX> = (root) => {
+const codemod: Codemod<TSX> = (root) => {
   const rootNode = root.root();
   
   // Early return for non-applicable files
@@ -511,7 +511,7 @@ const transform: Transform<TSX> = (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 }
 
-export default transform;
+export default codemod;
 ```
 
 ## Parse Helpers
@@ -537,15 +537,15 @@ export default function main() {
 Use `root.rename()` to rename a file alongside content changes. This is useful for codemods that convert between file formats (e.g., `.less` → `.css`, `.js` → `.ts`, `.cjs` → `.mjs`).
 
 ```ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type CSS from "codemod:ast-grep/langs/css";
 
-const transform: Transform<CSS> = async (root) => {
+const codemod: Codemod<CSS> = async (root) => {
   root.rename(root.filename().replace('.less', '.css'));
   return transformedContent; // or null for rename-only
 };
 
-export default transform;
+export default codemod;
 ```
 
 **Behavior matrix:**
@@ -577,18 +577,18 @@ Use `jssgTransform()` when a change in one file requires a corresponding change 
 
 ```ts
 import { jssgTransform } from "codemod:ast-grep";
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import type CSS from "codemod:ast-grep/langs/css";
 
 // Secondary transform: convert .less → .css
-const lessToCSS: Transform<CSS> = async (root) => {
+const lessToCSS: Codemod<CSS> = async (root) => {
   root.rename(root.filename().replace('.less', '.css'));
   return transformedCSS;
 };
 
 // Primary transform: update imports and trigger the conversion
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -613,7 +613,7 @@ const transform: Transform<TSX> = async (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 <Info>
@@ -703,10 +703,10 @@ const hooks = rootNode.findAll(createReactHookMatcher());
 Here's a complete example that adds type annotations to Next.js page components:
 
 ```ts
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = (root) => {
+const codemod: Codemod<TSX> = (root) => {
   const rootNode = root.root();
 
   // Find the default export
@@ -745,7 +745,7 @@ const transform: Transform<TSX> = (root) => {
   return rootNode.commitEdits([edit]);
 }
 
-export default transform;
+export default codemod;
 ```
 
 This example demonstrates:
@@ -760,7 +760,7 @@ This example demonstrates:
 For large codebases, optimize your traversal:
 
 ```ts
-const transform: Transform<TSX> = (root) => {
+const codemod: Codemod<TSX> = (root) => {
   const rootNode = root.root();
   
   // Early return for non-applicable files
@@ -793,7 +793,7 @@ const transform: Transform<TSX> = (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 }
 
-export default transform;
+export default codemod;
 ```
 
 **Optimization tips:**
@@ -804,10 +804,10 @@ export default transform;
 
 ```ts
 // Range‑aware decision: skip very long calls
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = (root) => {
+const codemod: Codemod<TSX> = (root) => {
   const node = root.root().find({ rule: { pattern: "longCall($A, $B, $C, $D)" } });
   if (!node) return null;
   const r = node.range();
@@ -815,7 +815,7 @@ const transform: Transform<TSX> = (root) => {
   return root.root().commitEdits([node.replace("shortCall()")]);
 };
 
-export default transform;
+export default codemod;
 ```
 
 
@@ -842,7 +842,7 @@ export default transform;
     <b>Debug steps:</b>
     <CodeBlock language="ts">
     {`
-    const transform: Transform<TSX> = (root) => {
+    const codemod: Codemod<TSX> = (root) => {
     const rootNode = root.root();
     
     // Add debug logging
@@ -863,7 +863,7 @@ export default transform;
     
     return rootNode.commitEdits(edits);
     }
-    export default transform;`}
+    export default codemod;`}
     </CodeBlock>
   </Accordion>
 

--- a/docs/jssg/security.mdx
+++ b/docs/jssg/security.mdx
@@ -106,17 +106,17 @@ Use these exact strings in the `capabilities` array:
   </Step>
   <Step title="Use fs in your transform">
     ```ts scripts/codemod.ts
-    import type { Transform } from "codemod:ast-grep";
+    import type { Codemod } from "codemod:ast-grep";
     import { readFileSync } from "fs";
     
-    const transform: Transform = (root) => {
+    const codemod: Codemod = (root) => {
       // Read a configuration file
       const config = JSON.parse(readFileSync("./config.json", "utf-8"));
       
       // ... use config in transformation
     };
     
-    export default transform;
+    export default codemod;
     ```
   </Step>
 </Steps>
@@ -132,9 +132,9 @@ Use these exact strings in the `capabilities` array:
   </Step>
   <Step title="Use fetch in your transform">
     ```ts scripts/codemod.ts
-    import type { Transform } from "codemod:ast-grep";
+    import type { Codemod } from "codemod:ast-grep";
     
-    const transform: Transform = async (root) => {
+    const codemod: Codemod = async (root) => {
       // Fetch latest API definitions
       const response = await fetch("https://api.example.com/schema.json");
       const schema = await response.json();
@@ -142,7 +142,7 @@ Use these exact strings in the `capabilities` array:
       // ... use schema in transformation
     };
     
-    export default transform;
+    export default codemod;
     ```
 
     <Info>
@@ -162,10 +162,10 @@ Use these exact strings in the `capabilities` array:
   </Step>
   <Step title="Spawn processes in your transform">
     ```ts scripts/codemod.ts
-    import type { Transform } from "codemod:ast-grep";
+    import type { Codemod } from "codemod:ast-grep";
     import { execSync } from "child_process";
     
-    const transform: Transform = (root) => {
+    const codemod: Codemod = (root) => {
       // Get current git branch
       const branch = execSync("git rev-parse --abbrev-ref HEAD", {
         encoding: "utf-8"
@@ -174,7 +174,7 @@ Use these exact strings in the `capabilities` array:
       // ... use branch info in transformation
     };
     
-    export default transform;
+    export default codemod;
     ```
 
     <Warning>

--- a/docs/jssg/utils.mdx
+++ b/docs/jssg/utils.mdx
@@ -74,11 +74,11 @@ Returns `null` if the import is not found.
 ### Example
 
 ```typescript
-import type { Transform } from "codemod:ast-grep";
+import type { Codemod } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { getImport } from "@jssg/utils/javascript/imports";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
 
   // Find the default import of "express"
@@ -98,7 +98,7 @@ const transform: Transform<TSX> = async (root) => {
   return null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ---
@@ -190,11 +190,11 @@ Add an import to the program. Smart behavior:
 ### Example
 
 ```typescript
-import type { Transform, Edit } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { addImport } from "@jssg/utils/javascript/imports";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -226,7 +226,7 @@ const transform: Transform<TSX> = async (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ---
@@ -259,11 +259,11 @@ Remove an import from the program. Smart behavior:
 ### Example
 
 ```typescript
-import type { Transform, Edit } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 import { removeImport } from "@jssg/utils/javascript/imports";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -278,7 +278,7 @@ const transform: Transform<TSX> = async (root) => {
   return edits.length > 0 ? rootNode.commitEdits(edits) : null;
 };
 
-export default transform;
+export default codemod;
 ```
 
 ---

--- a/docs/oss-quickstart.mdx
+++ b/docs/oss-quickstart.mdx
@@ -126,11 +126,11 @@ nodes:
 ```
 
 ```ts scripts/codemod.ts expandable
-import type { Transform, Edit } from "codemod:ast-grep";
+import type { Codemod, Edit } from "codemod:ast-grep";
 import type { SgNode } from "codemod:ast-grep";
 import type TSX from "codemod:ast-grep/langs/tsx";
 
-const transform: Transform<TSX> = async (root) => {
+const codemod: Codemod<TSX> = async (root) => {
   const rootNode = root.root();
   const edits: Edit[] = [];
 
@@ -246,7 +246,7 @@ const transform: Transform<TSX> = async (root) => {
   return rootNode.commitEdits(edits);
 };
 
-export default transform;
+export default codemod;
 ```
 
 </CodeGroup>

--- a/docs/workflows/reference.mdx
+++ b/docs/workflows/reference.mdx
@@ -613,7 +613,7 @@ The `from_state` field references an array in your workflow's [state schema](#sh
 
 In JSSG transforms via `options.matrixValues`:
 ```ts
-const transform: Transform<TSX> = async (root, options) => {
+const codemod: Codemod<TSX> = async (root, options) => {
   const team = options.matrixValues?.team;
   const shardId = options.matrixValues?.shardId;
 };

--- a/packages/jssg-types/src/modules/ast-grep.d.ts
+++ b/packages/jssg-types/src/modules/ast-grep.d.ts
@@ -545,7 +545,12 @@ declare module "codemod:ast-grep" {
     dryRun?: boolean;
   };
 
-  export type Transform<T extends TypesMap> = (
+  /**
+   * @deprecated Use `Codemod` type instead. The name `Transform` is misleading as it implies the function must return a transformed string, but in fact it can also return null for detection purposes.
+   */
+  export type Transform<T extends TypesMap> = Codemod<T>;
+
+  export type Codemod<T extends TypesMap> = (
     root: SgRoot<T>,
     options: TransformOptions<T>,
   ) => Promise<string | null>;


### PR DESCRIPTION



<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

We use JSSG codemods for detection/insights as well. It's not limited to transformation-only use cases. This just deprecates the name `Transform` for the main function and renames to `Codemod`


- Updated all instances of the Transform type to Codemod in codemod scripts for consistency and clarity.
- Adjusted function signatures to reflect the new Codemod type, ensuring compatibility with existing functionality.
- Modified documentation to replace references to Transform with Codemod, enhancing clarity on function behavior.
- Deprecated the Transform type in the type definitions, advising users to adopt the Codemod type instead.


#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
