### PR TITLE
feat(engine): automatically pick up sharding files for js-ast-grep runs

### DIFF
--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -379,6 +379,26 @@ fn resolve_optional_glob_list(
     })
 }
 
+/// Look up `_meta_files` from matrix values or workflow state and return it as
+/// a list of file paths, if present. Matrix takes precedence over state.
+///
+/// This enables automatic scoping of ast-grep / js-ast-grep steps to the files
+/// produced by a preceding shard step
+fn auto_meta_files_include(
+    state: &HashMap<String, serde_json::Value>,
+    matrix_values: Option<&HashMap<String, serde_json::Value>>,
+) -> Option<Vec<String>> {
+    if let Some(files) = matrix_values
+        .and_then(|m| m.get("_meta_files"))
+        .and_then(butterflow_models::variable::value_to_string_vec)
+    {
+        return Some(files);
+    }
+    state
+        .get("_meta_files")
+        .and_then(butterflow_models::variable::value_to_string_vec)
+}
+
 /// Workflow engine
 pub struct Engine {
     /// State adapter for persisting workflow state
@@ -2650,7 +2670,8 @@ impl Engine {
                     state,
                     task.matrix_values.as_ref(),
                     task_expr_ctx,
-                )?;
+                )?
+                .or_else(|| auto_meta_files_include(state, task.matrix_values.as_ref()));
                 resolved_ast_grep.exclude = resolve_optional_glob_list(
                     &ast_grep.exclude,
                     params,
@@ -2983,14 +3004,7 @@ impl Engine {
             matrix_input.as_ref(),
             task_expr_ctx,
         )?
-        .or_else(|| {
-            // Auto-apply matrix._meta_files as the include list when no
-            // explicit include is configured or resolves to empty.
-            matrix_input
-                .as_ref()
-                .and_then(|m| m.get("_meta_files"))
-                .and_then(butterflow_models::variable::value_to_string_vec)
-        });
+        .or_else(|| auto_meta_files_include(resolved_state_ref, matrix_input.as_ref()));
 
         let resolved_exclude = resolve_optional_glob_list(
             &js_ast_grep.exclude,


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description
Automatically pick up `_meta_files` from state, produced by sharding steps for js-ast-grep and ast-grep steps

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
