### PR TITLE
Fix/results ignore managed worktrees

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -287,7 +287,8 @@ pub async fn handler(
         .map_err(|e| anyhow::anyhow!("Failed to parse parameters: {}", e))?;
     let workflow_definition = butterflow_core::utils::parse_workflow_file(&workflow_path)
         .map_err(|e| anyhow::anyhow!("Failed to parse workflow before run: {}", e))?;
-    let auto_launch_tui = !args.no_interactive && workflow_has_manual_steps(&workflow_definition);
+    let auto_launch_tui =
+        should_auto_launch_package_run_tui(args.no_interactive, &workflow_definition);
 
     let capabilities = resolve_capabilities(
         ResolveCapabilitiesArgs {
@@ -331,17 +332,10 @@ pub async fn handler(
 
     // Set the package name so it's stored on the WorkflowRun
     engine.set_name(Some(args.package.clone()));
-    {
-        let cfg = engine.workflow_run_config_mut();
-        cfg.enable_managed_git = auto_launch_tui;
-        cfg.enable_worktrees = auto_launch_tui;
-    }
+    apply_package_run_mode_to_config(engine.workflow_run_config_mut(), auto_launch_tui);
     if auto_launch_tui {
         engine.set_quiet(true);
         engine.set_progress_callback(Arc::new(None));
-        engine
-            .workflow_run_config_mut()
-            .capture_stdout_in_quiet_mode = false;
     }
 
     // For pro codemod dry-run: streamline execution — auto-trigger manual
@@ -547,6 +541,25 @@ fn should_prompt_for_skill_install_with_tty(
     stdout_is_tty: bool,
 ) -> bool {
     !no_interactive && stdin_is_tty && stdout_is_tty
+}
+
+fn should_auto_launch_package_run_tui(
+    no_interactive: bool,
+    workflow_definition: &butterflow_core::Workflow,
+) -> bool {
+    !no_interactive && workflow_has_manual_steps(workflow_definition)
+}
+
+fn apply_package_run_mode_to_config(
+    cfg: &mut butterflow_core::config::WorkflowRunConfig,
+    auto_launch_tui: bool,
+) {
+    cfg.enable_managed_git = auto_launch_tui;
+    cfg.enable_worktrees = auto_launch_tui;
+    if auto_launch_tui {
+        cfg.quiet = true;
+        cfg.capture_stdout_in_quiet_mode = false;
+    }
 }
 
 fn skill_install_command(package_id: &str) -> String {
@@ -1087,5 +1100,68 @@ nodes:
             skill_install_prompt_message(SkillInstallOfferContext::WorkflowAndSkillPostRun)
                 .contains("follow-up workflows")
         );
+    }
+
+    fn workflow_with_manual_step() -> butterflow_core::Workflow {
+        butterflow_core::Workflow {
+            version: "1".to_string(),
+            state: None,
+            params: None,
+            templates: vec![],
+            nodes: vec![butterflow_core::Node {
+                id: "manual-node".to_string(),
+                name: "Manual Node".to_string(),
+                description: None,
+                r#type: butterflow_models::node::NodeType::Manual,
+                depends_on: vec![],
+                trigger: None,
+                strategy: None,
+                runtime: None,
+                steps: vec![butterflow_core::Step {
+                    id: None,
+                    name: "noop".to_string(),
+                    action: butterflow_models::step::StepAction::RunScript("echo hi".to_string()),
+                    env: None,
+                    condition: None,
+                    commit: None,
+                }],
+                env: HashMap::new(),
+                branch_name: Some("codemod-test".to_string()),
+                pull_request: Some(butterflow_models::step::PullRequestConfig {
+                    title: "Test PR".to_string(),
+                    body: None,
+                    draft: Some(true),
+                    base: None,
+                }),
+            }],
+        }
+    }
+
+    #[test]
+    fn non_tui_package_run_disables_managed_git_and_worktrees_even_with_manual_steps() {
+        let workflow = workflow_with_manual_step();
+        let auto_launch_tui = should_auto_launch_package_run_tui(true, &workflow);
+        assert!(!auto_launch_tui);
+
+        let mut cfg = butterflow_core::config::WorkflowRunConfig::default();
+        apply_package_run_mode_to_config(&mut cfg, auto_launch_tui);
+        assert!(!cfg.enable_managed_git);
+        assert!(!cfg.enable_worktrees);
+        assert!(!cfg.quiet);
+        assert!(cfg.capture_stdout_in_quiet_mode);
+    }
+
+    #[test]
+    fn interactive_manual_package_run_enables_tui_managed_git_mode() {
+        let workflow = workflow_with_manual_step();
+        let auto_launch_tui = should_auto_launch_package_run_tui(false, &workflow);
+        assert!(auto_launch_tui);
+
+        let mut cfg = butterflow_core::config::WorkflowRunConfig::default();
+        apply_package_run_mode_to_config(&mut cfg, auto_launch_tui);
+        assert!(cfg.enable_managed_git);
+        assert!(cfg.enable_worktrees);
+        assert!(cfg.quiet);
+        assert!(!cfg.capture_stdout_in_quiet_mode);
     }
 }

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -77,6 +77,25 @@ pub struct Command {
     format: String,
 }
 
+fn should_auto_launch_workflow_tui(
+    no_interactive: bool,
+    workflow_definition: &butterflow_core::Workflow,
+) -> bool {
+    !no_interactive && workflow_has_manual_steps(workflow_definition)
+}
+
+fn apply_workflow_run_mode_to_config(
+    cfg: &mut butterflow_core::config::WorkflowRunConfig,
+    auto_launch_tui: bool,
+) {
+    cfg.enable_managed_git = auto_launch_tui;
+    cfg.enable_worktrees = auto_launch_tui;
+    if auto_launch_tui {
+        cfg.quiet = true;
+        cfg.capture_stdout_in_quiet_mode = false;
+    }
+}
+
 /// Run a workflow
 pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<()> {
     // Resolve workflow file and bundle path
@@ -122,7 +141,8 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         .unwrap_or_else(|| args.workflow.clone());
     let workflow_definition = utils::parse_workflow_file(&workflow_file_path)
         .context("Failed to parse workflow before run")?;
-    let auto_launch_tui = !args.no_interactive && workflow_has_manual_steps(&workflow_definition);
+    let auto_launch_tui =
+        should_auto_launch_workflow_tui(args.no_interactive, &workflow_definition);
 
     // Always collect diffs so we can offer report interactively
     let diff_collector = Some(Arc::new(Mutex::new(Vec::<FileDiff>::new())));
@@ -153,17 +173,10 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     )?;
 
     engine.set_name(Some(workflow_label));
-    {
-        let cfg = engine.workflow_run_config_mut();
-        cfg.enable_managed_git = auto_launch_tui;
-        cfg.enable_worktrees = auto_launch_tui;
-    }
+    apply_workflow_run_mode_to_config(engine.workflow_run_config_mut(), auto_launch_tui);
     if auto_launch_tui {
         engine.set_quiet(true);
         engine.set_progress_callback(std::sync::Arc::new(None));
-        engine
-            .workflow_run_config_mut()
-            .capture_stdout_in_quiet_mode = false;
     }
     let (_, seconds) = run_workflow(&mut engine, config).await?;
 
@@ -225,4 +238,77 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         .await;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_workflow_run_mode_to_config, should_auto_launch_workflow_tui};
+    use butterflow_core::config::WorkflowRunConfig;
+    use butterflow_core::{Node, Step, Workflow};
+    use butterflow_models::node::NodeType;
+    use butterflow_models::step::{PullRequestConfig, StepAction};
+    use std::collections::HashMap;
+
+    fn workflow_with_manual_step() -> Workflow {
+        Workflow {
+            version: "1".to_string(),
+            state: None,
+            params: None,
+            templates: vec![],
+            nodes: vec![Node {
+                id: "manual-node".to_string(),
+                name: "Manual Node".to_string(),
+                description: None,
+                r#type: NodeType::Manual,
+                depends_on: vec![],
+                trigger: None,
+                strategy: None,
+                runtime: None,
+                steps: vec![Step {
+                    id: None,
+                    name: "noop".to_string(),
+                    action: StepAction::RunScript("echo hi".to_string()),
+                    env: None,
+                    condition: None,
+                    commit: None,
+                }],
+                env: HashMap::new(),
+                branch_name: Some("codemod-test".to_string()),
+                pull_request: Some(PullRequestConfig {
+                    title: "Test PR".to_string(),
+                    body: None,
+                    draft: Some(true),
+                    base: None,
+                }),
+            }],
+        }
+    }
+
+    #[test]
+    fn non_tui_workflow_run_disables_managed_git_and_worktrees_even_with_manual_steps() {
+        let workflow = workflow_with_manual_step();
+        let auto_launch_tui = should_auto_launch_workflow_tui(true, &workflow);
+        assert!(!auto_launch_tui);
+
+        let mut cfg = WorkflowRunConfig::default();
+        apply_workflow_run_mode_to_config(&mut cfg, auto_launch_tui);
+        assert!(!cfg.enable_managed_git);
+        assert!(!cfg.enable_worktrees);
+        assert!(!cfg.quiet);
+        assert!(cfg.capture_stdout_in_quiet_mode);
+    }
+
+    #[test]
+    fn interactive_manual_workflow_run_enables_tui_managed_git_mode() {
+        let workflow = workflow_with_manual_step();
+        let auto_launch_tui = should_auto_launch_workflow_tui(false, &workflow);
+        assert!(auto_launch_tui);
+
+        let mut cfg = WorkflowRunConfig::default();
+        apply_workflow_run_mode_to_config(&mut cfg, auto_launch_tui);
+        assert!(cfg.enable_managed_git);
+        assert!(cfg.enable_worktrees);
+        assert!(cfg.quiet);
+        assert!(!cfg.capture_stdout_in_quiet_mode);
+    }
 }

