### PR TITLE
fix(cli): route sandbox failures to task logs

### DIFF
--- a/crates/codemod-sandbox/src/sandbox/engine/scripts/extract_selector_script.js.txt
+++ b/crates/codemod-sandbox/src/sandbox/engine/scripts/extract_selector_script.js.txt
@@ -1,22 +1,17 @@
 import astGrep from "codemod:ast-grep";
-import * as exports from "./{script_name}";
 
-export function runSelector() {{
-    try {{
-        if ('getSelector' in exports) {{
-            const getSelector  = exports.getSelector;
-            if (typeof getSelector !== "function") {{
-                throw new Error("jssg selector must be a function. " + typeof getSelector + " found.");
-            }}
-
-            return {{
-                id: "selector",
-                language: CODEMOD_LANGUAGE,
-                ...getSelector({{ params: CODEMOD_PARAMS }})
-            }};
+export async function runSelector() {{
+    const exports = await import("./{script_name}");
+    if ('getSelector' in exports) {{
+        const getSelector  = exports.getSelector;
+        if (typeof getSelector !== "function") {{
+            throw new Error("jssg selector must be a function. " + typeof getSelector + " found.");
         }}
-    }} catch (e) {{
-        console.error(e);
-        return null;
+
+        return {{
+            id: "selector",
+            language: CODEMOD_LANGUAGE,
+            ...getSelector({{ params: CODEMOD_PARAMS }})
+        }};
     }}
 }}

--- a/crates/codemod-sandbox/src/sandbox/engine/scripts/main_script.js.txt
+++ b/crates/codemod-sandbox/src/sandbox/engine/scripts/main_script.js.txt
@@ -2,13 +2,8 @@ import astGrep from "codemod:ast-grep";
 import transform from "./{script_name}";
 
 export function executeCodemod(sgRoot, options) {{
-    try {{
-        if (typeof transform !== "function") {{
-            throw new Error("jssg codemod modules must export a function. " + typeof transform + " found.");
-        }}
-        return transform(sgRoot, options);
-    }} catch (e) {{
-        console.error(e);
-        throw e;
+    if (typeof transform !== "function") {{
+        throw new Error("jssg codemod modules must export a function. " + typeof transform + " found.");
     }}
+    return transform(sgRoot, options);
 }}

--- a/crates/codemod-sandbox/src/sandbox/engine/scripts/shard_script.js.txt
+++ b/crates/codemod-sandbox/src/sandbox/engine/scripts/shard_script.js.txt
@@ -1,17 +1,12 @@
 import shard from "./{script_name}";
 
 export async function executeShard(input) {{
-    try {{
-        if (typeof shard !== "function") {{
-            throw new Error("Shard modules must export a default function. " + typeof shard + " found.");
-        }}
-        const result = await shard(input);
-        if (!Array.isArray(result)) {{
-            throw new Error("Shard function must return an array of shard results. " + typeof result + " found.");
-        }}
-        return result;
-    }} catch (e) {{
-        console.error(e);
-        throw e;
+    if (typeof shard !== "function") {{
+        throw new Error("Shard modules must export a default function. " + typeof shard + " found.");
     }}
+    const result = await shard(input);
+    if (!Array.isArray(result)) {{
+        throw new Error("Shard function must return an array of shard results. " + typeof result + " found.");
+    }}
+    return result;
 }}

--- a/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
@@ -2,7 +2,7 @@ use super::codemod_lang::CodemodLang;
 use super::curated_fs::{CuratedFsConfig, CuratedFsModule, CuratedFsPromisesModule};
 use super::quickjs_adapters::{QuickJSLoader, QuickJSResolver};
 use crate::ast_grep::AstGrepModule;
-use crate::metrics::MetricsModule;
+use crate::metrics::{MetricsContext, MetricsModule};
 use crate::sandbox::errors::ExecutionError;
 use crate::sandbox::resolvers::ModuleResolver;
 use crate::utils::quickjs_utils::maybe_promise;
@@ -159,6 +159,16 @@ where
                 })?;
         }
 
+        // Selector extraction may evaluate the codemod's full module graph.
+        // Install a disposable metrics context so modules that import
+        // `codemod:metrics` can initialize without requiring transform execution.
+        ctx.store_userdata(MetricsContext::new())
+            .map_err(|e| ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                    message: format!("Failed to store MetricsContext: {:?}", e),
+                },
+            })?;
+
         let execution = async {
             let module = Module::declare(ctx.clone(), "__selector_extractor.js", js_code)
                 .catch(&ctx)
@@ -273,4 +283,117 @@ where
         execution.await
     })
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::engine::codemod_lang::CodemodLang;
+    use crate::sandbox::resolvers::oxc_resolver::OxcResolver;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn selector_extraction_propagates_get_selector_errors() {
+        let dir = tempdir().unwrap();
+        let script_path = dir.path().join("codemod.js");
+        std::fs::write(
+            &script_path,
+            r#"
+            export function getSelector() {
+                throw new Error("selector exploded");
+            }
+            export default function codemod() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = Arc::new(OxcResolver::new(dir.path().to_path_buf(), None).unwrap());
+        let result = extract_selector_with_quickjs(SelectorEngineOptions {
+            script_path: &script_path,
+            language: "typescript".parse::<CodemodLang>().unwrap(),
+            resolver,
+            capabilities: None,
+            target_directory: Some(dir.path()),
+        })
+        .await;
+
+        let error = match result {
+            Ok(_) => panic!("selector errors should fail extraction"),
+            Err(error) => error,
+        };
+        assert!(
+            error.to_string().contains("selector exploded"),
+            "expected selector error to propagate, got: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn selector_extraction_supports_const_arrow_get_selector_exports() {
+        let dir = tempdir().unwrap();
+        let script_path = dir.path().join("codemod.js");
+        std::fs::write(
+            &script_path,
+            r#"
+            export const getSelector = () => ({
+                rule: { kind: "string_fragment" },
+            });
+            export default function codemod() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = Arc::new(OxcResolver::new(dir.path().to_path_buf(), None).unwrap());
+        let result = extract_selector_with_quickjs(SelectorEngineOptions {
+            script_path: &script_path,
+            language: "tsx".parse::<CodemodLang>().unwrap(),
+            resolver,
+            capabilities: None,
+            target_directory: Some(dir.path()),
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_some(),
+            "const arrow getSelector exports should be supported"
+        );
+    }
+
+    #[tokio::test]
+    async fn selector_extraction_supports_top_level_metrics_imports() {
+        let dir = tempdir().unwrap();
+        let script_path = dir.path().join("codemod.js");
+        std::fs::write(
+            &script_path,
+            r#"
+            import { useMetricAtom } from "codemod:metrics";
+
+            const selectorMetric = useMetricAtom("selector_metric");
+
+            export const getSelector = () => {
+                selectorMetric.increment();
+                return { rule: { kind: "string_fragment" } };
+            };
+            export default function codemod() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = Arc::new(OxcResolver::new(dir.path().to_path_buf(), None).unwrap());
+        let result = extract_selector_with_quickjs(SelectorEngineOptions {
+            script_path: &script_path,
+            language: "tsx".parse::<CodemodLang>().unwrap(),
+            resolver,
+            capabilities: None,
+            target_directory: Some(dir.path()),
+        })
+        .await
+        .unwrap();
+
+        assert!(
+            result.is_some(),
+            "selector extraction should support top-level metrics imports"
+        );
+    }
 }

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -4367,9 +4367,10 @@ impl Engine {
             }
         }
 
-        // Persist shared state to the workflow state adapter
+        // Persist shared state to the workflow state adapter. Dry-run executions
+        // use the shared state context in-memory only, including shard pre-scans.
         if let Some(wf_run_id) = workflow_run_id {
-            if !self.workflow_run_config.skip_state_writes {
+            if !self.workflow_run_config.skip_state_writes && !config.dry_run {
                 let persistable = shared_state_context.get_persistable();
                 let removals = shared_state_context.get_removals();
 
@@ -5839,6 +5840,85 @@ mod tests {
         );
 
         assert_eq!(eligible, vec!["src/changed.ts"]);
+    }
+
+    #[tokio::test]
+    async fn dry_run_js_ast_grep_does_not_persist_shared_state() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_path = temp_dir.path();
+        std::fs::create_dir_all(temp_path.join("src")).unwrap();
+        std::fs::write(
+            temp_path.join("stateful-codemod.js"),
+            r#"
+import { setState } from "codemod:workflow";
+
+export default function transform(ast) {
+  setState("preScanMutation", "leaked");
+  return ast;
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(temp_path.join("src/app.js"), "const value = 1;\n").unwrap();
+
+        let workflow_run_id = Uuid::new_v4();
+        let config = WorkflowRunConfig {
+            bundle_path: temp_path.to_path_buf(),
+            target_path: temp_path.to_path_buf(),
+            ..WorkflowRunConfig::default()
+        };
+        let engine = Engine::with_state_adapter(
+            Box::new(LocalStateAdapter::with_base_dir(
+                temp_path.join("state-store"),
+            )),
+            config,
+        );
+
+        engine
+            .execute_js_ast_grep_step(
+                "test-node".to_string(),
+                "test-step".to_string(),
+                &UseJSAstGrep {
+                    js_file: "stateful-codemod.js".to_string(),
+                    base_path: Some("src".to_string()),
+                    include: Some(vec!["**/*.js".to_string()]),
+                    exclude: None,
+                    max_threads: None,
+                    dry_run: Some(true),
+                    language: Some("javascript".to_string()),
+                    capabilities: None,
+                    semantic_analysis: Some(SemanticAnalysisConfig::Mode(
+                        SemanticAnalysisMode::File,
+                    )),
+                },
+                None,
+                None,
+                &CapabilitiesData {
+                    capabilities: None,
+                    capabilities_security_callback: None,
+                },
+                &None,
+                Some(workflow_run_id),
+                None,
+                &StructuredLogger::default(),
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let state = engine
+            .state_adapter
+            .lock()
+            .await
+            .get_state(workflow_run_id)
+            .await
+            .unwrap();
+        assert!(
+            !state.contains_key("preScanMutation"),
+            "dry-run shard scans must not persist codemod workflow state"
+        );
     }
 
     #[test]

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -2799,6 +2799,9 @@ impl Engine {
                 }
                 Err(e) => {
                     step_logger.step_end("failure", step_start_time.elapsed().as_millis() as u64);
+                    let _ = self
+                        .append_task_log(task_id, format!("Step {} failed: {}", step.name, e))
+                        .await;
 
                     // Create a task diff to update the status
                     let mut fields = HashMap::new();
@@ -3641,7 +3644,7 @@ impl Engine {
             })?
         };
 
-        let selector_config = extract_selector_with_quickjs(SelectorEngineOptions {
+        let selector_config = match extract_selector_with_quickjs(SelectorEngineOptions {
             script_path: &js_file_path,
             language,
             resolver: Arc::clone(&resolver),
@@ -3652,7 +3655,17 @@ impl Engine {
             target_directory: Some(&target_path),
         })
         .await
-        .map_err(|e| Error::StepExecution(format!("Failed to extract selector: {e}")))?;
+        {
+            Ok(selector_config) => selector_config,
+            Err(e) => {
+                let message = format!("Failed to extract js-ast-grep selector: {e}");
+                if let Some(task_id) = task_log_task_id {
+                    let _ = self.append_task_log(task_id, &message).await;
+                }
+                slog!(logger, warn, "{}", message);
+                None
+            }
+        };
 
         let semantic_provider: Option<Arc<dyn SemanticProvider>> =
             match &js_ast_grep.semantic_analysis {
@@ -4968,8 +4981,15 @@ impl Engine {
         // If a js-ast-grep config is set, pre-scan to find only files with matches
         let eligible_files = if let Some(js_ast_grep) = &shard_config.js_ast_grep {
             Some(
-                self.scan_eligible_files_with_jssg(shard_config, js_ast_grep, &target_path, logger)
-                    .await?,
+                self.scan_eligible_files_with_jssg(
+                    shard_config,
+                    js_ast_grep,
+                    &target_path,
+                    task.id,
+                    task.workflow_run_id,
+                    logger,
+                )
+                .await?,
             )
         } else {
             None
@@ -5079,6 +5099,8 @@ impl Engine {
         shard_config: &butterflow_models::step::UseShard,
         js_ast_grep: &butterflow_models::step::UseJSAstGrep,
         target_path: &Path,
+        task_id: Uuid,
+        workflow_run_id: Uuid,
         logger: &StructuredLogger,
     ) -> Result<Vec<String>> {
         // Clone the config and force dry_run mode
@@ -5102,7 +5124,7 @@ impl Engine {
             .map(|v| v.clone().into_iter().collect());
 
         self.execute_js_ast_grep_step(
-            "shard-scan".to_string(),
+            task_id.to_string(),
             "shard-scan".to_string(),
             &dry_run_config,
             None,
@@ -5116,7 +5138,7 @@ impl Engine {
                     .map(|callback| callback.clone()),
             },
             &None,
-            None,
+            Some(workflow_run_id),
             None,
             logger,
             Some(collector.clone()),

--- a/crates/core/tests/engine_tests.rs
+++ b/crates/core/tests/engine_tests.rs
@@ -4234,6 +4234,79 @@ interface ApiResponse {
 }
 
 #[tokio::test]
+async fn test_execute_js_ast_grep_step_falls_back_when_selector_extraction_fails() {
+    let temp_dir = TempDir::new().unwrap();
+    let temp_path = temp_dir.path();
+
+    create_test_file(
+        temp_path,
+        "codemod.js",
+        r#"
+export function getSelector() {
+  throw new Error("selector should not make the workflow fail");
+}
+
+export default function transform(ast) {
+  return ast
+    .findAll({ rule: { pattern: 'var $NAME = $VALUE' } })
+    .replace('let $NAME = $VALUE');
+}
+"#,
+    );
+
+    create_test_file(
+        temp_path,
+        "src/app.js",
+        r#"
+function main() {
+    var count = 0;
+}
+"#,
+    );
+
+    let config = WorkflowRunConfig {
+        bundle_path: temp_path.to_path_buf(),
+        ..WorkflowRunConfig::default()
+    };
+    let engine = Engine::with_workflow_run_config(config);
+    let result = engine
+        .execute_js_ast_grep_step(
+            "test-node".to_string(),
+            "test-step".to_string(),
+            &UseJSAstGrep {
+                js_file: "codemod.js".to_string(),
+                base_path: Some("src".to_string()),
+                include: Some(vec!["**/*.js".to_string()]),
+                exclude: None,
+                max_threads: Some(2),
+                dry_run: Some(false),
+                language: Some("javascript".to_string()),
+                capabilities: None,
+                semantic_analysis: Some(SemanticAnalysisConfig::Mode(SemanticAnalysisMode::File)),
+            },
+            None,
+            None,
+            &CapabilitiesData {
+                capabilities: None,
+                capabilities_security_callback: None,
+            },
+            &None,
+            None,
+            None,
+            &StructuredLogger::default(),
+            None,
+            None,
+            None,
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "selector extraction is an optimization and should fall back to full-file execution: {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn test_execute_js_ast_grep_step_dry_run() {
     let temp_dir = TempDir::new().unwrap();
     let temp_path = temp_dir.path();


### PR DESCRIPTION
#### 📚 Description
Fix TUI/log handling for sandboxed JSSG failures and fix `getSelector` import.

Internal sandbox wrapper scripts were printing caught errors directly with `console.error`, which can leak into the TUI and corrupt the task table. The wrappers now let errors propagate to Rust, where the engine can handle them consistently.

Also routes shard-scan js-ast-grep execution through the parent `Evaluate Shards` task ID so failures are visible in that task’s logs.

Changes
- changed `runSelector` so that it loads `getSelector` function expression dynamically to avoid temporal dead zone issues.
- Remove direct `console.error` calls from internal selector/codemod/shard wrapper scripts.
- Propagate selector extraction errors instead of swallowing them and returning no selector.
- Append generic step failure summaries to task logs.
- Route shard-scan logs/errors to the parent shard-evaluation task.
- Add coverage that selector extraction propagates `getSelector` failures.


#### 🧪 Test Plan
- `cargo fmt --check` green
- `cargo test -p codemod-sandbox selector_extraction_propagates_get_selector_errors` green
- `cargo test -p butterflow-core shard_scan` green
-  Tested manually on:
    - https://github.com/codemod/useful-codemods/tree/main/codemods/debarrel
    - `I18n` codemod
    - Backstage `location-entityref-required` codemod
