### PR TITLE
feat: sandboxed file system module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tree-sitter-loader",
+ "vfs",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-tree-sitter-sg",

--- a/crates/cli/src/commands/jssg/list_applicable.rs
+++ b/crates/cli/src/commands/jssg/list_applicable.rs
@@ -99,6 +99,7 @@ pub async fn handler(args: &Command) -> Result<()> {
         language: args.language.parse().unwrap(),
         resolver: resolver.clone(),
         capabilities: config.capabilities.clone(),
+        target_directory: None,
     })
     .await?;
     let combined_scan: Option<Arc<CombinedScan<CodemodLang>>> = selector_config

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -331,7 +331,11 @@ pub async fn handler(
 
     // Set the package name so it's stored on the WorkflowRun
     engine.set_name(Some(args.package.clone()));
-    engine.workflow_run_config_mut().enable_managed_git = auto_launch_tui;
+    {
+        let cfg = engine.workflow_run_config_mut();
+        cfg.enable_managed_git = auto_launch_tui;
+        cfg.enable_worktrees = auto_launch_tui;
+    }
     if auto_launch_tui {
         engine.set_quiet(true);
         engine.set_progress_callback(Arc::new(None));

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -331,6 +331,7 @@ pub async fn handler(
 
     // Set the package name so it's stored on the WorkflowRun
     engine.set_name(Some(args.package.clone()));
+    engine.workflow_run_config_mut().enable_managed_git = auto_launch_tui;
     if auto_launch_tui {
         engine.set_quiet(true);
         engine.set_progress_callback(Arc::new(None));

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -153,7 +153,11 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     )?;
 
     engine.set_name(Some(workflow_label));
-    engine.workflow_run_config_mut().enable_managed_git = auto_launch_tui;
+    {
+        let cfg = engine.workflow_run_config_mut();
+        cfg.enable_managed_git = auto_launch_tui;
+        cfg.enable_worktrees = auto_launch_tui;
+    }
     if auto_launch_tui {
         engine.set_quiet(true);
         engine.set_progress_callback(std::sync::Arc::new(None));

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -153,6 +153,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     )?;
 
     engine.set_name(Some(workflow_label));
+    engine.workflow_run_config_mut().enable_managed_git = auto_launch_tui;
     if auto_launch_tui {
         engine.set_quiet(true);
         engine.set_progress_callback(std::sync::Arc::new(None));

--- a/crates/codemod-sandbox/Cargo.toml
+++ b/crates/codemod-sandbox/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1.0", features = [
 ], optional = true }
 bytes = "1.0"
 dashmap = "6"
+vfs = { version = "0.12", optional = true, default-features = false }
 sha2 = "0.10"
 oxc_resolver = "11.13.1"
 oxc = { version = "0.99.0", features = ["transformer", "codegen", "semantic"] }
@@ -86,6 +87,7 @@ native = [
   "language-python",
   "tree-sitter-loader",
   "ast-grep-dynamic",
+  "vfs",
 ]
 jssg-in-memory = ["native"]
 real-fs = ["tokio", "ignore"]

--- a/crates/codemod-sandbox/src/lib.rs
+++ b/crates/codemod-sandbox/src/lib.rs
@@ -13,8 +13,10 @@ pub use metrics::{MetricsContext, MetricsData};
 #[cfg(feature = "native")]
 pub use sandbox::engine::codemod_lang::CodemodLang;
 #[cfg(feature = "jssg-in-memory")]
+pub use sandbox::engine::curated_fs::FileFetcher;
+#[cfg(feature = "jssg-in-memory")]
 pub use sandbox::engine::{
-    execute_codemod_sync, CodemodOutput, ExecutionResult, InMemoryExecutionOptions,
+    execute_codemod_sync, CodemodOutput, ExecutionResult, FsSandbox, InMemoryExecutionOptions,
     ProcessSandbox,
 };
 #[cfg(feature = "jssg-in-memory")]

--- a/crates/codemod-sandbox/src/lib.rs
+++ b/crates/codemod-sandbox/src/lib.rs
@@ -15,6 +15,7 @@ pub use sandbox::engine::codemod_lang::CodemodLang;
 #[cfg(feature = "jssg-in-memory")]
 pub use sandbox::engine::{
     execute_codemod_sync, CodemodOutput, ExecutionResult, InMemoryExecutionOptions,
+    ProcessSandbox,
 };
 #[cfg(feature = "jssg-in-memory")]
 pub use sandbox::resolvers::{InMemoryLoader, InMemoryResolver};

--- a/crates/codemod-sandbox/src/sandbox/engine/curated_fs.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/curated_fs.rs
@@ -1,0 +1,685 @@
+//! Curated filesystem module for codemod sandboxes.
+//!
+//! Exposes a Node.js-compatible `fs` (and `fs/promises`) API that is
+//! constrained to a caller-configured `target_dir` prefix. Any incoming path
+//! is normalized against `target_dir` and rejected with `EACCES` if the
+//! canonical form would escape. The actual storage is a
+//! [`vfs::VfsPath`] so callers can plug in either a `MemoryFS` (in-memory
+//! codemod execution, e.g. pg_ast_grep) or a `PhysicalFS` (CLI) without the
+//! module caring.
+//!
+//! When the caller opts the codemod into the `Fs` llrt capability explicitly,
+//! the llrt fs module is used instead and this curated module is not
+//! registered — see `in_memory_engine.rs` for the wiring.
+
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use rquickjs::{
+    module::{Declarations, Exports, ModuleDef},
+    prelude::{Async, Func, Opt},
+    Ctx, Error, Exception, IntoJs, JsLifetime, Object, Result, Value,
+};
+use vfs::error::VfsErrorKind;
+use vfs::{VfsError, VfsFileType, VfsPath};
+
+/// Fallback resolver invoked when a read targets a path that is inside the
+/// curated sandbox's `target_dir` but isn't present in the backing VFS.
+///
+/// Returning `Ok(Some(bytes))` tells the curated fs to write the bytes into
+/// the VFS (so subsequent reads are pure memory hits) and hand them back to
+/// the codemod. `Ok(None)` means the upstream store confirmed the file
+/// genuinely doesn't exist — the codemod sees `ENOENT`. `Err(msg)` means an
+/// infrastructure failure and surfaces as `EIO`.
+///
+/// Implementations should be cheap to call concurrently and are expected to
+/// dedup in-flight requests themselves (e.g. pg_ast_grep's fetcher uses a
+/// per-path `OnceCell` so 1000 workers asking for the same file block on a
+/// single SPI round-trip).
+pub trait FileFetcher: Send + Sync {
+    fn fetch(&self, path: &str) -> std::result::Result<Option<Vec<u8>>, String>;
+}
+
+/// Stored in rquickjs userdata so module methods can look up the backing
+/// filesystem and prefix.
+#[derive(Clone)]
+pub struct CuratedFsConfig {
+    /// Absolute path prefix that every fs operation must stay within. Incoming
+    /// paths are resolved against this and rejected with `EACCES` if their
+    /// normalized form escapes.
+    pub target_dir: String,
+    /// Backing virtual filesystem. All reads/writes are routed through this.
+    pub root: VfsPath,
+    /// Optional fallback that fills VFS misses from an external store. When
+    /// set, a read that resolves inside `target_dir` but isn't in `root`
+    /// consults the fetcher; fetched bytes are written into `root` so
+    /// subsequent reads (including from other workers sharing `root`) are
+    /// pure memory hits.
+    pub fetcher: Option<Arc<dyn FileFetcher>>,
+}
+
+// `CuratedFsConfig` contains no `'js`-bound references, so the `'js` lifetime
+// in rquickjs userdata is a no-op for it.
+unsafe impl<'js> JsLifetime<'js> for CuratedFsConfig {
+    type Changed<'to> = CuratedFsConfig;
+}
+
+impl CuratedFsConfig {
+    pub fn new(target_dir: impl Into<String>, root: VfsPath) -> Self {
+        Self {
+            target_dir: target_dir.into(),
+            root,
+            fetcher: None,
+        }
+    }
+
+    /// Attach a fallback [`FileFetcher`] that is consulted when a read targets
+    /// a path inside `target_dir` that isn't currently in the VFS.
+    pub fn with_fetcher(mut self, fetcher: Arc<dyn FileFetcher>) -> Self {
+        self.fetcher = Some(fetcher);
+        self
+    }
+
+    fn normalized_target(&self) -> String {
+        let trimmed = self.target_dir.trim_end_matches('/');
+        if trimmed.is_empty() {
+            "/".to_string()
+        } else {
+            trimmed.to_string()
+        }
+    }
+
+    /// Resolve an incoming path against [`Self::target_dir`]. Relative paths
+    /// are resolved beneath `target_dir`; absolute paths are left as-is but
+    /// must normalize to a location inside `target_dir`.
+    fn resolve(&self, input: &str) -> std::result::Result<(String, VfsPath), FsErrorKind> {
+        let target = self.normalized_target();
+        let raw = if input.starts_with('/') {
+            input.to_string()
+        } else if target == "/" {
+            format!("/{input}")
+        } else {
+            format!("{target}/{input}")
+        };
+        let normalized = normalize_path(&raw);
+        let within_target = normalized == target
+            || (target == "/" && normalized.starts_with('/'))
+            || normalized.starts_with(&format!("{target}/"));
+        if !within_target {
+            return Err(FsErrorKind::AccessDenied { path: normalized });
+        }
+        let vfs_path = self
+            .root
+            .join(normalized.trim_start_matches('/'))
+            .map_err(|_| FsErrorKind::InvalidPath {
+                path: normalized.clone(),
+            })?;
+        Ok((normalized, vfs_path))
+    }
+}
+
+/// Normalize a POSIX-style path: strip `.` segments, resolve `..` against
+/// preceding segments, and collapse multiple slashes. Leading `/` is preserved
+/// (required by the prefix check); `..` segments that would escape the root
+/// are clamped at the root.
+fn normalize_path(input: &str) -> String {
+    let absolute = input.starts_with('/');
+    let mut stack: Vec<&str> = Vec::new();
+    for seg in input.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                stack.pop();
+            }
+            s => stack.push(s),
+        }
+    }
+    if absolute {
+        format!("/{}", stack.join("/"))
+    } else {
+        stack.join("/")
+    }
+}
+
+/// Error categories we report back to JavaScript. Each maps to a Node-style
+/// `err.code` string.
+#[derive(Debug)]
+#[allow(dead_code)] // IsDirectory/NotDirectory reserved for future stat-driven paths
+enum FsErrorKind {
+    AccessDenied { path: String },
+    NotFound { path: String },
+    InvalidPath { path: String },
+    IsDirectory { path: String },
+    NotDirectory { path: String },
+    Io { message: String, path: String },
+}
+
+impl FsErrorKind {
+    fn code(&self) -> &'static str {
+        match self {
+            FsErrorKind::AccessDenied { .. } => "EACCES",
+            FsErrorKind::NotFound { .. } => "ENOENT",
+            FsErrorKind::InvalidPath { .. } => "EINVAL",
+            FsErrorKind::IsDirectory { .. } => "EISDIR",
+            FsErrorKind::NotDirectory { .. } => "ENOTDIR",
+            FsErrorKind::Io { .. } => "EIO",
+        }
+    }
+
+    fn path(&self) -> &str {
+        match self {
+            FsErrorKind::AccessDenied { path }
+            | FsErrorKind::NotFound { path }
+            | FsErrorKind::InvalidPath { path }
+            | FsErrorKind::IsDirectory { path }
+            | FsErrorKind::NotDirectory { path }
+            | FsErrorKind::Io { path, .. } => path,
+        }
+    }
+
+    fn message(&self, syscall: &str) -> String {
+        let path = self.path();
+        match self {
+            FsErrorKind::AccessDenied { .. } => {
+                format!("EACCES: permission denied, {syscall} '{path}'")
+            }
+            FsErrorKind::NotFound { .. } => {
+                format!("ENOENT: no such file or directory, {syscall} '{path}'")
+            }
+            FsErrorKind::InvalidPath { .. } => {
+                format!("EINVAL: invalid argument, {syscall} '{path}'")
+            }
+            FsErrorKind::IsDirectory { .. } => {
+                format!("EISDIR: illegal operation on a directory, {syscall} '{path}'")
+            }
+            FsErrorKind::NotDirectory { .. } => {
+                format!("ENOTDIR: not a directory, {syscall} '{path}'")
+            }
+            FsErrorKind::Io { message, .. } => {
+                format!("EIO: {message}, {syscall} '{path}'")
+            }
+        }
+    }
+}
+
+fn throw_fs(ctx: &Ctx<'_>, kind: FsErrorKind, syscall: &str) -> Error {
+    let message = kind.message(syscall);
+    let exc = match Exception::from_message(ctx.clone(), &message) {
+        Ok(e) => e,
+        Err(e) => return e,
+    };
+    let obj = exc.as_object();
+    let _ = obj.set("code", kind.code());
+    let _ = obj.set("syscall", syscall);
+    let _ = obj.set("path", kind.path());
+    exc.throw()
+}
+
+fn map_vfs_err(err: VfsError, path: &str) -> FsErrorKind {
+    match err.kind() {
+        VfsErrorKind::FileNotFound => FsErrorKind::NotFound {
+            path: path.to_string(),
+        },
+        VfsErrorKind::InvalidPath => FsErrorKind::InvalidPath {
+            path: path.to_string(),
+        },
+        _ => FsErrorKind::Io {
+            message: err.to_string(),
+            path: path.to_string(),
+        },
+    }
+}
+
+fn config(ctx: &Ctx<'_>) -> Result<CuratedFsConfig> {
+    ctx.userdata::<CuratedFsConfig>()
+        .map(|r| r.clone())
+        .ok_or_else(|| {
+            Exception::throw_message(ctx, "CuratedFsConfig not installed in runtime userdata")
+        })
+}
+
+// ---------- encoding helpers ----------
+
+fn encoding_from_options<'js>(options: Opt<Value<'js>>) -> Option<String> {
+    let value = options.0?;
+    if let Some(s) = value.as_string() {
+        return s.to_string().ok();
+    }
+    if let Some(obj) = value.as_object() {
+        if let Ok(enc) = obj.get::<_, Option<String>>("encoding") {
+            return enc;
+        }
+    }
+    None
+}
+
+fn recursive_from_options<'js>(options: Opt<Value<'js>>) -> bool {
+    match options.0 {
+        Some(value) => value
+            .as_object()
+            .and_then(|obj| obj.get::<_, Option<bool>>("recursive").ok().flatten())
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+// ---------- sync ops ----------
+
+/// Read raw bytes for `normalized` from `cfg`'s VFS, falling back to
+/// `cfg.fetcher` on FileNotFound. Bytes fetched from the fallback are
+/// written back into the VFS so subsequent reads (including from other
+/// workers sharing `cfg.root`) are pure memory hits.
+fn read_bytes_via_vfs_or_fetcher(
+    ctx: &Ctx<'_>,
+    cfg: &CuratedFsConfig,
+    normalized: &str,
+    vfs_path: &VfsPath,
+) -> Result<Vec<u8>> {
+    match vfs_path.open_file() {
+        Ok(mut file) => {
+            let mut bytes = Vec::new();
+            file.read_to_end(&mut bytes).map_err(|e| {
+                throw_fs(
+                    ctx,
+                    FsErrorKind::Io {
+                        message: e.to_string(),
+                        path: normalized.to_string(),
+                    },
+                    "read",
+                )
+            })?;
+            Ok(bytes)
+        }
+        Err(err) => {
+            if !matches!(err.kind(), VfsErrorKind::FileNotFound) {
+                return Err(throw_fs(ctx, map_vfs_err(err, normalized), "open"));
+            }
+            let Some(fetcher) = &cfg.fetcher else {
+                return Err(throw_fs(
+                    ctx,
+                    FsErrorKind::NotFound {
+                        path: normalized.to_string(),
+                    },
+                    "open",
+                ));
+            };
+            match fetcher.fetch(normalized) {
+                Ok(Some(bytes)) => {
+                    // Populate the VFS so the next read skips the fetcher
+                    // entirely (and so other workers sharing this VFS see
+                    // the file immediately).
+                    if let Some(parent) = parent_of(normalized) {
+                        if let Ok(parent_vfs) = cfg.root.join(parent.trim_start_matches('/')) {
+                            let _ = parent_vfs.create_dir_all();
+                        }
+                    }
+                    match vfs_path.create_file() {
+                        Ok(mut f) => {
+                            let _ = f.write_all(&bytes);
+                        }
+                        // Another worker raced us — if the file now exists,
+                        // proceed with our freshly fetched bytes and let
+                        // their write stand. Any other write failure is
+                        // non-fatal for the current read.
+                        Err(_) => {}
+                    }
+                    Ok(bytes)
+                }
+                Ok(None) => Err(throw_fs(
+                    ctx,
+                    FsErrorKind::NotFound {
+                        path: normalized.to_string(),
+                    },
+                    "open",
+                )),
+                Err(message) => Err(throw_fs(
+                    ctx,
+                    FsErrorKind::Io {
+                        message,
+                        path: normalized.to_string(),
+                    },
+                    "open",
+                )),
+            }
+        }
+    }
+}
+
+fn read_file_sync_impl<'js>(
+    ctx: &Ctx<'js>,
+    path: &str,
+    encoding: Option<String>,
+) -> Result<Value<'js>> {
+    let cfg = config(ctx)?;
+    let (normalized, vfs_path) = cfg.resolve(path).map_err(|e| throw_fs(ctx, e, "open"))?;
+    let bytes = read_bytes_via_vfs_or_fetcher(ctx, &cfg, &normalized, &vfs_path)?;
+    if encoding.is_some() {
+        let s = String::from_utf8_lossy(&bytes).into_owned();
+        s.into_js(ctx)
+    } else {
+        // TODO: return a real Buffer/Uint8Array once llrt_buffer is on the
+        // dependency path. For the curated fs MVP we always decode as UTF-8;
+        // codemods operating on text source don't observe a difference.
+        let s = String::from_utf8_lossy(&bytes).into_owned();
+        s.into_js(ctx)
+    }
+}
+
+fn read_file_sync<'js>(
+    ctx: Ctx<'js>,
+    path: String,
+    options: Opt<Value<'js>>,
+) -> Result<Value<'js>> {
+    let encoding = encoding_from_options(options);
+    read_file_sync_impl(&ctx, &path, encoding)
+}
+
+fn write_file_sync_impl(ctx: &Ctx<'_>, path: &str, data: String) -> Result<()> {
+    let cfg = config(ctx)?;
+    let (normalized, vfs_path) = cfg.resolve(path).map_err(|e| throw_fs(ctx, e, "open"))?;
+    if let Some(parent) = parent_of(&normalized) {
+        let parent_vfs = cfg.root.join(parent.trim_start_matches('/')).map_err(|_| {
+            throw_fs(
+                ctx,
+                FsErrorKind::InvalidPath {
+                    path: parent.clone(),
+                },
+                "mkdir",
+            )
+        })?;
+        parent_vfs
+            .create_dir_all()
+            .map_err(|e| throw_fs(ctx, map_vfs_err(e, &parent), "mkdir"))?;
+    }
+    let mut file = vfs_path
+        .create_file()
+        .map_err(|e| throw_fs(ctx, map_vfs_err(e, &normalized), "open"))?;
+    file.write_all(data.as_bytes()).map_err(|e| {
+        throw_fs(
+            ctx,
+            FsErrorKind::Io {
+                message: e.to_string(),
+                path: normalized.clone(),
+            },
+            "write",
+        )
+    })?;
+    Ok(())
+}
+
+fn write_file_sync(
+    ctx: Ctx<'_>,
+    path: String,
+    data: String,
+    _options: Opt<Value<'_>>,
+) -> Result<()> {
+    write_file_sync_impl(&ctx, &path, data)
+}
+
+fn exists_sync(ctx: Ctx<'_>, path: String) -> Result<bool> {
+    let cfg = config(&ctx)?;
+    let (_, vfs_path) = match cfg.resolve(&path) {
+        Ok(p) => p,
+        // Paths outside target_dir are reported as non-existent rather than
+        // throwing — matches Node's `existsSync` which never throws.
+        Err(_) => return Ok(false),
+    };
+    Ok(vfs_path.exists().unwrap_or(false))
+}
+
+fn readdir_sync(ctx: Ctx<'_>, path: String, _options: Opt<Value<'_>>) -> Result<Vec<String>> {
+    let cfg = config(&ctx)?;
+    let (normalized, vfs_path) = cfg
+        .resolve(&path)
+        .map_err(|e| throw_fs(&ctx, e, "scandir"))?;
+    let iter = vfs_path
+        .read_dir()
+        .map_err(|e| throw_fs(&ctx, map_vfs_err(e, &normalized), "scandir"))?;
+    let prefix = if normalized.ends_with('/') {
+        normalized.clone()
+    } else {
+        format!("{normalized}/")
+    };
+    let mut entries: Vec<String> = iter
+        .map(|p| {
+            let s = p.as_str().to_string();
+            s.strip_prefix(&prefix).unwrap_or(&s).to_string()
+        })
+        .collect();
+    entries.sort();
+    Ok(entries)
+}
+
+fn mkdir_sync(ctx: Ctx<'_>, path: String, options: Opt<Value<'_>>) -> Result<()> {
+    let cfg = config(&ctx)?;
+    let (normalized, vfs_path) = cfg.resolve(&path).map_err(|e| throw_fs(&ctx, e, "mkdir"))?;
+    let recursive = recursive_from_options(options);
+    let result = if recursive {
+        vfs_path.create_dir_all()
+    } else {
+        vfs_path.create_dir()
+    };
+    result.map_err(|e| throw_fs(&ctx, map_vfs_err(e, &normalized), "mkdir"))?;
+    Ok(())
+}
+
+fn stat_sync<'js>(ctx: Ctx<'js>, path: String) -> Result<Object<'js>> {
+    let cfg = config(&ctx)?;
+    let (normalized, vfs_path) = cfg.resolve(&path).map_err(|e| throw_fs(&ctx, e, "stat"))?;
+    let meta = vfs_path
+        .metadata()
+        .map_err(|e| throw_fs(&ctx, map_vfs_err(e, &normalized), "stat"))?;
+    stats_object(&ctx, meta.file_type, meta.len)
+}
+
+fn unlink_sync(ctx: Ctx<'_>, path: String) -> Result<()> {
+    let cfg = config(&ctx)?;
+    let (normalized, vfs_path) = cfg
+        .resolve(&path)
+        .map_err(|e| throw_fs(&ctx, e, "unlink"))?;
+    vfs_path
+        .remove_file()
+        .map_err(|e| throw_fs(&ctx, map_vfs_err(e, &normalized), "unlink"))?;
+    Ok(())
+}
+
+fn stats_object<'js>(ctx: &Ctx<'js>, file_type: VfsFileType, size: u64) -> Result<Object<'js>> {
+    let obj = Object::new(ctx.clone())?;
+    obj.set("size", size as f64)?;
+    let is_file = matches!(file_type, VfsFileType::File);
+    let is_dir = matches!(file_type, VfsFileType::Directory);
+    let is_file_fn = rquickjs::Function::new(ctx.clone(), move || is_file)?;
+    let is_dir_fn = rquickjs::Function::new(ctx.clone(), move || is_dir)?;
+    obj.set("isFile", is_file_fn)?;
+    obj.set("isDirectory", is_dir_fn)?;
+    Ok(obj)
+}
+
+fn parent_of(path: &str) -> Option<String> {
+    let trimmed = path.trim_end_matches('/');
+    let idx = trimmed.rfind('/')?;
+    if idx == 0 {
+        Some("/".to_string())
+    } else {
+        Some(trimmed[..idx].to_string())
+    }
+}
+
+// ---------- promise (async) wrappers ----------
+//
+// The VFS API is synchronous, so the async variants simply wrap the sync
+// logic in an async fn. rquickjs turns the returned future into a JS Promise.
+
+async fn read_file<'js>(
+    ctx: Ctx<'js>,
+    path: String,
+    options: Opt<Value<'js>>,
+) -> Result<Value<'js>> {
+    let encoding = encoding_from_options(options);
+    read_file_sync_impl(&ctx, &path, encoding)
+}
+
+async fn write_file(
+    ctx: Ctx<'_>,
+    path: String,
+    data: String,
+    _options: Opt<Value<'_>>,
+) -> Result<()> {
+    write_file_sync_impl(&ctx, &path, data)
+}
+
+async fn readdir_async(ctx: Ctx<'_>, path: String, options: Opt<Value<'_>>) -> Result<Vec<String>> {
+    readdir_sync(ctx, path, options)
+}
+
+async fn mkdir_async(ctx: Ctx<'_>, path: String, options: Opt<Value<'_>>) -> Result<()> {
+    mkdir_sync(ctx, path, options)
+}
+
+async fn stat_async<'js>(ctx: Ctx<'js>, path: String) -> Result<Object<'js>> {
+    stat_sync(ctx, path)
+}
+
+async fn unlink_async(ctx: Ctx<'_>, path: String) -> Result<()> {
+    unlink_sync(ctx, path)
+}
+
+// ---------- module registration ----------
+
+/// `fs` module — exports the sync API and a `promises` sub-object.
+pub struct CuratedFsModule;
+
+impl ModuleDef for CuratedFsModule {
+    fn declare(declare: &Declarations) -> Result<()> {
+        declare.declare("readFileSync")?;
+        declare.declare("writeFileSync")?;
+        declare.declare("existsSync")?;
+        declare.declare("readdirSync")?;
+        declare.declare("mkdirSync")?;
+        declare.declare("statSync")?;
+        declare.declare("unlinkSync")?;
+        declare.declare("promises")?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        // Verify the config is present up front so import-time failures are
+        // clear rather than showing up on first method call.
+        let _ = config(ctx)?;
+
+        let default = Object::new(ctx.clone())?;
+        let promises = build_promises_object(ctx)?;
+
+        default.set("readFileSync", Func::from(read_file_sync))?;
+        default.set("writeFileSync", Func::from(write_file_sync))?;
+        default.set("existsSync", Func::from(exists_sync))?;
+        default.set("readdirSync", Func::from(readdir_sync))?;
+        default.set("mkdirSync", Func::from(mkdir_sync))?;
+        default.set("statSync", Func::from(stat_sync))?;
+        default.set("unlinkSync", Func::from(unlink_sync))?;
+        default.set("promises", promises.clone())?;
+
+        exports.export("readFileSync", Func::from(read_file_sync))?;
+        exports.export("writeFileSync", Func::from(write_file_sync))?;
+        exports.export("existsSync", Func::from(exists_sync))?;
+        exports.export("readdirSync", Func::from(readdir_sync))?;
+        exports.export("mkdirSync", Func::from(mkdir_sync))?;
+        exports.export("statSync", Func::from(stat_sync))?;
+        exports.export("unlinkSync", Func::from(unlink_sync))?;
+        exports.export("promises", promises)?;
+        exports.export("default", default)?;
+        Ok(())
+    }
+}
+
+/// `fs/promises` module — exports the async/promise-returning variants.
+pub struct CuratedFsPromisesModule;
+
+impl ModuleDef for CuratedFsPromisesModule {
+    fn declare(declare: &Declarations) -> Result<()> {
+        declare.declare("readFile")?;
+        declare.declare("writeFile")?;
+        declare.declare("readdir")?;
+        declare.declare("mkdir")?;
+        declare.declare("stat")?;
+        declare.declare("unlink")?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        let _ = config(ctx)?;
+        let default = build_promises_object(ctx)?;
+
+        exports.export("readFile", Func::from(Async(read_file)))?;
+        exports.export("writeFile", Func::from(Async(write_file)))?;
+        exports.export("readdir", Func::from(Async(readdir_async)))?;
+        exports.export("mkdir", Func::from(Async(mkdir_async)))?;
+        exports.export("stat", Func::from(Async(stat_async)))?;
+        exports.export("unlink", Func::from(Async(unlink_async)))?;
+        exports.export("default", default)?;
+        Ok(())
+    }
+}
+
+fn build_promises_object<'js>(ctx: &Ctx<'js>) -> Result<Object<'js>> {
+    let promises = Object::new(ctx.clone())?;
+    promises.set("readFile", Func::from(Async(read_file)))?;
+    promises.set("writeFile", Func::from(Async(write_file)))?;
+    promises.set("readdir", Func::from(Async(readdir_async)))?;
+    promises.set("mkdir", Func::from(Async(mkdir_async)))?;
+    promises.set("stat", Func::from(Async(stat_async)))?;
+    promises.set("unlink", Func::from(Async(unlink_async)))?;
+    Ok(promises)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vfs::MemoryFS;
+
+    fn make_config() -> CuratedFsConfig {
+        CuratedFsConfig::new("/app", MemoryFS::new().into())
+    }
+
+    #[test]
+    fn resolve_allows_path_under_target() {
+        let cfg = make_config();
+        let (normalized, _) = cfg.resolve("/app/src/foo.ts").unwrap();
+        assert_eq!(normalized, "/app/src/foo.ts");
+    }
+
+    #[test]
+    fn resolve_joins_relative_under_target() {
+        let cfg = make_config();
+        let (normalized, _) = cfg.resolve("src/foo.ts").unwrap();
+        assert_eq!(normalized, "/app/src/foo.ts");
+    }
+
+    #[test]
+    fn resolve_rejects_outside_target() {
+        let cfg = make_config();
+        match cfg.resolve("/etc/passwd") {
+            Err(FsErrorKind::AccessDenied { path }) => assert_eq!(path, "/etc/passwd"),
+            other => panic!("expected AccessDenied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_rejects_dotdot_escape() {
+        let cfg = make_config();
+        match cfg.resolve("/app/../etc/passwd") {
+            Err(FsErrorKind::AccessDenied { path }) => assert_eq!(path, "/etc/passwd"),
+            other => panic!("expected AccessDenied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn normalize_strips_dots_and_resolves_dotdot() {
+        assert_eq!(normalize_path("/app/src/./foo.ts"), "/app/src/foo.ts");
+        assert_eq!(normalize_path("/app/src/../src/foo.ts"), "/app/src/foo.ts");
+        assert_eq!(normalize_path("/app/../etc/passwd"), "/etc/passwd");
+        assert_eq!(normalize_path("/app//src///foo.ts"), "/app/src/foo.ts");
+    }
+}

--- a/crates/codemod-sandbox/src/sandbox/engine/curated_fs.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/curated_fs.rs
@@ -2,8 +2,12 @@
 //!
 //! Exposes a Node.js-compatible `fs` (and `fs/promises`) API that is
 //! constrained to a caller-configured `target_dir` prefix. Any incoming path
-//! is normalized against `target_dir` and rejected with `EACCES` if the
-//! canonical form would escape. The actual storage is a
+//! is lexically normalized (collapsing `.`/`..` and redundant slashes) and
+//! rejected with `EACCES` if the result would escape `target_dir`. When the
+//! VFS is backed by real disk (see [`CuratedFsConfig::with_physical_target_dir`]),
+//! the resolver additionally walks each path component with `symlink_metadata`
+//! and rejects any path that traverses a symlink, so symlinks inside the
+//! repo cannot be used to escape the sandbox. The actual storage is a
 //! [`vfs::VfsPath`] so callers can plug in either a `MemoryFS` (in-memory
 //! codemod execution, e.g. pg_ast_grep) or a `PhysicalFS` (CLI) without the
 //! module caring.
@@ -13,12 +17,13 @@
 //! registered — see `in_memory_engine.rs` for the wiring.
 
 use std::io::{Read, Write};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use rquickjs::{
     module::{Declarations, Exports, ModuleDef},
     prelude::{Async, Func, Opt},
-    Ctx, Error, Exception, IntoJs, JsLifetime, Object, Result, Value,
+    Ctx, Error, Exception, IntoJs, JsLifetime, Object, Result, TypedArray, Value,
 };
 use vfs::error::VfsErrorKind;
 use vfs::{VfsError, VfsFileType, VfsPath};
@@ -56,6 +61,13 @@ pub struct CuratedFsConfig {
     /// subsequent reads (including from other workers sharing `root`) are
     /// pure memory hits.
     pub fetcher: Option<Arc<dyn FileFetcher>>,
+    /// When set, indicates that `root` maps 1:1 to real-disk paths and gives
+    /// the host-filesystem path that corresponds to [`Self::target_dir`]. The
+    /// resolver uses this to additionally reject any requested path that
+    /// traverses a symlink; without this extra check, a `/repo/link/secret`
+    /// where `link` is a symlink to `/etc` would pass the lexical prefix
+    /// guard and let the codemod read outside the sandbox.
+    pub physical_target_dir: Option<PathBuf>,
 }
 
 // `CuratedFsConfig` contains no `'js`-bound references, so the `'js` lifetime
@@ -70,6 +82,7 @@ impl CuratedFsConfig {
             target_dir: target_dir.into(),
             root,
             fetcher: None,
+            physical_target_dir: None,
         }
     }
 
@@ -77,6 +90,17 @@ impl CuratedFsConfig {
     /// a path inside `target_dir` that isn't currently in the VFS.
     pub fn with_fetcher(mut self, fetcher: Arc<dyn FileFetcher>) -> Self {
         self.fetcher = Some(fetcher);
+        self
+    }
+
+    /// Declare that the backing VFS maps 1:1 to real-disk paths (e.g.
+    /// `PhysicalFS::new("/")`) and give the host path corresponding to
+    /// `target_dir`. Enables symlink-safe resolution: any requested path
+    /// whose existing intermediate components include a symlink is rejected
+    /// with `EACCES`, preventing sandbox escape via crafted or pre-existing
+    /// symlinks. Leave unset for in-memory VFS backends.
+    pub fn with_physical_target_dir(mut self, physical_target_dir: PathBuf) -> Self {
+        self.physical_target_dir = Some(physical_target_dir);
         self
     }
 
@@ -91,7 +115,10 @@ impl CuratedFsConfig {
 
     /// Resolve an incoming path against [`Self::target_dir`]. Relative paths
     /// are resolved beneath `target_dir`; absolute paths are left as-is but
-    /// must normalize to a location inside `target_dir`.
+    /// must normalize to a location inside `target_dir`. When
+    /// [`Self::physical_target_dir`] is set, also rejects paths whose
+    /// existing intermediate components include a symlink (so a codemod
+    /// can't escape via `target_dir/link-to-outside/...`).
     fn resolve(&self, input: &str) -> std::result::Result<(String, VfsPath), FsErrorKind> {
         let target = self.normalized_target();
         let raw = if input.starts_with('/') {
@@ -108,6 +135,9 @@ impl CuratedFsConfig {
         if !within_target {
             return Err(FsErrorKind::AccessDenied { path: normalized });
         }
+        if let Some(phys_target) = &self.physical_target_dir {
+            check_no_symlink_escape(phys_target, &target, &normalized)?;
+        }
         let vfs_path = self
             .root
             .join(normalized.trim_start_matches('/'))
@@ -116,6 +146,38 @@ impl CuratedFsConfig {
             })?;
         Ok((normalized, vfs_path))
     }
+}
+
+/// Walk the host-filesystem path corresponding to `normalized` starting from
+/// `phys_target` and reject if any component exists and is a symlink. This
+/// closes the gap that pure lexical normalization leaves open on real disk:
+/// `/repo/link/secret` passes the prefix check even when `link` is a symlink
+/// to `/etc`, and would otherwise let a codemod read outside the sandbox.
+/// Components that don't exist yet (e.g. when writing a fresh file) are
+/// ignored — no symlink can exist at a missing path.
+fn check_no_symlink_escape(
+    phys_target: &Path,
+    normalized_target: &str,
+    normalized: &str,
+) -> std::result::Result<(), FsErrorKind> {
+    let rel = normalized
+        .strip_prefix(normalized_target)
+        .unwrap_or(normalized)
+        .trim_start_matches('/');
+    let mut cursor = phys_target.to_path_buf();
+    for component in Path::new(rel).components() {
+        if let Component::Normal(name) = component {
+            cursor.push(name);
+            if let Ok(meta) = std::fs::symlink_metadata(&cursor) {
+                if meta.file_type().is_symlink() {
+                    return Err(FsErrorKind::AccessDenied {
+                        path: normalized.to_string(),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Normalize a POSIX-style path: strip `.` segments, resolve `..` against
@@ -313,15 +375,12 @@ fn read_bytes_via_vfs_or_fetcher(
                             let _ = parent_vfs.create_dir_all();
                         }
                     }
-                    match vfs_path.create_file() {
-                        Ok(mut f) => {
-                            let _ = f.write_all(&bytes);
-                        }
-                        // Another worker raced us — if the file now exists,
-                        // proceed with our freshly fetched bytes and let
-                        // their write stand. Any other write failure is
-                        // non-fatal for the current read.
-                        Err(_) => {}
+                    // Another worker raced us — if the file now exists,
+                    // proceed with our freshly fetched bytes and let
+                    // their write stand. Any other write failure is
+                    // non-fatal for the current read.
+                    if let Ok(mut f) = vfs_path.create_file() {
+                        let _ = f.write_all(&bytes);
                     }
                     Ok(bytes)
                 }
@@ -354,14 +413,17 @@ fn read_file_sync_impl<'js>(
     let (normalized, vfs_path) = cfg.resolve(path).map_err(|e| throw_fs(ctx, e, "open"))?;
     let bytes = read_bytes_via_vfs_or_fetcher(ctx, &cfg, &normalized, &vfs_path)?;
     if encoding.is_some() {
+        // Node decodes as UTF-8 when `encoding` is "utf-8"/"utf8". For any
+        // other encoding we still hand back a string — the curated fs MVP
+        // doesn't implement per-encoding decoders. Codemods operating on
+        // text source don't observe a difference.
         let s = String::from_utf8_lossy(&bytes).into_owned();
         s.into_js(ctx)
     } else {
-        // TODO: return a real Buffer/Uint8Array once llrt_buffer is on the
-        // dependency path. For the curated fs MVP we always decode as UTF-8;
-        // codemods operating on text source don't observe a difference.
-        let s = String::from_utf8_lossy(&bytes).into_owned();
-        s.into_js(ctx)
+        // Match Node semantics: without `encoding`, return a Uint8Array so
+        // callers that `Buffer.from(...)` or otherwise treat the result as
+        // binary data behave the same as they do under Node.
+        TypedArray::<u8>::new(ctx.clone(), bytes).map(|ta| ta.into_value())
     }
 }
 
@@ -681,5 +743,68 @@ mod tests {
         assert_eq!(normalize_path("/app/src/../src/foo.ts"), "/app/src/foo.ts");
         assert_eq!(normalize_path("/app/../etc/passwd"), "/etc/passwd");
         assert_eq!(normalize_path("/app//src///foo.ts"), "/app/src/foo.ts");
+    }
+
+    /// When `physical_target_dir` is set, traversing a symlink — even one
+    /// whose lexical form stays under `target_dir` — must be rejected. This
+    /// is the gap pure lexical normalization leaves open on real disk.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_with_physical_target_dir_rejects_symlink_traversal() {
+        use std::os::unix::fs::symlink;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir(&repo).unwrap();
+        std::fs::create_dir(&outside).unwrap();
+        std::fs::write(outside.join("secret"), "leaked").unwrap();
+        symlink(&outside, repo.join("link")).unwrap();
+
+        let repo_str = repo.to_string_lossy().into_owned();
+        let cfg = CuratedFsConfig::new(repo_str.clone(), MemoryFS::new().into())
+            .with_physical_target_dir(repo.clone());
+
+        // Lexically under target_dir, but traverses a symlink — must be
+        // rejected so the codemod can't read `outside/secret`.
+        let traversal = format!("{repo_str}/link/secret");
+        match cfg.resolve(&traversal) {
+            Err(FsErrorKind::AccessDenied { path }) => assert_eq!(path, traversal),
+            other => panic!("expected AccessDenied, got {other:?}"),
+        }
+
+        // A non-existent path under target_dir is fine — no symlink can
+        // live at a path that doesn't exist, and writes need to resolve
+        // parents even when the file itself is absent.
+        let fresh = format!("{repo_str}/fresh.ts");
+        assert!(cfg.resolve(&fresh).is_ok());
+
+        // Regular files inside target_dir still resolve.
+        std::fs::write(repo.join("ok.ts"), "ok").unwrap();
+        let ok = format!("{repo_str}/ok.ts");
+        assert!(cfg.resolve(&ok).is_ok());
+    }
+
+    /// Without `physical_target_dir` (in-memory VFS backends like pg_ast_grep),
+    /// the symlink check is skipped — MemoryFS has no symlinks, and poking
+    /// the host filesystem would be both wrong and slow.
+    #[cfg(unix)]
+    #[test]
+    fn resolve_without_physical_target_dir_skips_symlink_check() {
+        use std::os::unix::fs::symlink;
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        symlink(temp.path().join("outside"), repo.join("link")).unwrap();
+
+        // target_dir matches the host repo path but `physical_target_dir`
+        // is intentionally unset — this is the in-memory engine's profile.
+        let repo_str = repo.to_string_lossy().into_owned();
+        let cfg = CuratedFsConfig::new(repo_str.clone(), MemoryFS::new().into());
+
+        // Without the symlink check, lexical resolution alone succeeds; the
+        // VFS (here MemoryFS) is what ultimately serves the read and it has
+        // no concept of the host symlink.
+        let traversal = format!("{repo_str}/link/secret");
+        assert!(cfg.resolve(&traversal).is_ok());
     }
 }

--- a/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
@@ -349,7 +349,12 @@ where
 
         if let Some(target_dir) = curated_fs_target.clone() {
             let physical_root: vfs::VfsPath = vfs::PhysicalFS::new(std::path::PathBuf::from("/")).into();
-            ctx.store_userdata(CuratedFsConfig::new(target_dir, physical_root))
+            // PhysicalFS is rooted at "/", so `target_dir` is already the
+            // host-disk path corresponding to the VFS target. Hand it through
+            // so the resolver can reject paths that traverse a symlink.
+            let cfg = CuratedFsConfig::new(target_dir.clone(), physical_root)
+                .with_physical_target_dir(std::path::PathBuf::from(&target_dir));
+            ctx.store_userdata(cfg)
                 .map_err(|e| ExecutionError::Runtime {
                     source: crate::sandbox::errors::RuntimeError::InitializationFailed {
                         message: format!("Failed to store CuratedFsConfig: {:?}", e),
@@ -782,7 +787,12 @@ where
 
         if let Some(target_dir) = curated_fs_target.clone() {
             let physical_root: vfs::VfsPath = vfs::PhysicalFS::new(std::path::PathBuf::from("/")).into();
-            ctx.store_userdata(CuratedFsConfig::new(target_dir, physical_root))
+            // See the selector-config callsite above: PhysicalFS is rooted
+            // at "/", so target_dir already names the host path and can be
+            // reused for the symlink-safe check.
+            let cfg = CuratedFsConfig::new(target_dir.clone(), physical_root)
+                .with_physical_target_dir(std::path::PathBuf::from(&target_dir));
+            ctx.store_userdata(cfg)
                 .map_err(|e| ExecutionError::Runtime {
                     source: crate::sandbox::errors::RuntimeError::InitializationFailed {
                         message: format!("Failed to store CuratedFsConfig: {:?}", e),

--- a/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
@@ -1,4 +1,5 @@
 use super::codemod_lang::CodemodLang;
+use super::curated_fs::{CuratedFsConfig, CuratedFsModule, CuratedFsPromisesModule};
 use super::quickjs_adapters::{QuickJSLoader, QuickJSResolver};
 use super::transform_helpers::{
     build_transform_options, process_transform_result, ModificationCheck,
@@ -201,6 +202,10 @@ where
     // Create AstGrep instance for the SgRootRjs
     let ast_grep = AstGrep::new(options.content, options.language);
 
+    // Track whether the caller opted into llrt's real-disk fs capability
+    // so we know whether to install the curated fs below instead.
+    let mut fs_capability_enabled = false;
+
     // Set up built-in modules
     let mut module_builder = LlrtModuleBuilder::build();
     if let Some(capabilities) = options.capabilities {
@@ -211,6 +216,7 @@ where
                 }
                 LlrtSupportedModules::Fs => {
                     module_builder.enable_fs();
+                    fs_capability_enabled = true;
                 }
                 LlrtSupportedModules::ChildProcess => {
                     module_builder.enable_child_process();
@@ -219,6 +225,17 @@ where
             }
         }
     }
+
+    // Install the curated `fs` when the caller gave us a target directory
+    // and didn't explicitly opt into the unrestricted llrt fs.
+    let curated_fs_target = if !fs_capability_enabled {
+        options
+            .target_directory
+            .map(|p| p.to_string_lossy().into_owned())
+    } else {
+        None
+    };
+
     let (mut built_in_resolver, mut built_in_loader, global_attachment) =
         module_builder.builder.build();
     // Add AstGrepModule
@@ -236,6 +253,13 @@ where
     // Add RuntimeModule (progress/failure hooks)
     built_in_resolver = built_in_resolver.add_name("codemod:runtime");
     built_in_loader = built_in_loader.with_module("codemod:runtime", RuntimeModule);
+
+    if curated_fs_target.is_some() {
+        built_in_resolver = built_in_resolver.add_name("fs").add_name("fs/promises");
+        built_in_loader = built_in_loader
+            .with_module("fs", CuratedFsModule)
+            .with_module("fs/promises", CuratedFsPromisesModule);
+    }
 
     let fs_resolver = QuickJSResolver::new(Arc::clone(&options.resolver));
     let fs_loader = QuickJSLoader;
@@ -322,6 +346,16 @@ where
                 message: format!("Failed to store RuntimeHooksContext: {:?}", e),
             },
         })?;
+
+        if let Some(target_dir) = curated_fs_target.clone() {
+            let physical_root: vfs::VfsPath = vfs::PhysicalFS::new(std::path::PathBuf::from("/")).into();
+            ctx.store_userdata(CuratedFsConfig::new(target_dir, physical_root))
+                .map_err(|e| ExecutionError::Runtime {
+                    source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                        message: format!("Failed to store CuratedFsConfig: {:?}", e),
+                    },
+                })?;
+        }
 
         global_attachment.attach(&ctx).map_err(|e| ExecutionError::Runtime {
             source: crate::sandbox::errors::RuntimeError::InitializationFailed {
@@ -622,6 +656,12 @@ pub struct ShardFunctionOptions<'a, R> {
     /// Optional capabilities to gate module access (fetch, fs, child_process).
     /// When `None`, no extra modules are enabled.
     pub capabilities: Option<HashSet<LlrtSupportedModules>>,
+    /// Directory the curated `fs` module is constrained to. When `Some`
+    /// and the caller hasn't opted into the llrt `Fs` capability, the
+    /// shard function's `import "fs"` resolves to the curated fs backed
+    /// by `vfs::PhysicalFS` at disk root `/`, prefix-checked against this
+    /// path.
+    pub target_directory: Option<&'a Path>,
 }
 
 /// Execute a shard function with QuickJS and return the result as JSON.
@@ -655,6 +695,7 @@ where
         },
     })?;
 
+    let mut fs_capability_enabled = false;
     let mut module_builder = LlrtModuleBuilder::build();
     if let Some(capabilities) = options.capabilities {
         for capability in capabilities {
@@ -664,6 +705,7 @@ where
                 }
                 LlrtSupportedModules::Fs => {
                     module_builder.enable_fs();
+                    fs_capability_enabled = true;
                 }
                 LlrtSupportedModules::ChildProcess => {
                     module_builder.enable_child_process();
@@ -672,6 +714,14 @@ where
             }
         }
     }
+
+    let curated_fs_target = if !fs_capability_enabled {
+        options
+            .target_directory
+            .map(|p| p.to_string_lossy().into_owned())
+    } else {
+        None
+    };
 
     let (mut built_in_resolver, mut built_in_loader, global_attachment) =
         module_builder.builder.build();
@@ -687,6 +737,13 @@ where
 
     built_in_resolver = built_in_resolver.add_name("codemod:runtime");
     built_in_loader = built_in_loader.with_module("codemod:runtime", RuntimeModule);
+
+    if curated_fs_target.is_some() {
+        built_in_resolver = built_in_resolver.add_name("fs").add_name("fs/promises");
+        built_in_loader = built_in_loader
+            .with_module("fs", CuratedFsModule)
+            .with_module("fs/promises", CuratedFsPromisesModule);
+    }
 
     let fs_resolver = QuickJSResolver::new(Arc::clone(&options.resolver));
     let fs_loader = QuickJSLoader;
@@ -722,6 +779,16 @@ where
                 message: format!("Failed to store RuntimeHooksContext: {:?}", e),
             },
         })?;
+
+        if let Some(target_dir) = curated_fs_target.clone() {
+            let physical_root: vfs::VfsPath = vfs::PhysicalFS::new(std::path::PathBuf::from("/")).into();
+            ctx.store_userdata(CuratedFsConfig::new(target_dir, physical_root))
+                .map_err(|e| ExecutionError::Runtime {
+                    source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                        message: format!("Failed to store CuratedFsConfig: {:?}", e),
+                    },
+                })?;
+        }
 
         global_attachment.attach(&ctx).map_err(|e| ExecutionError::Runtime {
             source: crate::sandbox::errors::RuntimeError::InitializationFailed {
@@ -1508,6 +1575,7 @@ export default function shard(input) {
                 "state": {}
             }),
             capabilities: None,
+            target_directory: None,
         };
 
         let result = execute_shard_function_with_quickjs(options).await;

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -738,6 +738,83 @@ export default function transform(root) {
         }
     }
 
+    /// `readFileSync` without an `encoding` argument must return a Uint8Array
+    /// to match Node. Codemods doing binary reads (or calling `Buffer.from`
+    /// on the result) rely on this; an accidental UTF-8 string would lose
+    /// non-text bytes and break length-based checks.
+    #[test]
+    fn test_fs_sandbox_read_without_encoding_returns_uint8array() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        let codemod_content = r#"
+import fs from "fs";
+export default function transform(root) {
+  const buf = fs.readFileSync("/app/sibling.ts");
+  const parts = [
+    "typed=" + (buf instanceof Uint8Array),
+    "len=" + buf.byteLength,
+    "b0=" + buf[0],
+    "b1=" + buf[1],
+  ];
+  const txt = fs.readFileSync("/app/sibling.ts", "utf-8");
+  parts.push("utf=" + (typeof txt));
+  parts.push("eq=" + (txt === "hi"));
+  return parts.join(";");
+}
+        "#
+        .trim();
+
+        fs::write(temp_dir.path().join("fs_bytes_codemod.js"), codemod_content)
+            .expect("Failed to write codemod file");
+
+        let root = build_memory_fs_with_files(&[
+            ("/app/main.ts", "const x = 1;"),
+            ("/app/sibling.ts", "hi"),
+        ]);
+        let fs_sandbox = FsSandbox {
+            target_dir: "/app".to_string(),
+            root: root.clone(),
+            fetcher: None,
+        };
+
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = "const x = 1;";
+        let ast = AstGrep::new(content, js_lang());
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: Some("/app/main.ts"),
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: Some(fs_sandbox),
+        });
+
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => {
+                    // 'h' = 0x68 = 104, 'i' = 0x69 = 105
+                    assert_eq!(
+                        modified.content,
+                        "typed=true;len=2;b0=104;b1=105;utf=string;eq=true",
+                    );
+                }
+                other => panic!("Expected modified result, got: {:?}", other),
+            },
+            Err(e) => panic!("Expected success, got error: {:?}", e),
+        }
+    }
+
     /// Mirror pg_ast_grep's batch flow: run the same fs-using codemod across
     /// many files sequentially (one tokio runtime + one QuickJS runtime per
     /// file, just like execute_codemod_sync on each Rayon worker). If the fs

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -1,4 +1,5 @@
 use super::codemod_lang::CodemodLang;