--- a/crates/cli/src/report_server.rs
+++ b/crates/cli/src/report_server.rs
@@ -16,7 +16,10 @@ const REPORT_HTML: &str = include_str!("../report-ui/dist/index.html");
 /// In debug builds, try to read the built SPA from disk at runtime
 #[cfg(debug_assertions)]
 fn get_report_html() -> String {
+    let compile_time_manifest_dir =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("report-ui/dist/index.html");
     let candidates = [
+        compile_time_manifest_dir,
         std::path::PathBuf::from("crates/cli/report-ui/dist/index.html"),
         std::path::PathBuf::from("report-ui/dist/index.html"),
     ];

--- a/crates/core/src/report.rs
+++ b/crates/core/src/report.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -183,10 +183,7 @@ pub fn convert_diffs(diffs: &[crate::diff::FileDiff], target_path: &str) -> Vec<
     diffs
         .iter()
         .map(|d| {
-            let rel = Path::new(&d.path)
-                .strip_prefix(base)
-                .map(|p| p.display().to_string())
-                .unwrap_or_else(|_| d.path.clone());
+            let rel = normalize_report_diff_path(Path::new(&d.path), base);
             ReportFileDiff {
                 path: rel,
                 diff_text: Some(d.diff_text.clone()),
@@ -195,4 +192,85 @@ pub fn convert_diffs(diffs: &[crate::diff::FileDiff], target_path: &str) -> Vec<
             }
         })
         .collect()
+}
+
+fn normalize_report_diff_path(diff_path: &Path, target_path: &Path) -> String {
+    if let Ok(relative) = diff_path.strip_prefix(target_path) {
+        return relative.display().to_string();
+    }
+
+    if let Some(relative) = relativize_managed_worktree_path(diff_path) {
+        return relative.display().to_string();
+    }
+
+    diff_path.display().to_string()
+}
+
+fn relativize_managed_worktree_path(diff_path: &Path) -> Option<PathBuf> {
+    let components: Vec<Component<'_>> = diff_path.components().collect();
+    let worktree_root_index = components.iter().position(|component| {
+        component
+            .as_os_str()
+            .to_string_lossy()
+            .ends_with(".codemod-worktrees")
+    })?;
+
+    let relative_components = components
+        .into_iter()
+        .skip(worktree_root_index + 2)
+        .collect::<Vec<_>>();
+    if relative_components.is_empty() {
+        return None;
+    }
+
+    let mut relative_path = PathBuf::new();
+    for component in relative_components {
+        relative_path.push(component.as_os_str());
+    }
+    Some(relative_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{convert_diffs, normalize_report_diff_path};
+    use crate::diff::FileDiff;
+    use std::path::Path;
+
+    #[test]
+    fn convert_diffs_keeps_paths_relative_to_target() {
+        let diffs = vec![FileDiff {
+            path: "/tmp/repo/src/app.ts".to_string(),
+            diff_text: "@@".to_string(),
+            additions: 1,
+            deletions: 0,
+        }];
+
+        let report_diffs = convert_diffs(&diffs, "/tmp/repo");
+        assert_eq!(report_diffs[0].path, "src/app.ts");
+    }
+
+    #[test]
+    fn convert_diffs_relativizes_managed_worktree_paths() {
+        let diffs = vec![FileDiff {
+            path: "/Users/me/backstage.codemod-worktrees/codemod-123/src/plugins/catalog.ts"
+                .to_string(),
+            diff_text: "@@".to_string(),
+            additions: 4,
+            deletions: 2,
+        }];
+
+        let report_diffs = convert_diffs(&diffs, "/Users/me/backstage");
+        assert_eq!(report_diffs[0].path, "src/plugins/catalog.ts");
+    }
+
+    #[test]
+    fn normalize_report_diff_path_preserves_unrelated_paths() {
+        let path = Path::new("/outside/project/generated.txt");
+        let target = Path::new("/tmp/repo");
+
+        assert_eq!(
+            normalize_report_diff_path(path, target),
+            "/outside/project/generated.txt"
+        );
+    }
 }

--- a/crates/core/tests/engine_tests.rs
+++ b/crates/core/tests/engine_tests.rs
@@ -268,6 +268,48 @@ fn create_test_workflow() -> Workflow {
     }
 }
 
