### PR TITLE
fix(jssg-utils): preserve sibling bindings in removeImport for mixed import statements

### DIFF
--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -775,6 +775,65 @@ function getStatementRangeWithNewline<T extends Language>(
 }
 
 /**
+ * For an ESM `import_statement` that contains a `named_imports` subtree, return
+ * the range of `, { ... }` so it can be spliced out while preserving any
+ * sibling default or namespace binding. Returns null if there is no
+ * `named_imports` child.
+ */
+function getNamedImportsSpliceRange<T extends Language>(
+  importStmt: SgNode<T>,
+  programText: string,
+): { start: number; end: number } | null {
+  const tsStmt = importStmt as unknown as SgNode<TS>;
+  const namedImports = tsStmt.find({ rule: { kind: "named_imports" } });
+  if (!namedImports) return null;
+
+  const range = namedImports.range();
+  let start = range.start.index;
+  const end = range.end.index;
+
+  // Walk back over whitespace to find the comma that joins the default /
+  // namespace binding to the named imports chunk. If there is one, include
+  // it so the resulting statement keeps clean spacing.
+  let i = start - 1;
+  while (i >= 0 && /\s/.test(programText[i] ?? "")) i--;
+  if (i >= 0 && programText[i] === ",") {
+    start = i;
+  }
+
+  return { start, end };
+}
+
+/**
+ * For an ESM `import_statement` that combines a default binding with named
+ * imports, return the range covering the default identifier plus its trailing
+ * `,` / whitespace so only the default is removed.
+ */
+function getDefaultBindingSpliceRange<T extends Language>(
+  importStmt: SgNode<T>,
+  programText: string,
+): { start: number; end: number } | null {
+  const tsStmt = importStmt as unknown as SgNode<TS>;
+  const importClause = tsStmt.find({ rule: { kind: "import_clause" } });
+  if (!importClause) return null;
+
+  const defaultId = importClause.children().find((c) => c.kind() === "identifier");
+  if (!defaultId) return null;
+
+  const range = defaultId.range();
+  const start = range.start.index;
+  let end = range.end.index;
+
+  while (end < programText.length && /\s/.test(programText[end] ?? "")) end++;
+  if (end < programText.length && programText[end] === ",") {
+    end++;
+    while (end < programText.length && /\s/.test(programText[end] ?? "")) end++;
+  }
+
+  return { start, end };
+}
+
+/**
  * Find the range of a specifier including comma/whitespace for clean removal.
  */
 function getSpecifierRangeWithSeparator<T extends Language>(
@@ -1170,6 +1229,21 @@ export function removeImport<T extends Language>(
         }) ?? null;
 
       if (!statement) return null;
+
+      // ESM statements that combine `import default, { named } from 'mod'`
+      // must only drop the default identifier — the named imports survive.
+      const tsStmt = statement as unknown as SgNode<TS>;
+      if (tsStmt.kind() === "import_statement") {
+        const importClause = tsStmt.find({ rule: { kind: "import_clause" } });
+        const hasNamedImports = importClause?.find({ rule: { kind: "named_imports" } }) != null;
+        if (hasNamedImports) {
+          const splice = getDefaultBindingSpliceRange(statement, programText);
+          if (splice) {
+            return { startPos: splice.start, endPos: splice.end, insertedText: "" };
+          }
+        }
+      }
+
       const { start, end } = getStatementRangeWithNewline(statement, programText);
       return { startPos: start, endPos: end, insertedText: "" };
     }