+use super::curated_fs::{CuratedFsConfig, CuratedFsModule, CuratedFsPromisesModule, FileFetcher};
 use super::execution_engine::{CodemodOutput, ExecutionResult};
 use super::quickjs_adapters::QuickJSResolver;
 use super::transform_helpers::{
@@ -24,6 +25,7 @@ use std::marker::PhantomData;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
+use vfs::VfsPath;
 
 /// Default execution timeout in milliseconds (180s)
 const DEFAULT_TIMEOUT_MS: u64 = 180000;
@@ -44,6 +46,27 @@ pub struct ProcessSandbox {
     pub env: HashMap<String, String>,
     /// Value returned by `process.cwd()`.
     pub cwd: String,
+}
+
+/// Curated filesystem sandbox. When attached to
+/// [`InMemoryExecutionOptions::fs_sandbox`], the codemod's `fs` import is
+/// backed by `root` and constrained to paths beneath `target_dir`.
+///
+/// When the caller instead opts the codemod into the `Fs` llrt capability,
+/// llrt's real-disk fs is used and this option is ignored.
+#[derive(Clone)]
+pub struct FsSandbox {
+    /// Absolute prefix that the codemod is allowed to read/write. Paths that
+    /// normalize outside this prefix are rejected with `EACCES`.
+    pub target_dir: String,
+    /// Backing VFS. For pg_ast_grep this is a pre-populated `MemoryFS`; for
+    /// CLI runs it would be a `PhysicalFS` rooted at `/`.
+    pub root: VfsPath,
+    /// Optional fallback consulted on VFS miss. Typically used by
+    /// pg_ast_grep to lazily pull sibling files from Postgres so a read of
+    /// a shared config that isn't pre-loaded in the per-file MemoryFS
+    /// succeeds instead of returning `ENOENT`.
+    pub fetcher: Option<Arc<dyn FileFetcher>>,
 }
 
 /// In-memory execution options for executing a codemod on a pre-parsed AST
@@ -84,6 +107,14 @@ pub struct InMemoryExecutionOptions<'a, R> {
     /// When `None`, the host-derived defaults from llrt_modules remain in
     /// place.
     pub process_sandbox: Option<ProcessSandbox>,
+    /// Optional curated filesystem sandbox.
+    ///
+    /// When `Some`, a curated `fs` / `fs/promises` module backed by the
+    /// provided `VfsPath` is registered and constrained to `target_dir`.
+    /// When `None`, no fs module is provided (codemods that `import "fs"`
+    /// will fail to resolve unless the caller separately enables the llrt
+    /// `Fs` capability).
+    pub fs_sandbox: Option<FsSandbox>,
 }
 
 /// Execute a codemod synchronously by blocking on the async runtime