+fn create_git_managed_workflow() -> Workflow {
+    Workflow {
+        version: "1".to_string(),
+        state: None,
+        params: None,
+        templates: vec![],
+        nodes: vec![Node {
+            id: "apply-transforms".to_string(),
+            name: "Apply AST Transformations".to_string(),
+            description: None,
+            r#type: NodeType::Automatic,
+            depends_on: vec![],
+            trigger: None,
+            strategy: None,
+            runtime: Some(Runtime {
+                r#type: RuntimeType::Direct,
+                image: None,
+                working_dir: None,
+                user: None,
+                network: None,
+                options: None,
+            }),
+            steps: vec![Step {
+                id: Some("step-1".to_string()),
+                name: "Mutate file".to_string(),
+                action: StepAction::RunScript("echo 'done'".to_string()),
+                env: None,
+                condition: None,
+                commit: None,
+            }],
+            env: HashMap::new(),
+            branch_name: Some("codemod-test-branch".to_string()),
+            pull_request: Some(butterflow_models::step::PullRequestConfig {
+                title: "Managed git test PR".to_string(),
+                body: None,
+                draft: Some(true),
+                base: None,
+            }),
+        }],
+    }
+}
+
 fn create_single_run_script_workflow(command: String) -> Workflow {
     Workflow {
         version: "1".to_string(),
@@ -2755,6 +2797,102 @@ async fn test_resume_workflow_git_managed_manual_matrix_children_produce_logs_an
             latest_states.lock().unwrap().clone()
         )
     });
