### PR TITLE
fix: preserve default imports when removing named imports

### DIFF
--- a/.changeset/small-ways-hear.md
+++ b/.changeset/small-ways-hear.md
@@ -1,0 +1,5 @@
+---
+"@jssg/utils": patch
+---
+
+Fix removeImport to preserve default and namespace imports after removing all specifiers

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -753,6 +753,76 @@ function countSpecifiersInStatement<T extends Language>(statement: SgNode<T>): n
 }
 
 /**
+ * Count how many of the requested specifier names are actually present in the
+ * given import statement. Used to decide whether a named-removal strips every
+ * specifier in the statement (so the clause can go) or just some of them.
+ */
+function countMatchingSpecifiers<T extends Language>(
+  statement: SgNode<T>,
+  specifierNames: readonly string[],
+): number {
+  const tsStmt = statement as unknown as SgNode<TS>;
+  const wanted = new Set(specifierNames);
+  let count = 0;
+
+  if (tsStmt.kind() === "import_statement") {
+    for (const spec of tsStmt.findAll({ rule: { kind: "import_specifier" } })) {
+      const nameNode = spec.field("name");
+      if (nameNode && wanted.has(nameNode.text())) count++;
+    }
+    return count;
+  }
+
+  const objectPattern = tsStmt.find({ rule: { kind: "object_pattern" } });
+  if (!objectPattern) return 0;
+
+  for (const shorthand of objectPattern.findAll({
+    rule: { kind: "shorthand_property_identifier_pattern" },
+  })) {
+    if (wanted.has(shorthand.text())) count++;
+  }
+  for (const pair of objectPattern.findAll({ rule: { kind: "pair_pattern" } })) {
+    const key = pair.field("key");
+    if (key && wanted.has(key.text())) count++;
+  }
+  return count;
+}
+
+/**
+ * Parts of an ESM `import_clause`. An import_statement can pair a default
+ * binding with either a `named_imports` or a `namespace_import`, and removing
+ * one half of such a mixed clause must leave the other half intact.
+ */
+type ImportClauseParts = {
+  defaultIdent: SgNode<TS> | null;
+  namespaceImport: SgNode<TS> | null;
+  namedImports: SgNode<TS> | null;
+};
+
+function analyzeImportClause<T extends Language>(importStmt: SgNode<T>): ImportClauseParts {
+  const tsStmt = importStmt as unknown as SgNode<TS>;
+  const parts: ImportClauseParts = {
+    defaultIdent: null,
+    namespaceImport: null,
+    namedImports: null,
+  };
+  const clause = tsStmt.find({ rule: { kind: "import_clause" } });
+  if (!clause) return parts;
+
+  for (const child of clause.children()) {
+    const k = child.kind();
+    if (k === "identifier" && !parts.defaultIdent) {
+      parts.defaultIdent = child as SgNode<TS>;
+    } else if (k === "namespace_import") {
+      parts.namespaceImport = child as SgNode<TS>;
+    } else if (k === "named_imports") {
+      parts.namedImports = child as SgNode<TS>;
+    }
+  }
+  return parts;
+}
+
+/**
  * Find the full range of a statement including one trailing line ending, if present.
  * Handles CRLF, LF, and legacy lone CR so removal edits stay consistent across platforms.
  */
@@ -1170,6 +1240,22 @@ export function removeImport<T extends Language>(
         }) ?? null;
 
       if (!statement) return null;
+
+      // If the default is paired with a named or namespace clause in the same
+      // import_statement, strip only the default (and the following comma) so
+      // the sibling binding survives.
+      if ((statement as unknown as SgNode<TS>).kind() === "import_statement") {
+        const parts = analyzeImportClause(statement);
+        const sibling = parts.namedImports ?? parts.namespaceImport;
+        if (parts.defaultIdent && sibling) {
+          return {
+            startPos: parts.defaultIdent.range().start.index,
+            endPos: sibling.range().start.index,
+            insertedText: "",
+          };
+        }
+      }
+
       const { start, end } = getStatementRangeWithNewline(statement, programText);
       return { startPos: start, endPos: end, insertedText: "" };
     }