@@ -179,6 +210,16 @@ where
     built_in_resolver = built_in_resolver.add_name("codemod:workflow");
     built_in_loader = built_in_loader.with_module("codemod:workflow", WorkflowGlobalModule);
 
+    // Register the curated fs module as `fs` / `fs/promises` when the caller
+    // asked for a curated sandbox. The config is installed into userdata
+    // below so the module can find it on first import.
+    if options.fs_sandbox.is_some() {
+        built_in_resolver = built_in_resolver.add_name("fs").add_name("fs/promises");
+        built_in_loader = built_in_loader
+            .with_module("fs", CuratedFsModule)
+            .with_module("fs/promises", CuratedFsPromisesModule);
+    }
+
     let in_memory_resolver = QuickJSResolver::new(Arc::clone(&resolver_arc));
     let noop_loader = InMemoryLoader::new(Arc::clone(&resolver_arc));
 
@@ -201,6 +242,7 @@ where
     let metrics_context = options.metrics_context.clone();
     let shared_state_context = options.shared_state_context.clone();
     let process_sandbox = options.process_sandbox.clone();
+    let fs_sandbox = options.fs_sandbox.clone();
 
     let timeout_exceeded_check = Arc::clone(&timeout_exceeded);
 
@@ -220,6 +262,20 @@ where
                 message: format!("Failed to store SharedStateContext: {:?}", e),
             },
         })?;