@@ -1212,8 +1286,25 @@ export function removeImport<T extends Language>(
 
       const specifierCount = countSpecifiersInStatement(found.statement);
 
-      // If this is the last specifier, remove the entire statement
+      // If this is the last specifier, remove the entire statement — EXCEPT
+      // when the ESM statement also carries a default or namespace binding,
+      // in which case only the ", { ... }" chunk is removed so the sibling
+      // binding is preserved.
       if (specifierCount <= options.specifiers.length) {
+        const tsStmt = found.statement as unknown as SgNode<TS>;
+        if (tsStmt.kind() === "import_statement") {
+          const importClause = tsStmt.find({ rule: { kind: "import_clause" } });
+          const hasDefault =
+            importClause?.children().some((c) => c.kind() === "identifier") ?? false;
+          const hasNamespace = importClause?.find({ rule: { kind: "namespace_import" } }) != null;
+          if (hasDefault || hasNamespace) {
+            const splice = getNamedImportsSpliceRange(found.statement, programText);
+            if (splice) {
+              return { startPos: splice.start, endPos: splice.end, insertedText: "" };
+            }
+          }
+        }
+
         const { start, end } = getStatementRangeWithNewline(found.statement, programText);
         return { startPos: start, endPos: end, insertedText: "" };
       }

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -865,6 +865,347 @@ function testRemoveSideEffectImportOnlyMatchesSourceField() {
   assert(program.text() === src, "Source must be unchanged");
 }
 
+// ============================================================================
+// === removeImport edge cases ===
+// ============================================================================
+
+// --- Bug #1 regression: removing the only named specifier when a default
+// binding is also present must keep the default intact.
+function testRemoveNamed_LastNamed_KeepsDefault_ESM() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  const edit = removeImport(program, { type: "named", specifiers: ["bar"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\nconsole.log(foo, bar);\n",
+    `Should strip only ", { bar }" and keep default "foo". Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- Bug #2 regression: default + named, but remove the only named specifier
+// when there are multiple named siblings listed (still drops only the ones
+// that exist in this statement).
+function testRemoveNamed_LastNamed_KeepsDefault_MultipleSpecifiersArg() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  // Caller lists more specifiers than actually exist on the statement; must
+  // still not drop the default binding.
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["bar", "unrelated"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\nconsole.log(foo, bar);\n",
+    `Default must survive when the caller over-lists specifiers. Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- Bug #2 regression (TypeScript parse path).
+function testRemoveNamed_LastNamed_KeepsDefault_TSX() {
+  const program = parseProgram("tsx", "import foo, { bar } from 'mod';\nconsole.log(foo, bar);\n");
+  const edit = removeImport(program, { type: "named", specifiers: ["bar"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\nconsole.log(foo, bar);\n",
+    `TSX: should strip only ", { bar }" and keep default "foo". Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- Symmetric bug: removing the default binding when named specifiers are
+// also present must keep the named imports intact.
+function testRemoveDefault_KeepsNamed_ESM() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import { bar } from 'mod';\nconsole.log(foo, bar);\n",
+    `Should strip only "foo, " and keep named import for bar. Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- Default + multiple named specifiers: removing default keeps all named.
+function testRemoveDefault_KeepsNamed_MultipleSpecifiers() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar, baz } from 'mod';\nconsole.log(foo, bar, baz);\n",
+  );
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import { bar, baz } from 'mod';\nconsole.log(foo, bar, baz);\n",
+    `Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- Namespace-only statement: removeImport default must still return null
+// (nothing to remove, namespace alone shouldn't be deleted via default-type).
+function testRemoveDefault_NamespaceOnly_ReturnsNull() {
+  const src = "import * as ns from 'mod';\nconsole.log(ns);\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit === null, "Default removal on namespace-only import must be null");
+  assert(program.text() === src, "Source must be unchanged");
+}
+
+// --- Multi-specifier removal: listing every specifier that exists in the
+// statement removes the whole statement.
+function testRemoveNamed_AllSpecifiersListed_RemovesWholeStatement() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo, bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["foo", "bar"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "console.log(foo, bar);\n",
+    `All specifiers listed → statement removed. Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- Multi-line named imports: removing a middle specifier must not leave
+// dangling commas or blank lines, and must keep the other specifiers.
+function testRemoveNamed_MultiLine_RemoveMiddle() {
+  const src = "import {\n  foo,\n  bar,\n  baz,\n} from 'mod';\nconsole.log(foo, bar, baz);\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "named", specifiers: ["bar"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes(",,"), `Should not produce double commas: ${JSON.stringify(result)}`);
+  const importPortion = result.slice(0, result.indexOf("from 'mod'") + "from 'mod';".length);
+  assert(
+    !/\bbar\b/.test(importPortion),
+    `bar must be gone from import. Got: ${JSON.stringify(importPortion)}`,
+  );
+  assert(/\bfoo\b/.test(importPortion) && /\bbaz\b/.test(importPortion), "foo and baz must remain");
+  assert(result.includes("from 'mod'"), "Must still reference module");
+}
+
+// --- Multi-line named imports: removing the last specifier keeps earlier
+// trailing-comma formatting clean.
+function testRemoveNamed_MultiLine_RemoveLast() {
+  const src = "import {\n  foo,\n  bar,\n  baz,\n} from 'mod';\nconsole.log(foo, bar, baz);\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "named", specifiers: ["baz"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes(",,"), "No double commas");
+  const importPortion = result.slice(0, result.indexOf("from 'mod'") + "from 'mod';".length);
+  assert(
+    !/\bbaz\b/.test(importPortion),
+    `baz must be gone from the import. Got: ${JSON.stringify(importPortion)}`,
+  );
+  assert(/\bfoo\b/.test(importPortion) && /\bbar\b/.test(importPortion), "foo and bar must remain");
+}
+
+// --- `import { foo as bar }` + remove named 'foo' → match by original name,
+// statement removed because it's the only specifier.
+function testRemoveNamed_MatchesByOriginalName_StatementRemoved() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo as bar } from 'mod';\nconsole.log(bar);\n",
+  );
+  const edit = removeImport(program, { type: "named", specifiers: ["foo"], from: "mod" });
+  assert(edit !== null, "Should match by original name");
+  const result = program.commitEdits([edit!]);
+  assert(
+    !result.includes("import"),
+    `Whole statement should be removed: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- `import { foo as bar }` + remove named 'bar' → alias is not a specifier
+// name, so nothing matches, returns null.
+function testRemoveNamed_AliasNotMatched_ReturnsNull() {
+  const src = "import { foo as bar } from 'mod';\nconsole.log(bar);\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "named", specifiers: ["bar"], from: "mod" });
+  assert(edit === null, "Alias name must not match — original name is the specifier");
+  assert(program.text() === src, "Source must be unchanged");
+}
+
+// --- CJS destructured: remove one of two destructured specifiers.
+function testRemoveNamed_CJS_Destructured_RemoveOne() {
+  const program = parseProgram(
+    "javascript",
+    "const { a, b } = require('mod');\nconsole.log(a, b);\n",
+  );
+  const edit = removeImport(program, { type: "named", specifiers: ["a"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    /const\s*\{\s*b\s*\}\s*=\s*require\('mod'\);/.test(result),
+    `Should leave { b } = require('mod'). Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- CJS destructured: removing the only remaining specifier drops the
+// whole declaration.
+function testRemoveNamed_CJS_Destructured_RemoveLast() {
+  const program = parseProgram("javascript", "const { a } = require('mod');\nconsole.log(a);\n");
+  const edit = removeImport(program, { type: "named", specifiers: ["a"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("require"), "Whole declaration should be gone");
+}
+
+// --- CJS pair pattern: removing by original key removes the whole statement
+// when it's the only specifier.
+function testRemoveNamed_CJS_PairPattern_RemoveByOriginal() {
+  const program = parseProgram(
+    "javascript",
+    "const { a: aa } = require('mod');\nconsole.log(aa);\n",
+  );
+  const edit = removeImport(program, { type: "named", specifiers: ["a"], from: "mod" });
+  assert(edit !== null, "Should match pair_pattern by original key");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("require"), "Whole declaration should be gone");
+}
+
+// --- Re-exports (pin behavior: all variants return null since removeImport
+// operates on import-like statements only).
+function testRemoveNamed_ExportFrom_ReturnsNull() {
+  const src = "export { foo } from 'mod';\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "named", specifiers: ["foo"], from: "mod" });
+  assert(edit === null, "export { foo } from 'mod' is not removable via removeImport");
+  assert(program.text() === src, "Source must be unchanged");
+}
+
+function testRemoveDefault_ExportStar_ReturnsNull() {
+  const src = "export * from 'mod';\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit === null, "export * from 'mod' is not a default import");
+  assert(program.text() === src, "Source must be unchanged");
+}
+
+function testRemoveNamespace_ExportNamespace_ReturnsNull() {
+  const src = "export * as ns from 'mod';\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "namespace", from: "mod" });
+  assert(edit === null, "export * as ns from 'mod' is not a namespace import");
+  assert(program.text() === src, "Source must be unchanged");
+}
+
+// --- CRLF line endings: removal must stay consistent and not leave dangling
+// \r characters.
+function testRemoveDefault_CRLF() {
+  const src = "import foo from 'mod';\r\nconsole.log(foo);\r\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "console.log(foo);\r\n",
+    `CRLF source should collapse cleanly. Got: ${JSON.stringify(result)}`,
+  );
+}
+
+function testRemoveNamed_CRLF_KeepsDefault() {
+  const src = "import foo, { bar } from 'mod';\r\nconsole.log(foo, bar);\r\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, { type: "named", specifiers: ["bar"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\r\nconsole.log(foo, bar);\r\n",
+    `CRLF + default preserved. Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- removeSideEffectForms: trailing comment on same line must not be
+// removed along with the side-effect import.
+function testRemoveSideEffectImport_TrailingComment_NotRemoved() {
+  const src = "import 'mod'; // keep me\nconsole.log(1);\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: true,
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(!result.includes("import 'mod'"), "The import must be gone");
+  assert(
+    result.includes("// keep me"),
+    `Trailing comment must survive. Got: ${JSON.stringify(result)}`,
+  );
+}
+
+// --- Two side-effect imports of same module: only one edit returned.
+function testRemoveSideEffectImport_TwoCopies_OnlyOneEdit() {
+  const src = "import 'mod';\nimport 'mod';\nconsole.log(1);\n";
+  const program = parseProgram("javascript", src);
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: true,
+  });
+  assert(edit !== null, "First call should return an edit");
+  const afterFirst = program.commitEdits([edit!]);
+  assert(
+    (afterFirst.match(/import 'mod';/g) || []).length === 1,
+    "Only one of the two side-effect imports should be removed on first call",
+  );
+  // Subsequent call on a fresh parse removes the next.
+  const program2 = parseProgram("javascript", afterFirst);
+  const edit2 = removeImport(program2, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: true,
+  });
+  assert(edit2 !== null, "Second call should remove the remaining one");
+  const afterSecond = program2.commitEdits([edit2!]);
+  assert(!afterSecond.includes("import 'mod'"), "Both copies should now be gone");
+}
+
+// --- TS type-only import: removing the only type specifier removes the
+// entire `import type` statement.
+function testRemoveNamed_TSTypeOnly_StatementRemoved() {
+  const program = parseProgram("typescript", "import type { X } from 'mod';\ntype Y = X;\n");
+  const edit = removeImport(program, { type: "named", specifiers: ["X"], from: "mod" });
+  assert(edit !== null, "Should return an edit for `import type { X }`");
+  const result = program.commitEdits([edit!]);
+  assert(
+    !result.includes("import type"),
+    `Whole statement should be removed. Got: ${JSON.stringify(result)}`,
+  );
+  assert(result.includes("type Y"), "Unrelated code kept");
+}
+
+// --- TS inline type specifier: removing one keeps the other; the `type`
+// keyword on the removed specifier goes away with it.
+function testRemoveNamed_TSInlineType_Other_Remains() {
+  const program = parseProgram("typescript", "import { type X, y } from 'mod';\nconsole.log(y);\n");
+  const edit = removeImport(program, { type: "named", specifiers: ["X"], from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    /import\s*\{\s*y\s*\}\s*from\s*'mod'/.test(result),
+    `Should leave import { y } from 'mod'. Got: ${JSON.stringify(result)}`,
+  );
+  assert(!result.includes("type X"), "Removed inline type specifier must be gone");
+}
+
 function run() {
   // getAllImports tests
   testReturnsEmptyArrayWhenNoImports();
@@ -933,6 +1274,31 @@ function run() {
   testRemoveBareRequireParenthesizedLiteralStillRemoved();
   testRemoveSideEffectImportWithFlag();
   testRemoveSideEffectImportOnlyMatchesSourceField();
+
+  // removeImport edge cases
+  testRemoveNamed_LastNamed_KeepsDefault_ESM();
+  testRemoveNamed_LastNamed_KeepsDefault_MultipleSpecifiersArg();
+  testRemoveNamed_LastNamed_KeepsDefault_TSX();
+  testRemoveDefault_KeepsNamed_ESM();
+  testRemoveDefault_KeepsNamed_MultipleSpecifiers();
+  testRemoveDefault_NamespaceOnly_ReturnsNull();
+  testRemoveNamed_AllSpecifiersListed_RemovesWholeStatement();
+  testRemoveNamed_MultiLine_RemoveMiddle();
+  testRemoveNamed_MultiLine_RemoveLast();
+  testRemoveNamed_MatchesByOriginalName_StatementRemoved();
+  testRemoveNamed_AliasNotMatched_ReturnsNull();
+  testRemoveNamed_CJS_Destructured_RemoveOne();
+  testRemoveNamed_CJS_Destructured_RemoveLast();
+  testRemoveNamed_CJS_PairPattern_RemoveByOriginal();
+  testRemoveNamed_ExportFrom_ReturnsNull();
+  testRemoveDefault_ExportStar_ReturnsNull();
+  testRemoveNamespace_ExportNamespace_ReturnsNull();
+  testRemoveDefault_CRLF();
+  testRemoveNamed_CRLF_KeepsDefault();
+  testRemoveSideEffectImport_TrailingComment_NotRemoved();
+  testRemoveSideEffectImport_TwoCopies_OnlyOneEdit();
+  testRemoveNamed_TSTypeOnly_StatementRemoved();
+  testRemoveNamed_TSInlineType_Other_Remains();
 
   console.log("imports.test.ts: all assertions passed");
 }


### PR DESCRIPTION
## Summary

`removeImport` in `@jssg/utils` would delete the entire `import_statement` whenever it removed the last matching specifier, even when the statement also carried a default or namespace binding. That silently dropped bindings the caller never asked to remove.

This PR fixes the two bugs behind that and adds 23 regression tests to pin behavior across the full edge-case matrix.

## The bug

Given a mixed statement like:

```ts
import foo, { bar } from 'mod';
```

Both directions were broken:

| Call | Before (wrong) | After (fixed) |
| --- | --- | --- |
| `removeImport(p, { type: 'named', specifiers: ['bar'], from: 'mod' })` | whole statement deleted → `foo` also gone | `import foo from 'mod';` |
| `removeImport(p, { type: 'default', from: 'mod' })` | whole statement deleted → `{ bar }` also gone | `import { bar } from 'mod';` |
| `removeImport(p, { type: 'named', specifiers: ['bar', 'unrelated'], from: 'mod' })` | whole statement deleted, even though only `bar` was actually present | `import foo from 'mod';` |

### Root cause

The named branch decided to remove the whole statement whenever `countSpecifiersInStatement(stmt) <= options.specifiers.length`. For `import foo, { bar } from 'mod'` that count is `1` (only `bar` is an `import_specifier`), so the whole statement was deleted and the default binding went with it.

The default branch had the mirror-image problem: it always deleted the whole `import_statement` once `getImport` resolved the default, without checking whether the `import_clause` also held a `named_imports` subtree.

## The fix

Two small helpers splice out just the relevant chunk instead of dropping the whole statement:

- `getNamedImportsSpliceRange(stmt, programText)` — returns the range of `, { ... }` by walking back from `named_imports.range().start` to the joining comma.
- `getDefaultBindingSpliceRange(stmt, programText)` — returns the range of `default identifier` + trailing `,` + whitespace.

`removeImport` now:

1. **Named branch**: before removing the whole statement on the `count <= specifiers.length` path, checks the `import_clause` for a sibling default `identifier` or `namespace_import`. If present, splices out `, { ... }` only.
2. **Default branch**: before removing the whole statement, checks the `import_clause` for a `named_imports` child. If present, splices out the default binding + `,` only.

Non-ESM nodes (CJS `lexical_declaration` / `variable_declaration`) skip the splice path and keep the existing whole-statement removal, which is the right behavior for `const foo = require('mod')` / `const { a, b } = require('mod')`.

## New edge-case tests

Added a dedicated `// === removeImport edge cases ===` section to [`packages/jssg-utils/tests/imports.test.ts`](packages/jssg-utils/tests/imports.test.ts) with 23 tests. Every one of these would have failed on `main` or is a pinned behavior the fix must not regress:

**Mixed-statement regressions (the bug fixes)**

- `testRemoveNamed_LastNamed_KeepsDefault_ESM` — `import foo, { bar } from 'mod'` + remove named `['bar']` → `import foo from 'mod';`.
- `testRemoveNamed_LastNamed_KeepsDefault_MultipleSpecifiersArg` — caller over-lists specifiers, default still survives.
- `testRemoveNamed_LastNamed_KeepsDefault_TSX` — same behavior under the TSX parser.
- `testRemoveDefault_KeepsNamed_ESM` — symmetric case, default removed, named kept.
- `testRemoveDefault_KeepsNamed_MultipleSpecifiers` — default removed with multiple named specifiers still present.

**Pinned / not-regressed behaviors**

- `testRemoveDefault_NamespaceOnly_ReturnsNull` — `import * as ns from 'mod'` + `removeImport default` is still `null`.
- `testRemoveNamed_AllSpecifiersListed_RemovesWholeStatement` — listing every specifier still deletes the whole statement.
- `testRemoveNamed_MultiLine_RemoveMiddle` / `_RemoveLast` — multi-line named imports, no `,,` artifacts.
- `testRemoveNamed_MatchesByOriginalName_StatementRemoved` — `{ foo as bar }` + remove `['foo']` removes the statement.
- `testRemoveNamed_AliasNotMatched_ReturnsNull` — alias name is not a specifier name.
- `testRemoveNamed_CJS_Destructured_RemoveOne` / `_RemoveLast` — `const { a, b } = require('mod')` paths.
- `testRemoveNamed_CJS_PairPattern_RemoveByOriginal` — `const { a: aa } = require('mod')` matches on the original key.
- `testRemoveNamed_ExportFrom_ReturnsNull`, `testRemoveDefault_ExportStar_ReturnsNull`, `testRemoveNamespace_ExportNamespace_ReturnsNull` — `export { ... } from`, `export *`, `export * as ns` are not part of `removeImport`'s surface; they return `null`.
- `testRemoveDefault_CRLF` / `testRemoveNamed_CRLF_KeepsDefault` — CRLF sources stay clean.
- `testRemoveSideEffectImport_TrailingComment_NotRemoved` — trailing `// comment` on a side-effect import line survives.
- `testRemoveSideEffectImport_TwoCopies_OnlyOneEdit` — two copies need two calls.
- `testRemoveNamed_TSTypeOnly_StatementRemoved` — `import type { X } from 'mod'` + remove `['X']` deletes the statement.
- `testRemoveNamed_TSInlineType_Other_Remains` — `import { type X, y } from 'mod'` + remove `['X']` → `import { y } from 'mod'`.

## Test plan

- [x] `pnpm -F @jssg/utils test` — all assertions pass (baseline + 23 new).
- [x] `pnpm -F @jssg/utils typecheck` — clean.
- [x] `pnpm lint` / `pnpm format --check` via pre-commit hook — clean.
- [x] CI on this PR.

Made with [Cursor](https://cursor.com)