@@ -1186,22 +1272,48 @@ export function removeImport<T extends Language>(
   }
 
   if (options.type === "namespace") {
-    const existing = getImport(program, { type: "default", from: options.from });
-    if (!existing || !existing.isNamespace) return null;
+    // Locate the namespace_import directly by source. Going through getImport
+    // would miss mixed statements like `import foo, * as ns from 'mod'`,
+    // where the default match wins over the namespace fallback.
+    const tsProgram = program as unknown as SgNode<TS, "program">;
+    const namespaceImport = tsProgram.find({
+      rule: {
+        kind: "namespace_import",
+        inside: {
+          stopBy: "end",
+          kind: "import_statement",
+          has: {
+            field: "source",
+            has: {
+              kind: "string_fragment",
+              regex: stringToExactRegexString(options.from),
+            },
+          },
+        },
+      },
+    });
+    if (!namespaceImport) return null;
 
     const statement =
-      allStatements.find((stmt) => {
-        const tsStmt = stmt as unknown as SgNode<TS>;
-        return tsStmt.has({
-          rule: {
-            kind: "namespace_import",
-            has: { kind: "identifier", regex: stringToExactRegexString(existing.alias) },
-          },
-        });
-      }) ?? null;
-
+      (namespaceImport.ancestors().find((a) => a.kind() === "import_statement") as
+        | SgNode<TS>
+        | undefined) ?? null;
     if (!statement) return null;
-    const { start, end } = getStatementRangeWithNewline(statement, programText);
+
+    const parts = analyzeImportClause(statement);
+    if (parts.defaultIdent && parts.namespaceImport) {
+      // Mixed: strip ', * as ns' keeping the default binding.
+      return {
+        startPos: parts.defaultIdent.range().end.index,
+        endPos: parts.namespaceImport.range().end.index,
+        insertedText: "",
+      };
+    }
+
+    const { start, end } = getStatementRangeWithNewline(
+      statement as unknown as SgNode<Language>,
+      programText,
+    );
     return { startPos: start, endPos: end, insertedText: "" };
   }
 