+
+        // Install the curated fs config before the codemod module evaluates
+        // so its first `import "fs"` resolves against the right root.
+        if let Some(sandbox) = fs_sandbox {
+            let mut cfg = CuratedFsConfig::new(sandbox.target_dir, sandbox.root);
+            if let Some(fetcher) = sandbox.fetcher {
+                cfg = cfg.with_fetcher(fetcher);
+            }
+            ctx.store_userdata(cfg).map_err(|e| ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                    message: format!("Failed to store CuratedFsConfig: {:?}", e),
+                },
+            })?;
+        }
 
         global_attachment.attach(&ctx).map_err(|e| ExecutionError::Runtime {
             source: crate::sandbox::errors::RuntimeError::InitializationFailed {
@@ -435,6 +491,7 @@ export default function transform(root) {
             timeout_ms: Some(50), // 50ms timeout for faster test
             memory_limit: None,
             process_sandbox: None,
+            fs_sandbox: None,
         });
 
         match result {
@@ -493,6 +550,7 @@ export default function transform(root) {
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: None,
+            fs_sandbox: None,
         });
 
         match result {
@@ -562,6 +620,7 @@ export default function transform(root) {
             timeout_ms: None,
             memory_limit: None,
             process_sandbox: Some(sandbox),
+            fs_sandbox: None,
         });
 
         match result {
@@ -571,6 +630,445 @@ export default function transform(root) {
                         modified.content,
                         "cwd=/app/;env=;keys=cwd,env;stripped=undefined,undefined,undefined,undefined",
                     );
+                }
+                other => panic!("Expected modified result, got: {:?}", other),
+            },
+            Err(e) => panic!("Expected success, got error: {:?}", e),
+        }
+    }
+
+    /// Build a MemoryFS-backed sandbox that contains the target file plus a
+    /// sibling the codemod can try to read/write. Returns the VfsPath root.
+    fn build_memory_fs_with_files(files: &[(&str, &str)]) -> vfs::VfsPath {
+        let root: vfs::VfsPath = vfs::MemoryFS::new().into();
+        for (path, content) in files {
+            if let Some(parent) = std::path::Path::new(path).parent() {
+                let p = parent.to_string_lossy();
+                if !p.is_empty() {
+                    let parent_vfs = root.join(p.trim_start_matches('/')).unwrap();
+                    let _ = parent_vfs.create_dir_all();
+                }
+            }
+            let file = root.join(path.trim_start_matches('/')).unwrap();
+            let mut w = file.create_file().unwrap();
+            use std::io::Write;
+            w.write_all(content.as_bytes()).unwrap();
+        }
+        root
+    }
+
+    /// Curated fs must expose allowed files to the sandbox while rejecting
+    /// paths that escape `target_dir`.
+    #[test]
+    fn test_fs_sandbox_allows_read_and_rejects_escape() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        // Codemod emits a summary of fs behaviour:
+        //   (1) successful read of a sibling inside target_dir
+        //   (2) error `.code` when reading outside target_dir
+        //   (3) error `.code` when reading a missing file inside target_dir
+        let codemod_content = r#"
+import fs from "fs";
+export default function transform(root) {
+  const ok = fs.readFileSync("/app/sibling.ts", "utf-8");
+  let escape = "none";
+  try {
+    fs.readFileSync("/etc/passwd", "utf-8");
+  } catch (e) {
+    escape = e.code;
+  }
+  let missing = "none";
+  try {
+    fs.readFileSync("/app/missing.ts", "utf-8");
+  } catch (e) {
+    missing = e.code;
+  }
+  return `ok=${ok};escape=${escape};missing=${missing}`;
+}
+        "#
+        .trim();
+
+        fs::write(temp_dir.path().join("fs_codemod.js"), codemod_content)
+            .expect("Failed to write codemod file");
+
+        let root = build_memory_fs_with_files(&[
+            ("/app/main.ts", "const x = 1;"),
+            ("/app/sibling.ts", "export const y = 2;"),
+        ]);
+        let fs_sandbox = FsSandbox {
+            target_dir: "/app".to_string(),
+            root: root.clone(),
+            fetcher: None,
+        };
+
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = "const x = 1;";
+        let ast = AstGrep::new(content, js_lang());
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: Some("/app/main.ts"),
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: Some(fs_sandbox),
+        });
+
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => {
+                    assert_eq!(
+                        modified.content,
+                        "ok=export const y = 2;;escape=EACCES;missing=ENOENT",
+                    );
+                }
+                other => panic!("Expected modified result, got: {:?}", other),
+            },
+            Err(e) => panic!("Expected success, got error: {:?}", e),
+        }
+    }
+
+    /// Mirror pg_ast_grep's batch flow: run the same fs-using codemod across
+    /// many files sequentially (one tokio runtime + one QuickJS runtime per
+    /// file, just like execute_codemod_sync on each Rayon worker). If the fs
+    /// sandbox path leaves behind poisoned global state (panic handler,
+    /// tokio internals, rquickjs userdata bookkeeping), later files fail
+    /// even though the first-file tests above pass.
+    #[test]
+    fn test_fs_sandbox_batch_like_pg_ast_grep() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        let codemod_content = r#"
+import fs from "fs";
+export default function transform(root) {
+  const content = fs.readFileSync(root.filename(), "utf-8");
+  return content + "\n// touched";
+}
+        "#
+        .trim();
+
+        fs::write(temp_dir.path().join("batch_codemod.js"), codemod_content)
+            .expect("Failed to write codemod file");
+
+        let files: Vec<(String, String)> = (0..16)
+            .map(|i| {
+                (
+                    format!("/app/src/file_{i}.ts"),
+                    format!("export const v{i} = {i};"),
+                )
+            })
+            .collect();
+
+        let mut modified = 0usize;
+        for (idx, (path, content)) in files.iter().enumerate() {
+            let root = build_memory_fs_with_files(&[(path.as_str(), content.as_str())]);
+            let fs_sandbox = FsSandbox {
+                target_dir: "/app".to_string(),
+                root,
+                fetcher: None,
+            };
+            let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+            let ast = AstGrep::new(content.as_str(), js_lang());
+            let out = execute_codemod_sync(InMemoryExecutionOptions {
+                codemod_source: codemod_content,
+                language: js_lang(),
+                ast,
+                original_sha256: Some(compute_sha256(content)),
+                resolver: Some(resolver),
+                selector_config: None,
+                params: None,
+                matrix_values: None,
+                file_path: Some(path.as_str()),
+                semantic_provider: None,
+                metrics_context: None,
+                shared_state_context: None,
+                timeout_ms: None,
+                memory_limit: None,
+                process_sandbox: None,
+                fs_sandbox: Some(fs_sandbox),
+            })
+            .unwrap_or_else(|e| panic!("iteration {idx} failed: {e:?}"));
+            match out.primary {
+                ExecutionResult::Modified(m) => {
+                    assert!(
+                        m.content.ends_with("// touched"),
+                        "iteration {idx} produced unexpected content: {:?}",
+                        m.content
+                    );
+                    modified += 1;
+                }
+                other => panic!("iteration {idx} expected modified, got {other:?}"),
+            }
+        }
+        assert_eq!(modified, files.len());
+    }
+
+    /// `writeFileSync` inside target_dir must land in the backing VFS and be
+    /// visible to subsequent reads; writes outside target_dir must fail.
+    #[test]
+    fn test_fs_sandbox_write_round_trip() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        let codemod_content = r#"
+import fs from "fs";
+export default function transform(root) {
+  fs.writeFileSync("/app/out.ts", "export const z = 3;", "utf-8");
+  const back = fs.readFileSync("/app/out.ts", "utf-8");
+  let denied = "none";
+  try {
+    fs.writeFileSync("/tmp/escape.ts", "leaked", "utf-8");
+  } catch (e) {
+    denied = e.code;
+  }
+  return `back=${back};denied=${denied}`;
+}
+        "#
+        .trim();
+
+        fs::write(temp_dir.path().join("fs_write_codemod.js"), codemod_content)
+            .expect("Failed to write codemod file");
+
+        let root = build_memory_fs_with_files(&[("/app/main.ts", "const x = 1;")]);
+        let fs_sandbox = FsSandbox {
+            target_dir: "/app".to_string(),
+            root: root.clone(),
+            fetcher: None,
+        };
+
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = "const x = 1;";
+        let ast = AstGrep::new(content, js_lang());
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: Some("/app/main.ts"),
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: Some(fs_sandbox),
+        });
+
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => {
+                    assert_eq!(modified.content, "back=export const z = 3;;denied=EACCES",);
+                    // Verify the write actually landed in the MemoryFS (not
+                    // just a runtime illusion) by reading through the VFS.
+                    let written = root.join("app/out.ts").unwrap();
+                    let mut buf = String::new();
+                    use std::io::Read;
+                    written
+                        .open_file()
+                        .unwrap()
+                        .read_to_string(&mut buf)
+                        .unwrap();
+                    assert_eq!(buf, "export const z = 3;");
+                }
+                other => panic!("Expected modified result, got: {:?}", other),
+            },
+            Err(e) => panic!("Expected success, got error: {:?}", e),
+        }
+    }
+
+    /// Hand-crafted fetcher that records every call for test assertions.
+    /// Returns Some(bytes) for keys in the preloaded map, None otherwise.
+    struct RecordingFetcher {
+        files: std::collections::HashMap<String, Vec<u8>>,
+        calls: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl RecordingFetcher {
+        fn new(entries: &[(&str, &str)]) -> Self {
+            let files = entries
+                .iter()
+                .map(|(p, c)| (p.to_string(), c.as_bytes().to_vec()))
+                .collect();
+            Self {
+                files,
+                calls: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    impl crate::sandbox::engine::curated_fs::FileFetcher for RecordingFetcher {
+        fn fetch(&self, path: &str) -> std::result::Result<Option<Vec<u8>>, String> {
+            self.calls.lock().unwrap().push(path.to_string());
+            Ok(self.files.get(path).cloned())
+        }
+    }
+
+    /// When a readFileSync misses the VFS, the configured fetcher should
+    /// fill it in, and subsequent reads of the same path should hit the
+    /// VFS cache (the fetcher is called once even across repeated reads).
+    #[test]
+    fn test_fs_sandbox_fetcher_fills_missing_and_caches() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        let codemod_content = r#"
+import fs from "fs";
+export default function transform(root) {
+  const first = fs.readFileSync("/app/shared/env.ts", "utf-8");
+  const second = fs.readFileSync("/app/shared/env.ts", "utf-8");
+  return `first=${first};second=${second}`;
+}
+        "#
+        .trim();
+
+        fs::write(temp_dir.path().join("fetcher_codemod.js"), codemod_content)
+            .expect("Failed to write codemod file");
+
+        // Only the target file is pre-seeded; env.ts comes from the fetcher.
+        let root = build_memory_fs_with_files(&[("/app/main.ts", "const x = 1;")]);
+        let fetcher = Arc::new(RecordingFetcher::new(&[(
+            "/app/shared/env.ts",
+            "export const ENV = 'prod';",
+        )]));
+        let fs_sandbox = FsSandbox {
+            target_dir: "/app".to_string(),
+            root: root.clone(),
+            fetcher: Some(fetcher.clone()),
+        };
+
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = "const x = 1;";
+        let ast = AstGrep::new(content, js_lang());
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: Some("/app/main.ts"),
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: Some(fs_sandbox),
+        });
+
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => {
+                    assert_eq!(
+                        modified.content,
+                        "first=export const ENV = 'prod';;second=export const ENV = 'prod';",
+                    );
+                }
+                other => panic!("Expected modified result, got: {:?}", other),
+            },
+            Err(e) => panic!("Expected success, got error: {:?}", e),
+        }
+        // Fetcher called exactly once — second read served from the VFS
+        // after the first read wrote the bytes back.
+        assert_eq!(fetcher.call_count(), 1, "fetcher should be called once");
+    }
+
+    /// A fetcher returning `Ok(None)` must surface as `ENOENT`; returning
+    /// `Err` must surface as `EIO`.
+    #[test]
+    fn test_fs_sandbox_fetcher_none_is_enoent_err_is_eio() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        let codemod_content = r#"
+import fs from "fs";
+export default function transform(root) {
+  let missing = "none";
+  try {
+    fs.readFileSync("/app/shared/missing.ts", "utf-8");
+  } catch (e) {
+    missing = e.code;
+  }
+  let failing = "none";
+  try {
+    fs.readFileSync("/app/shared/boom.ts", "utf-8");
+  } catch (e) {
+    failing = e.code;
+  }
+  return `missing=${missing};failing=${failing}`;
+}
+        "#
+        .trim();
+
+        fs::write(
+            temp_dir.path().join("fetcher_err_codemod.js"),
+            codemod_content,
+        )
+        .expect("Failed to write codemod file");
+
+        struct FailingFetcher;
+        impl crate::sandbox::engine::curated_fs::FileFetcher for FailingFetcher {
+            fn fetch(&self, path: &str) -> std::result::Result<Option<Vec<u8>>, String> {
+                if path.ends_with("/boom.ts") {
+                    Err("storage unavailable".to_string())
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+
+        let root = build_memory_fs_with_files(&[("/app/main.ts", "const x = 1;")]);
+        let fs_sandbox = FsSandbox {
+            target_dir: "/app".to_string(),
+            root,
+            fetcher: Some(Arc::new(FailingFetcher)),
+        };
+
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = "const x = 1;";
+        let ast = AstGrep::new(content, js_lang());
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: Some("/app/main.ts"),
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: Some(fs_sandbox),
+        });
+
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => {
+                    assert_eq!(modified.content, "missing=ENOENT;failing=EIO");
                 }
                 other => panic!("Expected modified result, got: {:?}", other),
             },

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -16,6 +16,7 @@ use ast_grep_core::matcher::MatcherExt;
 use ast_grep_core::tree_sitter::StrDoc;
 use ast_grep_core::AstGrep;
 use codemod_llrt_capabilities::module_builder::LlrtModuleBuilder;
