### PR TITLE
fix(docs): saml info

### DIFF
--- a/docs/platform/quickstart.mdx
+++ b/docs/platform/quickstart.mdx
@@ -80,7 +80,9 @@ Once you're comfortable with the basics, explore these enterprise capabilities t
 <Card title="Team Management" icon="people-group">
 Add team members to your organization to collaborate on migrations. Invite members and assign roles (Admin, Member, or Viewer) to control access to Campaigns and Insights.
 
-<b>Learn more:</b> [GitHub Integration](/platform/integrations/github#managing-team-members) or [GitLab Integration](/platform/integrations/gitlab#managing-team-members) for detailed instructions on managing team members.
+If your organization uses SAML SSO, users are provisioned automatically on first login and access is controlled through your IdP.
+
+<b>Learn more:</b> [GitHub Integration](/platform/integrations/github#managing-team-members) or [GitLab Integration](/platform/integrations/gitlab#managing-team-members) for manual invites, or [SAML SSO](/platform/saml#user-provisioning-and-access-control) for IdP-based access control.
 </Card>
 
 <Card title="Set up Insights" icon="chart-line-up-down">

--- a/docs/platform/saml.mdx
+++ b/docs/platform/saml.mdx
@@ -169,6 +169,14 @@ Example Okta attribute statements:
 
 After saving, make sure the SAML app is turned **On** for the correct users or organizational units.
 
+## User provisioning and access control
+
+Codemod uses **just-in-time (JIT) provisioning** by default. A user account is created automatically the first time someone signs in through your IdP — there is no separate user import or directory sync to configure.
+
+Because of this, who can access Codemod is controlled by your IdP: only users (or groups) that your IdP administrator assigns to the Codemod SAML app can sign in. To grant or revoke access, update the app assignment in your IdP (for example, in Okta under the app's **Assignments** tab, or in Google Workspace by turning the app **On** for specific organizational units).
+
+Once a user has signed in, an organization Admin can change their **role** (Admin, Member, or Viewer) from **Organization Settings** → **Members**. See [Managing team members](/platform/integrations/github#managing-team-members) for role definitions.
+
 ## Finalize
 
 When setup is complete, let the Codemod team know. We will remove the initial non-SSO login method so the first user also signs in through SSO going forward.

--- a/docs/platform/saml.mdx
+++ b/docs/platform/saml.mdx
@@ -177,6 +177,12 @@ Because of this, who can access Codemod is controlled by your IdP: only users (o
 
 Once a user has signed in, an organization Admin can change their **role** (Admin, Member, or Viewer) from **Organization Settings** → **Members**. See [Managing team members](/platform/integrations/github#managing-team-members) for role definitions.
 
+## Require SSO for all members
+
+After SSO is configured, an organization Admin can enforce SSO-only access from **Organization Settings** → **Security** → **Single Sign-On (SSO)** by toggling **Require SSO for all members** on.
+
+When enabled, members must authenticate through your SSO provider to access the organization. Members without an SSO-linked account will not be able to switch to this organization from the team switcher (top-left corner of the app), even if they previously connected GitHub or GitLab.
+
 ## Finalize
 
 When setup is complete, let the Codemod team know. We will remove the initial non-SSO login method so the first user also signs in through SSO going forward.

--- a/docs/snippets/managing-team-members.mdx
+++ b/docs/snippets/managing-team-members.mdx
@@ -1,5 +1,9 @@
 Add team members to your organization to collaborate on migrations and control access to Campaigns and Insights.
 
+<Note>
+  If your organization uses [SAML SSO](/platform/saml), users are provisioned automatically on first login (JIT) and access is controlled through your IdP — you do not need to invite them manually. Use the steps below to manage roles for users who already exist, or to invite users when SSO is not in use.
+</Note>
+
 <Steps>
   <Step title="Navigate to Organization Settings">
     Go to **Organization Settings** → **Members** in the Codemod app.

--- a/docs/snippets/managing-team-members.mdx
+++ b/docs/snippets/managing-team-members.mdx
@@ -1,7 +1,7 @@
 Add team members to your organization to collaborate on migrations and control access to Campaigns and Insights.
 
 <Note>
-  If your organization uses [SAML SSO](/platform/saml), users are provisioned automatically on first login (JIT) and access is controlled through your IdP — you do not need to invite them manually. Use the steps below to manage roles for users who already exist, or to invite users when SSO is not in use.
+  If your organization uses [SAML SSO](/platform/saml#user-provisioning-and-access-control), users are provisioned automatically on first login (JIT) and access is controlled through your IdP — you do not need to invite them manually. Use the steps below to manage roles for users who already exist, or to invite users when SSO is not in use.
 </Note>
 
 <Steps>


### PR DESCRIPTION
- Document JIT provisioning + IdP-based access control as the default in `docs/platform/saml.mdx`, addressing repeat customer questions (DataDog, Remitly; Linear CMD-4664)

- Cross-link the new section from `docs/platform/quickstart.mdx` Team Management card and the `managing-team-members` snippet to disambiguate manual invite vs. SSO/JIT paths