+}
+
+#[tokio::test]
+#[serial]
+async fn non_tui_workflow_run_skips_worktree_and_pull_request_flow() {
+    let repo_dir = TempDir::new().unwrap();
+    init_test_git_repo(repo_dir.path());
+    create_test_file(repo_dir.path(), "tracked.txt", "original\n");
+    Command::new("git")
+        .args(["add", "tracked.txt"])
+        .current_dir(repo_dir.path())
+        .status()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "add tracked file"])
+        .current_dir(repo_dir.path())
+        .status()
+        .unwrap();
+
+    let state_adapter = Box::new(MockStateAdapter::new());
+    let config = WorkflowRunConfig {
+        target_path: repo_dir.path().to_path_buf(),
+        enable_managed_git: false,
+        enable_worktrees: false,
+        ..WorkflowRunConfig::default()
+    };
+    let engine = Engine::with_state_adapter(state_adapter, config);
+
+    let workflow = create_git_managed_workflow();
+    let workflow_run_id = engine
+        .run_workflow(workflow, HashMap::new(), None, None)
+        .await
+        .unwrap();
+
+    let _ = wait_for_workflow_status(&engine, workflow_run_id, |status| {
+        matches!(status, WorkflowStatus::Completed)
+    })
+    .await;
+
+    let tasks = engine.get_tasks(workflow_run_id).await.unwrap();
+    let task = tasks
+        .iter()
+        .find(|task| task.node_id == "apply-transforms")
+        .expect("managed git task should exist");
+
+    assert_eq!(task.status, TaskStatus::Completed);
+    let logs = task.logs.join("\n");
+    assert!(
+        !logs.contains("Creating git worktree for branch"),
+        "non-TUI run should not create git worktrees; logs were: {logs}"
+    );
+    assert!(
+        !logs.contains("Publishing branch and creating pull request"),
+        "non-TUI run should not attempt PR creation; logs were: {logs}"
+    );
+    assert!(
+        !logs.contains("Pull request created:"),
+        "non-TUI run should not create PRs; logs were: {logs}"
+    );
+
+    let branch_output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(repo_dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        branch_output.status.success(),
+        "git rev-parse failed: {}",
+        String::from_utf8_lossy(&branch_output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&branch_output.stdout).trim(),
+        "main"
+    );
+
+    let worktree_output = Command::new("git")
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        worktree_output.status.success(),
+        "git worktree list failed: {}",
+        String::from_utf8_lossy(&worktree_output.stderr)
+    );
+    let worktree_stdout = String::from_utf8_lossy(&worktree_output.stdout);
+    let worktree_entries: Vec<_> = worktree_stdout
+        .lines()
+        .filter(|line| line.starts_with("worktree "))
+        .collect();
+    assert_eq!(
+        worktree_entries.len(),
+        1,
+        "expected only the main repo worktree, got {:?}",
+        worktree_entries
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
#### 📚 Description
<!-- 
A summary of the change. Include relevant motivation and context.
For visual changes, add a snapshot or a Loom screencast to speed up reviews.
-->
This PR fixes the following:

1. Ignore worktrees from the report
2. Skip worktree and PR creation for non-TUI workflows


#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

- Should be tested with a non-TUI workflow.
- No regressions for TUI workflows when it comes to PR creation and worktrees