+use codemod_llrt_capabilities::types::LlrtSupportedModules;
 use language_core::SemanticProvider;
 use rquickjs::{async_with, AsyncContext, AsyncRuntime, CatchResultExt, Function, Module};
 use std::collections::HashMap;
@@ -35,6 +36,15 @@ const DEFAULT_MAX_STACK_SIZE: usize = 4 * 1024 * 1024;
 
 /// SHA256 hash type (32 bytes)
 pub type Sha256Hash = [u8; 32];
+
+/// Sandboxed values for the QuickJS `process` global.
+#[derive(Clone, Debug, Default)]
+pub struct ProcessSandbox {
+    /// Values exposed on `process.env`.
+    pub env: HashMap<String, String>,
+    /// Value returned by `process.cwd()`.
+    pub cwd: String,
+}
 
 /// In-memory execution options for executing a codemod on a pre-parsed AST
 pub struct InMemoryExecutionOptions<'a, R> {
@@ -67,6 +77,13 @@ pub struct InMemoryExecutionOptions<'a, R> {
     pub timeout_ms: Option<u64>,
     /// Memory limit in bytes (default: 64 MB)
     pub memory_limit: Option<usize>,
+    /// Optional sandboxed values for the `process` global.
+    ///
+    /// When `Some`, the llrt `process` module is omitted from the runtime and
+    /// a minimal stub exposing only `env` and `cwd()` is installed instead.
+    /// When `None`, the host-derived defaults from llrt_modules remain in
+    /// place.
+    pub process_sandbox: Option<ProcessSandbox>,
 }
 
 /// Execute a codemod synchronously by blocking on the async runtime
