### PR TITLE
feat(cli): replace Pro codemod login prompt with free-preview notice

### DIFF
--- a/crates/cli/src/commands/login.rs
+++ b/crates/cli/src/commands/login.rs
@@ -21,16 +21,6 @@ pub struct Command {
     api_key: Option<String>,
 }
 
-impl Command {
-    pub fn new() -> Self {
-        Self {
-            registry: None,
-            scope: None,
-            api_key: None,
-        }
-    }
-}
-
 async fn validate_api_key_and_get_user_info(registry_url: &str, api_key: &str) -> Result<UserInfo> {
     let client = Client::new();
     let user_info_url = format!("{registry_url}/api/auth/oauth2/userinfo");

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -196,17 +196,25 @@ pub async fn handler(
     // how to unlock applying changes + advanced insights.
     let (resolved_package, dry_run) = if resolved_package.dry_run_only {
         if !args.dry_run && !args.no_interactive {
-            println!(
-                "{}",
-                style(
-                    "This is a Pro codemod. Preview changes and insights for free with no login or code sharing. \
-                     Applying changes and advanced insights requires a Pro plan and signing in. \
-                     Learn more: codemod.com/contact."
-                )
-                .yellow()
-            );
-            println!("{}", style("Press any key to proceed.").dim());
-            wait_for_any_key();
+            let notice = style(
+                "This is a Pro codemod. Preview changes and insights for free with no login or code sharing. \
+                 Applying changes and advanced insights requires a Pro plan and signing in. \
+                 Learn more: codemod.com/contact."
+            )
+            .yellow();
+
+            // Only block for a keypress when both stdin and stdout are attached
+            // to a terminal. Otherwise the notice (or the "press any key" line)
+            // would be hidden from the user — e.g. `codemod run <pro> > out.txt`
+            // would silently hang. In that case, route the notice to stderr so
+            // it stays visible and proceed straight into dry-run.
+            if io::stdin().is_terminal() && io::stdout().is_terminal() {
+                println!("{notice}");
+                println!("{}", style("Press any key to proceed.").dim());
+                wait_for_any_key();
+            } else {
+                eprintln!("{notice}");
+            }
         }
 
         let dry_run = if resolved_package.dry_run_only {
@@ -458,13 +466,15 @@ fn legacy_command_error(exit_code: Option<i32>) -> anyhow::Error {
     )
 }
 
-/// Block until the user presses any key. Falls back to a no-op when stdin
-/// isn't a terminal (e.g. piped input) or when raw mode can't be enabled.
+/// Block until the user presses any key. Falls back to a no-op when either
+/// stdin or stdout isn't a terminal (e.g. piped input or redirected output)
+/// or when raw mode can't be enabled. Callers must ensure any prompt they want
+/// the user to read has already been printed to a stream the user can see.
 fn wait_for_any_key() {
     use crossterm::event::{read, Event, KeyEventKind};
     use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 
-    if !io::stdin().is_terminal() {
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         return;
     }
     if enable_raw_mode().is_err() {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -192,61 +192,29 @@ pub async fn handler(
     };
 
     // Auto-force dry-run for non-pro users accessing pro codemods.
-    // Offer login first — if user logs in with a pro account, re-resolve
-    // the package so they get full access.
+    // Show an informational notice explaining what free preview covers and
+    // how to unlock applying changes + advanced insights.
     let (resolved_package, dry_run) = if resolved_package.dry_run_only {
-        let mut resolved = resolved_package;
-        let mut logged_in = false;
-
         if !args.dry_run && !args.no_interactive {
             println!(
                 "{}",
-                style("This is a pro codemod. You can preview changes, but applying them requires a Pro plan.").yellow()
+                style(
+                    "This is a Pro codemod. Preview changes and insights for free with no login or code sharing. \
+                     Applying changes and advanced insights requires a Pro plan and signing in. \
+                     Learn more: codemod.com/contact."
+                )
+                .yellow()
             );
-            let should_login = Confirm::new("Would you like to login now?")
-                .with_default(true)
-                .prompt()
-                .unwrap_or(false);
-
-            if should_login {
-                let login_args = crate::commands::login::Command::new();
-                if let Err(e) = crate::commands::login::handler(&login_args).await {
-                    eprintln!("{}", style(format!("Login failed: {e}")).red());
-                } else {
-                    // Re-resolve to check if user now has pro access
-                    let new_client = create_registry_client(args.registry.clone())?;
-                    match new_client
-                        .resolve_package(&args.package, Some(&registry_url), true, None)
-                        .await
-                    {
-                        Ok(new_resolved) => {
-                            resolved = new_resolved;
-                            logged_in = true;
-                        }
-                        Err(e) => {
-                            eprintln!(
-                                "{}",
-                                style(format!("Failed to re-resolve package: {e}")).red()
-                            );
-                        }
-                    }
-                }
-            }
+            println!("{}", style("Press any key to proceed.").dim());
+            wait_for_any_key();
         }
 
-        if resolved.dry_run_only && !logged_in && !args.dry_run {
-            println!(
-                "{}",
-                style("Running in dry-run mode (preview only).").yellow()
-            );
-        }
-
-        let dry_run = if resolved.dry_run_only {
+        let dry_run = if resolved_package.dry_run_only {
             true
         } else {
             args.dry_run
         };
-        (resolved, dry_run)
+        (resolved_package, dry_run)
     } else {
         (resolved_package, args.dry_run)
     };
@@ -488,6 +456,28 @@ fn legacy_command_error(exit_code: Option<i32>) -> anyhow::Error {
         "Legacy codemod command failed with exit code: {:?}",
         exit_code
     )
+}
+
+/// Block until the user presses any key. Falls back to a no-op when stdin
+/// isn't a terminal (e.g. piped input) or when raw mode can't be enabled.
+fn wait_for_any_key() {
+    use crossterm::event::{read, Event, KeyEventKind};
+    use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+    if !io::stdin().is_terminal() {
+        return;
+    }
+    if enable_raw_mode().is_err() {
+        return;
+    }
+    loop {
+        match read() {
+            Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => break,
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
+    let _ = disable_raw_mode();
 }
 
 fn load_codemod_manifest(codemod_config_path: &Path) -> Result<Option<CodemodManifest>> {

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -217,12 +217,7 @@ pub async fn handler(
             }
         }
 
-        let dry_run = if resolved_package.dry_run_only {
-            true
-        } else {
-            args.dry_run
-        };
-        (resolved_package, dry_run)
+        (resolved_package, true)
     } else {
         (resolved_package, args.dry_run)
     };


### PR DESCRIPTION
## Summary

- When resolving a Pro codemod without Pro entitlement, the CLI now shows a single informational notice instead of prompting the user to log in. The previous flow pushed people toward authentication without a clear path to becoming a paying customer.
- Notice text: *"This is a Pro codemod. Preview changes and insights for free with no login or code sharing. Applying changes and advanced insights requires a Pro plan and signing in. Learn more: codemod.com/contact."* Followed by *"Press any key to proceed."*
- Gated on `resolved_package.dry_run_only` (server-side entitlement signal), so logged-in Pro users with access do not see the notice. Logged-out users and logged-in non-Pro users do.
- `--no-interactive`, `--dry-run`, and non-TTY stdin skip the prompt entirely and go straight into dry-run preview, so scripted callers are unaffected.
- Removed the now-unused `login::Command::new()` constructor that only existed to drive the old in-run login prompt.

## Test plan

- [x] `cargo check -p codemod --all-targets` passes
- [x] `cargo test -p codemod` passes
- [x] Manual: logged out, run a Pro codemod — notice shows, any key proceeds to dry-run preview
- [x] Manual: logged in as Pro user, run the same codemod — no notice, full apply works
- [x] Manual: `codemod run <pro> --no-interactive` — no prompt, dry-run preview runs
- [x] Manual: `codemod run <pro> --dry-run` — no notice, dry-run preview runs
- [x] Manual: `echo "" | codemod run <pro>` — no hang on non-TTY stdin

<img width="1920" height="168" alt="Screenshot 2026-04-21 at 11 09 44 AM" src="https://github.com/user-attachments/assets/51aa0452-6b64-41bb-8102-5ed929043e4f" />


Made with [Cursor](https://cursor.com)