@@ -1211,9 +1323,26 @@ export function removeImport<T extends Language>(
       if (!found) continue;
 
       const specifierCount = countSpecifiersInStatement(found.statement);
+      const matchingCount = countMatchingSpecifiers(found.statement, options.specifiers);
 
-      // If this is the last specifier, remove the entire statement
-      if (specifierCount <= options.specifiers.length) {
+      // When every named specifier in this statement is being removed we can
+      // drop the clause. Compare against the count of matches actually present,
+      // not `options.specifiers.length` — the caller may pass names that don't
+      // exist in this statement.
+      if (matchingCount >= specifierCount) {
+        // If the statement also carries a default binding, strip only the
+        // `, { ... }` portion so the default survives.
+        if ((found.statement as unknown as SgNode<TS>).kind() === "import_statement") {
+          const parts = analyzeImportClause(found.statement);
+          if (parts.defaultIdent && parts.namedImports) {
+            return {
+              startPos: parts.defaultIdent.range().end.index,
+              endPos: parts.namedImports.range().end.index,
+              insertedText: "",
+            };
+          }
+        }
+
         const { start, end } = getStatementRangeWithNewline(found.statement, programText);
         return { startPos: start, endPos: end, insertedText: "" };
       }

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -850,6 +850,148 @@ function testRemoveSideEffectImportWithFlag() {
   assert(result.includes("console.log(1)"), "Should keep other statements");
 }
 
+/** `import foo, { bar } from 'mod'` + remove default → must keep `{ bar }`. */
+function testRemoveDefault_MixedWithNamed_KeepsNamedSibling() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import { bar } from 'mod';\nconsole.log(foo, bar);\n",
+    `Expected default stripped but named kept, got: ${JSON.stringify(result)}`,
+  );
+}
+
+/** `import foo, * as ns from 'mod'` + remove default → must keep `* as ns`. */
+function testRemoveDefault_MixedWithNamespace_KeepsNamespaceSibling() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, * as ns from 'mod';\nconsole.log(foo, ns);\n",
+  );
+  const edit = removeImport(program, { type: "default", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import * as ns from 'mod';\nconsole.log(foo, ns);\n",
+    `Expected default stripped but namespace kept, got: ${JSON.stringify(result)}`,
+  );
+}
+
+/** `import foo, { bar } from 'mod'` + remove last named ['bar'] → must keep `foo`. */
+function testRemoveNamed_LastInMixed_KeepsDefault() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["bar"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\nconsole.log(foo, bar);\n",
+    `Expected named clause stripped but default kept, got: ${JSON.stringify(result)}`,
+  );
+}
+
+/** `import foo, { bar } from 'mod'` + remove ['bar', 'unrelated'] → only `bar` is present; strip just the named clause. */
+function testRemoveNamed_PartiallyPresentInMixed_KeepsDefault() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["bar", "unrelated"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\nconsole.log(foo, bar);\n",
+    `Expected only present specifier removed, got: ${JSON.stringify(result)}`,
+  );
+}
+
+/** Removing ALL named specifiers from a mixed statement drops just the `{ ... }` chunk. */
+function testRemoveNamed_AllInMixed_KeepsDefault() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar, baz } from 'mod';\nconsole.log(foo, bar, baz);\n",
+  );
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["bar", "baz"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\nconsole.log(foo, bar, baz);\n",
+    `Expected named clause stripped, got: ${JSON.stringify(result)}`,
+  );
+}
+
+/** `import foo, { bar, baz } from 'mod'` + remove ['bar'] → keep default AND remaining named. */
+function testRemoveNamed_SubsetOfMixed_KeepsBoth() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, { bar, baz } from 'mod';\nconsole.log(foo, bar, baz);\n",
+  );
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["bar"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    /^import foo, \{\s*baz\s*\} from 'mod';\nconsole\.log\(foo, bar, baz\);\n$/.test(result),
+    `Expected bar removed but foo and baz kept, got: ${JSON.stringify(result)}`,
+  );
+}
+
+/** Guard: options.specifiers may contain names not in the statement — must not delete bindings that were never requested. */
+function testRemoveNamed_OptionsExceedStatement_PureNamedOnlyRemovesMatches() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo, bar } from 'mod';\nconsole.log(foo, bar);\n",
+  );
+  // `unrelated` is not in the statement; only `foo` is actually being removed,
+  // so `bar` must survive.
+  const edit = removeImport(program, {
+    type: "named",
+    specifiers: ["foo", "unrelated"],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import { bar } from 'mod';\nconsole.log(foo, bar);\n",
+    `Expected only foo removed, bar kept, got: ${JSON.stringify(result)}`,
+  );
+}
+
+/** `import foo, * as ns from 'mod'` + remove namespace → must keep `foo`. */
+function testRemoveNamespace_MixedWithDefault_KeepsDefault() {
+  const program = parseProgram(
+    "javascript",
+    "import foo, * as ns from 'mod';\nconsole.log(foo, ns);\n",
+  );
+  const edit = removeImport(program, { type: "namespace", from: "mod" });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import foo from 'mod';\nconsole.log(foo, ns);\n",
+    `Expected namespace stripped but default kept, got: ${JSON.stringify(result)}`,
+  );
+}
+
 /** Only the module source string counts — not other string literals (e.g. import attributes). */
 function testRemoveSideEffectImportOnlyMatchesSourceField() {
   const src = "import 'foo' assert { type: 'mod' };\nconsole.log(1);\n";
@@ -933,6 +1075,14 @@ function run() {
   testRemoveBareRequireParenthesizedLiteralStillRemoved();
   testRemoveSideEffectImportWithFlag();
   testRemoveSideEffectImportOnlyMatchesSourceField();
+  testRemoveDefault_MixedWithNamed_KeepsNamedSibling();
+  testRemoveDefault_MixedWithNamespace_KeepsNamespaceSibling();
+  testRemoveNamed_LastInMixed_KeepsDefault();
+  testRemoveNamed_PartiallyPresentInMixed_KeepsDefault();
+  testRemoveNamed_AllInMixed_KeepsDefault();
+  testRemoveNamed_SubsetOfMixed_KeepsBoth();
+  testRemoveNamed_OptionsExceedStatement_PureNamedOnlyRemovesMatches();
+  testRemoveNamespace_MixedWithDefault_KeepsDefault();
 
   console.log("imports.test.ts: all assertions passed");
 }


### PR DESCRIPTION
<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

`removeImport` in `@jssg/utils` would delete the entire `import_statement` whenever it removed the last matching specifier, even when the statement also carried a default or namespace binding. That silently dropped bindings the caller never asked to remove.

A better implementation for the issue in https://github.com/codemod/codemod/pull/2101

#### The bug

Given a mixed statement like:

```ts
import foo, { bar } from 'mod';
```

Both directions were broken:

| Call | Before (wrong) | After (fixed) |
| --- | --- | --- |
| `removeImport(p, { type: 'named', specifiers: ['bar'], from: 'mod' })` | whole statement deleted → `foo` also gone | `import foo from 'mod';` |
| `removeImport(p, { type: 'default', from: 'mod' })` | whole statement deleted → `{ bar }` also gone | `import { bar } from 'mod';` |
| `removeImport(p, { type: 'named', specifiers: ['bar', 'unrelated'], from: 'mod' })` | whole statement deleted, even though only `bar` was actually present | `import foo from 'mod';` |

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