@@ -142,7 +159,14 @@ where
     // Use the pre-parsed AST from options (allows AST caching)
     let ast_grep = options.ast;
 
-    let module_builder = LlrtModuleBuilder::build();
+    // When the caller asks for a process sandbox, omit the llrt `process`
+    // module so the host env, cwd, argv, exit, setuid, etc. are never attached
+    // in the first place; we install a restricted stub below instead.
+    let module_builder = if options.process_sandbox.is_some() {
+        LlrtModuleBuilder::build_with_exclusions(&[LlrtSupportedModules::Process])
+    } else {
+        LlrtModuleBuilder::build()
+    };
     let (mut built_in_resolver, mut built_in_loader, global_attachment) =
         module_builder.builder.build();
 
@@ -176,6 +200,7 @@ where
     // Capture metrics context and shared state context for use inside async block
     let metrics_context = options.metrics_context.clone();
     let shared_state_context = options.shared_state_context.clone();
+    let process_sandbox = options.process_sandbox.clone();
 
     let timeout_exceeded_check = Arc::clone(&timeout_exceeded);
 
@@ -201,6 +226,30 @@ where
                 message: format!("Failed to attach global modules: {e}"),
             },
         })?;
+
+        if let Some(sandbox) = process_sandbox {
+            let env_json = serde_json::to_string(&sandbox.env).map_err(|e| ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                    message: format!("Failed to serialize process.env sandbox: {e}"),
+                },
+            })?;
+            let cwd_json = serde_json::to_string(&sandbox.cwd).map_err(|e| ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                    message: format!("Failed to serialize process.cwd sandbox: {e}"),
+                },
+            })?;
+            // The llrt `process` module was excluded from the module builder
+            // above, so `globalThis.process` is currently undefined. Install a
+            // minimal stub that exposes only the sandboxed `env` and `cwd`.
+            let script = format!(
+                "globalThis.process = {{ env: {env_json}, cwd: function() {{ return {cwd_json}; }} }};"
+            );
+            ctx.eval::<(), _>(script).catch(&ctx).map_err(|e| ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                    message: format!("Failed to install process sandbox stub: {e}"),
+                },
+            })?;
+        }
 
         let execution = async {
             let module = Module::declare(ctx.clone(), "__codemod_entry.js", js_code)
@@ -385,6 +434,7 @@ export default function transform(root) {
             shared_state_context: None,
             timeout_ms: Some(50), // 50ms timeout for faster test
             memory_limit: None,
+            process_sandbox: None,
         });
 
         match result {
@@ -442,6 +492,7 @@ export default function transform(root) {
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
+            process_sandbox: None,
         });
 
         match result {
@@ -449,6 +500,77 @@ export default function transform(root) {
                 ExecutionResult::Modified(modified) => {
                     assert!(modified.content.contains("logger.log('Hello, world!')"));
                     assert!(modified.rename_to.is_none());
+                }
+                other => panic!("Expected modified result, got: {:?}", other),
+            },
+            Err(e) => panic!("Expected success, got error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn test_process_sandbox_overrides_env_and_cwd() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        // Codemod emits cwd, env keys, the sorted list of `process` keys, and
+        // whether a few dangerous llrt-provided properties are absent. When
+        // sandboxed, only `env` + `cwd` should survive; `exit`, `argv`,
+        // `platform` etc. should be undefined since the llrt process module
+        // is no longer attached.
+        let codemod_content = r#"
+export default function transform(root) {
+  const envKeys = Object.keys(process.env).sort().join(",");
+  const processKeys = Object.keys(process).sort().join(",");
+  const stripped = [
+    typeof process.exit,
+    typeof process.argv,
+    typeof process.platform,
+    typeof process.versions,
+  ].join(",");
+  return `cwd=${process.cwd()};env=${envKeys};keys=${processKeys};stripped=${stripped}`;
+}
+        "#
+        .trim();
+
+        fs::write(temp_dir.path().join("sandbox_codemod.js"), codemod_content)
+            .expect("Failed to write codemod file");
+
+        // Seed a host env var that must not leak into process.env.
+        std::env::set_var("PG_SG_SANDBOX_LEAK_CHECK", "should-not-appear");
+
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = "const x = 1;";
+        let ast = AstGrep::new(content, js_lang());
+
+        let sandbox = ProcessSandbox {
+            env: HashMap::new(),
+            cwd: "/app/".to_string(),
+        };
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: None,
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: Some(sandbox),
+        });
+
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => {
+                    assert_eq!(
+                        modified.content,
+                        "cwd=/app/;env=;keys=cwd,env;stripped=undefined,undefined,undefined,undefined",
+                    );
                 }
                 other => panic!("Expected modified result, got: {:?}", other),
             },

--- a/crates/codemod-sandbox/src/sandbox/engine/mod.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "native")]
+pub mod curated_fs;
 pub mod execution_engine;
 pub mod in_memory_engine;
 pub mod quickjs_adapters;

--- a/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
@@ -1,4 +1,5 @@
 use super::codemod_lang::CodemodLang;
+use super::curated_fs::{CuratedFsConfig, CuratedFsModule, CuratedFsPromisesModule};
 use super::quickjs_adapters::{QuickJSLoader, QuickJSResolver};
 use crate::ast_grep::AstGrepModule;
 use crate::metrics::MetricsModule;
@@ -23,6 +24,12 @@ pub struct SelectorEngineOptions<'a, R> {
     pub language: CodemodLang,
     pub resolver: Arc<R>,
     pub capabilities: Option<HashSet<LlrtSupportedModules>>,
+    /// Directory that the curated `fs` module is constrained to. When
+    /// `Some` and the caller hasn't opted into the llrt `Fs` capability,
+    /// the codemod's `import "fs"` resolves to a [`CuratedFsModule`]
+    /// backed by `vfs::PhysicalFS` at disk root `/`, with reads/writes
+    /// prefix-checked against this path.
+    pub target_directory: Option<&'a Path>,
 }
 
 /// Extract a selector from a codemod module using QuickJS
@@ -54,6 +61,10 @@ where
         },
     })?;
 
+    // Track whether the caller opted into llrt's real-disk fs capability
+    // so we know whether to install the curated fs below instead.
+    let mut fs_capability_enabled = false;
+
     // Set up built-in modules
     let mut module_builder = LlrtModuleBuilder::build();
     if let Some(capabilities) = options.capabilities {
@@ -64,6 +75,7 @@ where
                 }
                 LlrtSupportedModules::Fs => {
                     module_builder.enable_fs();
+                    fs_capability_enabled = true;
                 }
                 LlrtSupportedModules::ChildProcess => {
                     module_builder.enable_child_process();
@@ -72,6 +84,19 @@ where
             }
         }
     }
+
+    // If the caller provided a target_directory and didn't explicitly opt
+    // into llrt's unrestricted fs, install the curated fs. The script sees
+    // real on-disk paths; reads/writes outside `target_directory` are
+    // rejected with `EACCES`.
+    let curated_fs_target = if !fs_capability_enabled {
+        options
+            .target_directory
+            .map(|p| p.to_string_lossy().into_owned())
+    } else {
+        None
+    };
+
     let (mut built_in_resolver, mut built_in_loader, global_attachment) =
         module_builder.builder.build();
 
@@ -86,6 +111,14 @@ where
     // Add MetricsModule (metrics tracking)
     built_in_resolver = built_in_resolver.add_name("codemod:metrics");
     built_in_loader = built_in_loader.with_module("codemod:metrics", MetricsModule);
+
+    // Register the curated `fs` / `fs/promises` modules when applicable.
+    if curated_fs_target.is_some() {
+        built_in_resolver = built_in_resolver.add_name("fs").add_name("fs/promises");
+        built_in_loader = built_in_loader
+            .with_module("fs", CuratedFsModule)
+            .with_module("fs/promises", CuratedFsPromisesModule);
+    }
 
     let fs_resolver = QuickJSResolver::new(Arc::clone(&options.resolver));
     let fs_loader = QuickJSLoader;
@@ -113,6 +146,18 @@ where
                 message: format!("Failed to attach global modules: {e}"),
             },
         })?;
+
+        // Install the curated fs config (if applicable) before the codemod
+        // module evaluates so its first `import "fs"` resolves cleanly.
+        if let Some(target_dir) = curated_fs_target {
+            let physical_root: vfs::VfsPath = vfs::PhysicalFS::new(std::path::PathBuf::from("/")).into();
+            ctx.store_userdata(CuratedFsConfig::new(target_dir, physical_root))
+                .map_err(|e| ExecutionError::Runtime {
+                    source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                        message: format!("Failed to store CuratedFsConfig: {:?}", e),
+                    },
+                })?;
+        }
 
         let execution = async {
             let module = Module::declare(ctx.clone(), "__selector_extractor.js", js_code)

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -118,6 +118,12 @@ pub struct WorkflowRunConfig {
     pub install_skill_executor: Option<Arc<dyn InstallSkillExecutor>>,
     /// Optional per-task git worktree used for managed git execution.
     pub managed_git_worktree: Option<ManagedGitWorktree>,
+    /// When false, skip managed git operations (branch switching, worktrees,
+    /// commits, push, pull request creation) for nodes that declare
+    /// `branch_name` or `pull_request`. Cloud mode still manages git regardless
+    /// of this flag. Defaults to true; CLI sets it to false for headless runs
+    /// so those operations stay scoped to TUI-driven workflows.
+    pub enable_managed_git: bool,
 }
 
 impl Default for WorkflowRunConfig {
@@ -150,6 +156,7 @@ impl Default for WorkflowRunConfig {
             shell_command_approval_callback: None,
             install_skill_executor: None,
             managed_git_worktree: None,
+            enable_managed_git: true,
         }
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -118,12 +118,18 @@ pub struct WorkflowRunConfig {
     pub install_skill_executor: Option<Arc<dyn InstallSkillExecutor>>,
     /// Optional per-task git worktree used for managed git execution.
     pub managed_git_worktree: Option<ManagedGitWorktree>,
-    /// When false, skip managed git operations (branch switching, worktrees,
-    /// commits, push, pull request creation) for nodes that declare
-    /// `branch_name` or `pull_request`. Cloud mode still manages git regardless
-    /// of this flag. Defaults to true; CLI sets it to false for headless runs
-    /// so those operations stay scoped to TUI-driven workflows.
+    /// When false, skip managed git operations (branch switching, commits,
+    /// push, pull request creation) for nodes that declare `branch_name` or
+    /// `pull_request`. Cloud mode still manages git regardless of this flag.
+    /// Defaults to true; CLI sets it to false for headless runs so those
+    /// operations stay scoped to TUI-driven workflows.
     pub enable_managed_git: bool,
+    /// When false, skip per-task git worktree creation even if managed git is
+    /// enabled. Worktrees are only useful for TUI runs that execute multiple
+    /// tasks in parallel against the same checkout. Cloud and headless CLI
+    /// runs leave the working tree untouched and check out branches inline
+    /// instead. Defaults to false.
+    pub enable_worktrees: bool,
 }
 
 impl Default for WorkflowRunConfig {
@@ -157,6 +163,7 @@ impl Default for WorkflowRunConfig {
             install_skill_executor: None,
             managed_git_worktree: None,
             enable_managed_git: true,
+            enable_worktrees: false,
         }
     }
 }

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -3602,6 +3602,7 @@ impl Engine {
                 .capabilities
                 .as_ref()
                 .map(|v| v.clone().into_iter().collect()),
+            target_directory: Some(&target_path),
         })
         .await
         .map_err(|e| Error::StepExecution(format!("Failed to extract selector: {e}")))?;
@@ -5348,6 +5349,7 @@ impl Engine {
             resolver,
             input,
             capabilities: self.workflow_run_config.capabilities.clone(),
+            target_directory: Some(target_path),
         };
 
         let result = execute_shard_function_with_quickjs(options)

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -216,8 +216,11 @@ fn select_shard_scan_eligible_files(
     }
 }
 
-fn should_manage_git_for_node(node: &Node) -> bool {
-    crate::git_ops::is_cloud_mode() || node.pull_request.is_some() || node.branch_name.is_some()
+fn should_manage_git_for_node(node: &Node, enable_managed_git: bool) -> bool {
+    if crate::git_ops::is_cloud_mode() {
+        return true;
+    }
+    enable_managed_git && (node.pull_request.is_some() || node.branch_name.is_some())
 }
 
 fn record_unit_progress(
@@ -926,7 +929,10 @@ impl Engine {
                                 .iter()
                                 .find(|node| node.id == task.node_id)
                             {
-                                if should_manage_git_for_node(node) {
+                                if should_manage_git_for_node(
+                                    node,
+                                    engine.workflow_run_config.enable_managed_git,
+                                ) {
                                     let ctx =
                                         crate::git_ops::build_task_expression_context(&task.id.to_string());
                                     let configured_branch =
@@ -2488,7 +2494,8 @@ impl Engine {
 
         // Workflows that declare git outputs should use the managed branch/commit/PR path
         // in both cloud and local runs.
-        let manage_git = should_manage_git_for_node(node);
+        let manage_git =
+            should_manage_git_for_node(node, self.workflow_run_config.enable_managed_git);
         // Always build task expression context so CODEMOD_TASK_* env vars are
         // available as `task.*` template variables regardless of mode.
         let task_expr_ctx = Some(crate::git_ops::build_task_expression_context(
@@ -5938,7 +5945,8 @@ mod tests {
             }),
         };
 
-        assert!(should_manage_git_for_node(&node));
+        assert!(should_manage_git_for_node(&node, true));
+        assert!(!should_manage_git_for_node(&node, false));
     }
 
     #[test]

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -929,10 +929,12 @@ impl Engine {
                                 .iter()
                                 .find(|node| node.id == task.node_id)
                             {
-                                if should_manage_git_for_node(
-                                    node,
-                                    engine.workflow_run_config.enable_managed_git,
-                                ) {
+                                if engine.workflow_run_config.enable_worktrees
+                                    && should_manage_git_for_node(
+                                        node,
+                                        engine.workflow_run_config.enable_managed_git,
+                                    )
+                                {
                                     let ctx =
                                         crate::git_ops::build_task_expression_context(&task.id.to_string());
                                     let configured_branch =

--- a/crates/llrt-capabilities/src/module_builder.rs
+++ b/crates/llrt-capabilities/src/module_builder.rs
@@ -115,7 +115,14 @@ pub struct LlrtModuleBuilder {
 
 impl LlrtModuleBuilder {
     pub fn build() -> Self {
-        let default_modules = default_modules_set();
+        Self::build_with_exclusions(&[])
+    }
+
+    pub fn build_with_exclusions(exclude: &[LlrtSupportedModules]) -> Self {
+        let mut default_modules = default_modules_set();
+        for excluded in exclude {
+            default_modules.remove(excluded);
+        }
         let module_builder = ModuleBuilder::new()
             .with_global(module::init)
             .with_module(module::ModuleModule);

--- a/crates/mcp/src/data/prompts/codemod-cli-instructions.md
+++ b/crates/mcp/src/data/prompts/codemod-cli-instructions.md
@@ -368,9 +368,12 @@ Options:
   --allow-dirty        Allow running on repos with uncommitted changes
   --no-interactive     CI/headless mode - no prompts, auto-accept packages
   --no-color           Disable colored diff output in dry-run mode
-  --allow-fs           Allow filesystem access for the codemod
-  --allow-fetch        Allow network requests for the codemod
-  --allow-child-process Allow spawning child processes
+  --allow-fs           Upgrade the default sandboxed fs (which only permits
+                       reads/writes inside the target directory) to
+                       unrestricted real-disk fs. Only needed when the codemod
+                       accesses paths outside the target directory.
+  --allow-fetch        Allow network requests for the codemod.
+  --allow-child-process Allow spawning child processes.
   --param KEY=VALUE    Pass parameters to the codemod (e.g., --param autoAiReview=true)
   --registry           Custom registry URL
   --force              Force re-download even if cached

--- a/crates/mcp/src/data/prompts/codemod-troubleshooting.md
+++ b/crates/mcp/src/data/prompts/codemod-troubleshooting.md
@@ -29,13 +29,14 @@ Fix:
 ## Capability/Permission Failures
 
 Symptom:
-- transform needs filesystem, network, or child process capability.
+- transform fails with `err.code === "EACCES"` when reading/writing outside the target directory, or `fetch is not defined`, or `Cannot find module 'child_process'`.
 
 Fix:
-- enable required capability flags:
-  - `--allow-fs`
-  - `--allow-fetch`
-  - `--allow-child-process`
+- The default sandboxed `fs` already allows reads/writes inside the target directory. If the codemod only touches files inside the repo, no flag is needed — investigate the path instead.
+- If the codemod genuinely needs to access paths outside `target_dir`, network, or subprocesses, enable the matching flag:
+  - `--allow-fs` — swaps the sandboxed fs for the unrestricted real-disk fs (removes the `target_dir` prefix check).
+  - `--allow-fetch` — exposes the `fetch` global.
+  - `--allow-child-process` — exposes the `child_process` module.
 - for automation, combine with:
   - `--no-interactive`
 

--- a/crates/mcp/src/data/prompts/jssg-instructions.md
+++ b/crates/mcp/src/data/prompts/jssg-instructions.md
@@ -19,8 +19,9 @@ This guide provides comprehensive documentation for creating codemods using Java
 ## Runtime and Capabilities
 
 - JSSG is a QuickJS runtime with LLRT-based Node compatibility.
-- Standard Node-style imports are available in JSSG; some modules are capability-gated.
-- If the codemod uses gated APIs such as `fs`, `fetch`, or `child_process`, update `codemod.yaml` in the same change with the matching `capabilities` entry.
+- Standard Node-style imports are available in JSSG. `fs` is sandboxed to the target directory by default (no capability needed); `fetch` and `child_process` are gated.
+- Do not add `fs` to `capabilities` just because the codemod imports it. Only list `fs` when the codemod actually needs to read/write paths outside the target directory (that upgrades to the unrestricted real-disk fs). This should be rarely needed.
+- If the codemod uses `fetch` or `child_process`, update `codemod.yaml` in the same change with the matching `capabilities` entry.
 - For related multi-file JSSG work, prefer `jssgTransform` or other JSSG APIs before falling back to shell steps.
 - For detailed runtime and capability rules, read `jssg-runtime-capabilities-instructions` from Codemod MCP.
 

--- a/crates/mcp/src/data/prompts/jssg-runtime-capabilities.md
+++ b/crates/mcp/src/data/prompts/jssg-runtime-capabilities.md
@@ -37,7 +37,7 @@ Safe modules are available by default and do not require `codemod.yaml` capabili
 - Reads, writes, `readdir`, `mkdir`, `stat`, `exists`, `unlink` all work for paths inside `target_dir`.
 - Paths that normalize outside `target_dir` throw with `err.code === "EACCES"`.
 - Missing paths inside `target_dir` throw with `err.code === "ENOENT"`.
-- `..` segments and symlinks are canonicalized before the prefix check — codemods cannot escape the sandbox by crafting tricky paths.
+- `.` and `..` path segments are normalized before the prefix check. Do not assume symlinks are resolved as part of this sandbox check.
 
 Use the default sandboxed fs whenever the codemod only touches files inside the repo. Do not add `fs` to `capabilities` just because the codemod imports it.
 

--- a/crates/mcp/src/data/prompts/jssg-runtime-capabilities.md
+++ b/crates/mcp/src/data/prompts/jssg-runtime-capabilities.md
@@ -37,7 +37,7 @@ Safe modules are available by default and do not require `codemod.yaml` capabili
 - Reads, writes, `readdir`, `mkdir`, `stat`, `exists`, `unlink` all work for paths inside `target_dir`.
 - Paths that normalize outside `target_dir` throw with `err.code === "EACCES"`.
 - Missing paths inside `target_dir` throw with `err.code === "ENOENT"`.
-- `.` and `..` path segments are normalized before the prefix check. Do not assume symlinks are resolved as part of this sandbox check.
+- `.` and `..` path segments are normalized before the prefix check. On real-disk runs the resolver also rejects any path that traverses a symlink (checked via `symlink_metadata`), so symlinks inside the repo cannot be used to escape the sandbox.
 
 Use the default sandboxed fs whenever the codemod only touches files inside the repo. Do not add `fs` to `capabilities` just because the codemod imports it.
 

--- a/crates/mcp/src/data/prompts/jssg-runtime-capabilities.md
+++ b/crates/mcp/src/data/prompts/jssg-runtime-capabilities.md
@@ -17,6 +17,7 @@ Safe modules are available by default and do not require `codemod.yaml` capabili
 - `console`
 - `crypto`
 - `events`
+- `fs` (sandboxed — see below)
 - `os`
 - `path`
 - `perf_hooks`
@@ -29,17 +30,28 @@ Safe modules are available by default and do not require `codemod.yaml` capabili
 - `util`
 - `zlib`
 
-Unsafe modules require an explicit `capabilities` entry in `codemod.yaml`:
+### `fs` is sandboxed by default
 
-- `fs` -> `fs`
-- `fetch` -> `fetch`
-- `child_process` -> `child_process`
+`fs` and `fs/promises` are available without any capability entry, but are constrained to the workflow's target directory:
+
+- Reads, writes, `readdir`, `mkdir`, `stat`, `exists`, `unlink` all work for paths inside `target_dir`.
+- Paths that normalize outside `target_dir` throw with `err.code === "EACCES"`.
+- Missing paths inside `target_dir` throw with `err.code === "ENOENT"`.
+- `..` segments and symlinks are canonicalized before the prefix check — codemods cannot escape the sandbox by crafting tricky paths.
+
+Use the default sandboxed fs whenever the codemod only touches files inside the repo. Do not add `fs` to `capabilities` just because the codemod imports it.
+
+### Capability-gated (require explicit opt-in)
+
+- `fs` (unrestricted) — upgrades the sandboxed fs to LLRT's real-disk `fs`, removing the `target_dir` prefix check. Only add this if the codemod genuinely reads or writes paths outside the target directory (home config, caches, `/tmp`, etc.).
+- `fetch` — network requests. Fully deny-by-default.
+- `child_process` — process spawning. Fully deny-by-default.
 
 If the codemod imports or relies on one of these gated APIs, update `codemod.yaml` in the same change. Do not leave the transform using gated APIs without the matching capability declaration.
 
 ```yaml
 capabilities:
-  - fs
+  - fs             # only when paths outside target_dir are needed
   - fetch
   - child_process
 ```
@@ -56,7 +68,8 @@ When you add or remove a gated runtime dependency:
 
 Example:
 
-- If the codemod reads adjacent config files with `fs`, add `fs`.
+- If the codemod reads adjacent config files with `fs` that live inside the target directory, **no capability entry is needed** — the default sandboxed fs covers it.
+- If it reads files outside the target directory (e.g. `~/.config/...`), add `fs`.
 - If it calls an HTTP API with `fetch`, add `fetch`.
 - If it shells out to another tool with `child_process`, add `child_process`.
 

--- a/docs/jssg/security.mdx
+++ b/docs/jssg/security.mdx
@@ -1,37 +1,92 @@
 ---
 title: "Security & Capabilities"
-description: "Understand JSSG's deny-by-default security model and how to enable capabilities for file system, network, and process operations"
+description: "Understand JSSG's deny-by-default security model, the sandboxed fs, and how to grant unrestricted access to network, disk, or process APIs"
 ---
 
-JSSG follows a **deny-by-default security model** for sensitive operations. This means potentially unsafe modules like file system access, network requests, and child processes are disabled by default and must be explicitly enabled.
+JSSG follows a **deny-by-default security model** for the most sensitive operations (network requests and spawning processes) and a **sandboxed-by-default** model for file system access. Host environment and working directory are fully hidden from codemods; anything else that could touch the outside world is either scoped down or gated behind an explicit capability.
 
-## Why deny-by-default?
+## Why defense in depth?
 
-Codemods run arbitrary code transformations on your codebase. By restricting capabilities by default, JSSG ensures:
+Codemods run arbitrary code transformations on your codebase. By restricting or scoping capabilities, JSSG ensures:
 
-- **Safe execution**: Untrusted codemods cannot access sensitive resources without explicit permission
-- **Audit trail**: The `capabilities` field in `codemod.yaml` provides a clear record of what permissions a codemod requires
-- **Principle of least privilege**: Codemods only get the minimum permissions they need
+- **Safe execution**: Untrusted codemods can't exfiltrate secrets, read files outside the project, reach the network, or run shell commands without explicit permission.
+- **Audit trail**: The `capabilities` field in `codemod.yaml` provides a clear record of what *extra* permissions a codemod requires.
+- **Principle of least privilege**: The default surface is the minimum a typical transformation needs — just the files under your target directory.
 
-## Unsafe modules (require explicit permission)
+## File system — sandboxed by default
 
-These modules require explicit opt-in via the `capabilities` field:
+Unlike `fetch` and `child_process`, the `fs` module is **always available** but is constrained to the workflow's **target directory** (the folder you're running the codemod against). Reads and writes inside that directory succeed transparently; paths that normalize outside it are rejected with a Node-style `EACCES` error.
+
+<CardGroup cols={2}>
+  <Card title="Inside target_dir" icon="folder-open">
+    **Allowed by default**
+
+    `readFileSync`, `writeFileSync`, `readdirSync`, `mkdirSync`, `statSync`, `existsSync`, `unlinkSync`, and their `fs/promises` equivalents all work.
+  </Card>
+  <Card title="Outside target_dir" icon="shield-halved">
+    **Rejected with `EACCES`**
+
+    Absolute paths outside the target or `..` traversals that escape it throw a Node-style error with `err.code === "EACCES"`.
+  </Card>
+</CardGroup>
+
+```ts scripts/codemod.ts
+import type { Codemod } from "codemod:ast-grep";
+import { readFileSync } from "fs";
+
+const codemod: Codemod = (root) => {
+  // ✅ Works — adjacent file inside target_dir
+  const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
+
+  try {
+    // ❌ Throws EACCES — outside the sandbox
+    readFileSync("/etc/passwd", "utf-8");
+  } catch (e) {
+    // e.code === "EACCES"
+  }
+};
+
+export default codemod;
+```
+
+<Info>
+  Path comparisons are done against the *canonical* form — symlink targets and `..` segments are resolved before the prefix check, so codemods can't escape by crafting tricky paths.
+</Info>
+
+### Error codes
+
+The curated fs surfaces standard Node `err.code` strings so existing `catch` logic keeps working:
+
+| Code     | Meaning                                                     |
+| -------- | ----------------------------------------------------------- |
+| `EACCES` | Path is outside `target_dir`.                               |
+| `ENOENT` | Path is inside `target_dir` but the file doesn't exist.     |
+| `EIO`    | Backing storage failure (disk error, remote fetch failed).  |
+| `EINVAL` | Path couldn't be resolved.                                  |
+
+### Want unrestricted disk access?
+
+If a codemod *legitimately* needs to read or write outside the target directory (caches, home-directory config, scratch paths in `/tmp`), opt in explicitly — see [Unsafe capabilities](#unsafe-capabilities-require-explicit-permission) below. That swaps the curated fs for the unrestricted LLRT `fs` module and the path guard is no longer applied.
+
+## Unsafe capabilities — require explicit permission
+
+These still require opt-in via `capabilities`:
 
 <CardGroup cols={3}>
-  <Card title="fs" icon="folder">
-    **File system access**
+  <Card title="fs (unrestricted)" icon="folder">
+    **Full real-disk access**
 
-    Read, write, list, and delete files on disk
+    Upgrades from the sandboxed curated fs to LLRT's real-disk `fs` module. No `target_dir` prefix check. Use only when the codemod genuinely needs paths outside the target.
   </Card>
   <Card title="fetch" icon="globe">
     **Network requests**
 
-    Make HTTP/HTTPS requests
+    Make HTTP/HTTPS requests. Fully deny-by-default.
   </Card>
   <Card title="child_process" icon="terminal">
     **Process spawning**
 
-    Execute external commands
+    Execute external commands. Fully deny-by-default.
   </Card>
 </CardGroup>
 
@@ -40,12 +95,13 @@ These modules require explicit opt-in via the `capabilities` field:
 These modules are **always available** and require no special permissions:
 
 <AccordionGroup>
-  <Accordion title="Core utilities (13 modules)">
+  <Accordion title="Core utilities (14 modules)">
     - `assert` - Assertion testing
     - `buffer` - Binary data manipulation
     - `console` - Logging and debugging
     - `crypto` - Cryptographic operations
     - `events` - Event emitter patterns
+    - `fs` (sandboxed to `target_dir`)
     - `os` - Operating system information (read-only)
     - `path` - File path utilities
     - `perf_hooks` - Performance measurement
@@ -63,61 +119,85 @@ These modules are **always available** and require no special permissions:
 </AccordionGroup>
 
 <Info>
-  All default modules are considered safe because they don't perform file I/O, network requests, or process spawning.
+  Default modules don't perform network requests or spawn processes. `fs` is in this list because its default form is sandboxed to `target_dir`; adding `fs` to `capabilities` upgrades it to the unrestricted variant that can read and write anywhere on disk.
 </Info>
 
 ## Enabling capabilities
 
-To enable unsafe modules, add a `capabilities` field to your `codemod.yaml` file:
+To enable unsafe capabilities (or to upgrade `fs` from sandboxed to unrestricted), add a `capabilities` field to your `codemod.yaml` file:
 
 ```yaml codemod.yaml
 name: my-codemod
 version: 1.0.0
 capabilities:
-  - fs          # Enable file system access
-  - fetch       # Enable network requests
+  - fs             # Upgrade to unrestricted, real-disk fs (disables the target_dir guard)
+  - fetch          # Enable network requests
   - child_process  # Enable spawning processes
 ```
 
 <Warning>
-  Only enable capabilities that your codemod actually needs. Each capability increases the potential security risk if the codemod is untrusted.
+  Only request capabilities your codemod actually needs. Adding `fs` here **removes the target_dir guard** — the codemod can now read and write anywhere on disk. If you only need files in the repo, don't list it.
 </Warning>
 
 ### Capability names
 
 Use these exact strings in the `capabilities` array:
 
-| Capability      | Modules Enabled     | Use Case                                       |
-| --------------- | ------------------- | ---------------------------------------------- |
-| `fs`            | `fs`, `fs/promises` | Reading/writing files, checking file existence |
-| `fetch`         | `fetch` global      | Making HTTP requests to APIs                   |
-| `child_process` | `child_process`     | Running Git, npm, or other CLI tools           |
+| Capability      | What it changes                                                             | Use Case                                                  |
+| --------------- | --------------------------------------------------------------------------- | --------------------------------------------------------- |
+| `fs`            | Swaps the default sandboxed `fs` for LLRT's unrestricted real-disk `fs`.    | Reading files outside `target_dir` (home config, caches). |
+| `fetch`         | Exposes the `fetch` global.                                                 | Making HTTP requests to APIs.                             |
+| `child_process` | Exposes the `child_process` module.                                         | Running Git, npm, or other CLI tools.                     |
 
 ## Usage examples
 
-### File system operations
+### Default (sandboxed) file system
+
+No `capabilities` entry needed — this just works:
+
+```ts scripts/codemod.ts
+import type { Codemod } from "codemod:ast-grep";
+import { readFileSync, writeFileSync } from "fs";
+
+const codemod: Codemod = (root) => {
+  // Read an adjacent config file inside the target directory
+  const config = JSON.parse(readFileSync("./config.json", "utf-8"));
+
+  // Write a generated artifact next to the source
+  writeFileSync("./generated.ts", "export const X = 1;\n", "utf-8");
+};
+
+export default codemod;
+```
+
+### Unrestricted file system
 
 <Steps>
-  <Step title="Enable fs capability">
+  <Step title="Enable the fs capability (real-disk)">
     ```yaml codemod.yaml
     capabilities:
       - fs
     ```
   </Step>
-  <Step title="Use fs in your transform">
+  <Step title="Use fs anywhere on disk">
     ```ts scripts/codemod.ts
     import type { Codemod } from "codemod:ast-grep";
     import { readFileSync } from "fs";
-    
+
     const codemod: Codemod = (root) => {
-      // Read a configuration file
-      const config = JSON.parse(readFileSync("./config.json", "utf-8"));
-      
-      // ... use config in transformation
+      // With `capabilities: [fs]` the target_dir guard is gone — this works.
+      const globalConfig = JSON.parse(
+        readFileSync("/Users/me/.config/my-tool/config.json", "utf-8")
+      );
+      // ... use globalConfig in transformation
     };
-    
+
     export default codemod;
     ```
+
+    <Warning>
+      Listing `fs` gives the codemod read/write access to every path the host user has permission for. Review untrusted codemods carefully before enabling it.
+    </Warning>
   </Step>
 </Steps>
 
@@ -133,15 +213,15 @@ Use these exact strings in the `capabilities` array:
   <Step title="Use fetch in your transform">
     ```ts scripts/codemod.ts
     import type { Codemod } from "codemod:ast-grep";
-    
+
     const codemod: Codemod = async (root) => {
       // Fetch latest API definitions
       const response = await fetch("https://api.example.com/schema.json");
       const schema = await response.json();
-      
+
       // ... use schema in transformation
     };
-    
+
     export default codemod;
     ```
 
@@ -164,16 +244,16 @@ Use these exact strings in the `capabilities` array:
     ```ts scripts/codemod.ts
     import type { Codemod } from "codemod:ast-grep";
     import { execSync } from "child_process";
-    
+
     const codemod: Codemod = (root) => {
       // Get current git branch
       const branch = execSync("git rev-parse --abbrev-ref HEAD", {
         encoding: "utf-8"
       }).trim();
-      
+
       // ... use branch info in transformation
     };
-    
+
     export default codemod;
     ```
 
@@ -188,8 +268,10 @@ Use these exact strings in the `capabilities` array:
 You can also enable capabilities via CLI flags when running a codemod:
 
 ```bash
-# Enable specific capabilities
+# Upgrade fs to unrestricted (otherwise the default sandboxed fs is used)
 codemod jssg run --allow-fs path/to/codemod
+
+# Enable network + unrestricted fs
 codemod jssg run --allow-fetch --allow-fs path/to/codemod
 
 # Enable all capabilities (use with caution!)
@@ -200,22 +282,25 @@ codemod workflow run --allow-fs --allow-fetch --allow-child-process -w path/to/w
 ```
 
 <Info>
-  CLI flags take precedence over `codemod.yaml`. This is useful for testing or one-off runs where you trust the codemod source.
+  CLI flags take precedence over `codemod.yaml`. This is useful for testing or one-off runs where you trust the codemod source. `--allow-fs` swaps the sandboxed fs for the unrestricted variant — if your codemod only needs files inside the target directory, you don't need to pass it.
 </Info>
 
 ## Best practices
 
 <AccordionGroup>
+  <Accordion title="Prefer the default sandboxed fs">
+    If your codemod only reads/writes files inside the repo, don't add `fs` to `capabilities`. The default sandboxed `fs` already works and keeps the scope of your codemod tight for reviewers.
+  </Accordion>
   <Accordion title="Minimize required capabilities">
-    Only request capabilities your codemod truly needs. For example, if you only need to read files, document that your codemod won't write or delete files.
+    Only request capabilities your codemod truly needs. For example, if you only read config from the repo, you don't need any capabilities at all.
   </Accordion>
   <Accordion title="Document why capabilities are needed">
     In your README, explain why each capability is required and what operations use it.
 
     ```markdown README.md
     ## Required Capabilities
-    
-    - **fs**: Reads `package.json` to detect project dependencies
+
+    - **fs** (unrestricted): Reads `~/.config/my-tool/config.json` outside the repo
     - **fetch**: Calls an external API to get data
     ```
   </Accordion>
@@ -226,7 +311,7 @@ codemod workflow run --allow-fs --allow-fetch --allow-child-process -w path/to/w
     // ❌ BAD: Command injection vulnerability
     const userInput = options.branch;
     execSync(`git checkout ${userInput}`);
-    
+
     // ✅ GOOD: Validate input first
     const userInput = options.branch;
     if (!/^[a-zA-Z0-9_-]+$/.test(userInput)) {
@@ -243,7 +328,7 @@ codemod workflow run --allow-fs --allow-fetch --allow-child-process -w path/to/w
 ## Security considerations
 
 <Warning>
-  **Untrusted codemods**: Never run codemods from untrusted sources with capabilities enabled without reviewing the code first.
+  **Untrusted codemods**: Never run codemods from untrusted sources with `fs` (unrestricted), `fetch`, or `child_process` enabled without reviewing the code first. The default sandboxed fs is designed so that even a malicious codemod can't exfiltrate data outside the target directory.
 </Warning>
 
 ## Next steps

--- a/docs/jssg/security.mdx
+++ b/docs/jssg/security.mdx
@@ -3,7 +3,7 @@ title: "Security & Capabilities"
 description: "Understand JSSG's deny-by-default security model, the sandboxed fs, and how to grant unrestricted access to network, disk, or process APIs"
 ---
 
-JSSG follows a **deny-by-default security model** for the most sensitive operations (network requests and spawning processes) and a **sandboxed-by-default** model for file system access. Host environment and working directory are fully hidden from codemods; anything else that could touch the outside world is either scoped down or gated behind an explicit capability.
+JSSG follows a **deny-by-default security model** for the most sensitive operations (network requests and spawning processes) and a **sandboxed-by-default** model for file system access. By default, codemods can work only with files under the target directory; anything else that could touch the outside world is either scoped down or gated behind an explicit capability.
 
 ## Why defense in depth?
 
@@ -50,7 +50,7 @@ export default codemod;
 ```
 
 <Info>
-  Path comparisons are done against the *canonical* form — symlink targets and `..` segments are resolved before the prefix check, so codemods can't escape by crafting tricky paths.
+  Path comparisons use normalized path strings: `.` and `..` segments are resolved before the prefix check, so straightforward path-traversal attempts are rejected. This check is lexical and does not resolve symlink targets.
 </Info>
 
 ### Error codes

--- a/docs/jssg/security.mdx
+++ b/docs/jssg/security.mdx
@@ -50,7 +50,7 @@ export default codemod;
 ```
 
 <Info>
-  Path comparisons use normalized path strings: `.` and `..` segments are resolved before the prefix check, so straightforward path-traversal attempts are rejected. This check is lexical and does not resolve symlink targets.
+  Path comparisons first normalize `.`/`..` segments and collapse redundant slashes before the prefix check. When the curated fs is backed by real disk (the CLI), the resolver additionally walks each path component with `symlink_metadata` and rejects any path that traverses a symlink — a pre-existing `target_dir/link-to-elsewhere/secret` won't slip past the guard even though its lexical form stays under `target_dir`.
 </Info>
 
 ### Error codes


### PR DESCRIPTION
#### 📚 Description

A new sandboxed FS module that's enabled by default and the user can access files inside the target directory. The user can still promote the FS access by listing the FS capability.

Codemods are arbitrary user code. Default-unrestricted host access made it trivial for a buggy or untrusted codemod to read `~/.ssh/config`, exfiltrate `process.env` secrets, or touch files outside the repo. The new defaults keep codemods useful (read/write inside the repo JUST WORKS!) while making out-of-scope access an explicit, audited action.

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
