### PR TITLE
feat(jssg-utils): add support to dynamic imports with cb

### DIFF
--- a/.changeset/clear-baboons-wonder.md
+++ b/.changeset/clear-baboons-wonder.md
@@ -1,0 +1,5 @@
+---
+"@jssg/utils": patch
+---
+
+handle JavaScript dynamic imports on addImport, getImport, getAllImports, and removeImport

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -257,10 +257,7 @@ function findRawImportMatches<T extends Language>(
                     kind: "formal_parameters",
                     stopBy: "end",
                     inside: {
-                      any: [
-                        { kind: "arrow_function" },
-                        { kind: "function_expression" },
-                      ],
+                      any: [{ kind: "arrow_function" }, { kind: "function_expression" }],
                     },
                   },
                 },
@@ -281,10 +278,7 @@ function findRawImportMatches<T extends Language>(
                   kind: "formal_parameters",
                   stopBy: "end",
                   inside: {
-                    any: [
-                      { kind: "arrow_function" },
-                      { kind: "function_expression" },
-                    ],
+                    any: [{ kind: "arrow_function" }, { kind: "function_expression" }],
                   },
                 },
               },
@@ -305,10 +299,7 @@ function findRawImportMatches<T extends Language>(
                   kind: "formal_parameters",
                   stopBy: "end",
                   inside: {
-                    any: [
-                      { kind: "arrow_function" },
-                      { kind: "function_expression" },
-                    ],
+                    any: [{ kind: "arrow_function" }, { kind: "function_expression" }],
                   },
                 },
               },

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -152,6 +152,32 @@ function findRawImportMatches<T extends Language>(
     ],
   } satisfies Rule<Language>;
 
+  const dynamicThenRule = {
+    inside: {
+      stopBy: "end",
+      kind: "call_expression",
+      has: {
+        field: "function",
+        kind: "member_expression",
+        all: [
+          {
+            has: {
+              field: "property",
+              kind: "property_identifier",
+              regex: "^then$",
+            },
+          },
+          {
+            has: {
+              field: "object",
+              matches: CJS_OR_DYNAMIC_VALUE_UTIL_RULE,
+            },
+          },
+        ],
+      },
+    },
+  } satisfies Rule<Language>;
+
   return tsProgram.findAll({
     utils: {
       [CJS_OR_DYNAMIC_VALUE_UTIL_RULE]: cjsOrDynamicValue,
@@ -211,6 +237,83 @@ function findRawImportMatches<T extends Language>(
                 matches: CJS_OR_DYNAMIC_VALUE_UTIL_RULE,
               },
             },
+          ],
+        },
+        // - dynamic with callback: import("mod").then(mod => ...) or import("mod").then(function(mod) { ... })
+        {
+          all: [
+            {
+              kind: "identifier",
+              pattern: "$VAR_NAME",
+              any: [
+                {
+                  inside: {
+                    kind: "arrow_function",
+                    field: "parameter",
+                  },
+                },
+                {
+                  inside: {
+                    kind: "formal_parameters",
+                    stopBy: "end",
+                    inside: {
+                      any: [
+                        { kind: "arrow_function" },
+                        { kind: "function_expression" },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+            dynamicThenRule,
+          ],
+        },
+        // - dynamic with destructured callback: import("mod").then(({test}) => ...)
+        {
+          all: [
+            { kind: "shorthand_property_identifier_pattern" },
+            { pattern: "$ORIGINAL" },
+            {
+              inside: {
+                kind: "object_pattern",
+                inside: {
+                  kind: "formal_parameters",
+                  stopBy: "end",
+                  inside: {
+                    any: [
+                      { kind: "arrow_function" },
+                      { kind: "function_expression" },
+                    ],
+                  },
+                },
+              },
+            },
+            dynamicThenRule,
+          ],
+        },
+        // - dynamic with destructured + alias callback: import("mod").then(({test: alias}) => ...)
+        {
+          all: [
+            { kind: "pair_pattern" },
+            { has: { field: "key", kind: "property_identifier", pattern: "$ORIGINAL" } },
+            { has: { field: "value", kind: "identifier", pattern: "$ALIAS" } },
+            {
+              inside: {
+                kind: "object_pattern",
+                inside: {
+                  kind: "formal_parameters",
+                  stopBy: "end",
+                  inside: {
+                    any: [
+                      { kind: "arrow_function" },
+                      { kind: "function_expression" },
+                    ],
+                  },
+                },
+              },
+            },
+            dynamicThenRule,
           ],
         },
         // - CJS: const { foo } = require("mod")

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -1215,7 +1215,7 @@ export function addImport<T extends Language>(
             rule: { kind: "import_clause" },
           });
           if (importClause) {
-            const specifierStr = newSpecifiers.map(formatSpecifier).join(", ");
+            const specifierStr = newSpecifiers.map((spec) => formatSpecifier(spec)).join(", ");
             const insertPos = importClause.range().end.index;
             return {
               startPos: insertPos,

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -152,32 +152,6 @@ function findRawImportMatches<T extends Language>(
     ],
   } satisfies Rule<Language>;
 
-  const dynamicThenRule = {
-    inside: {
-      stopBy: "end",
-      kind: "call_expression",
-      has: {
-        field: "function",
-        kind: "member_expression",
-        all: [
-          {
-            has: {
-              field: "property",
-              kind: "property_identifier",
-              regex: "^then$",
-            },
-          },
-          {
-            has: {
-              field: "object",
-              matches: CJS_OR_DYNAMIC_VALUE_UTIL_RULE,
-            },
-          },
-        ],
-      },
-    },
-  } satisfies Rule<Language>;
-
   return tsProgram.findAll({
     utils: {
       [CJS_OR_DYNAMIC_VALUE_UTIL_RULE]: cjsOrDynamicValue,
@@ -239,72 +213,94 @@ function findRawImportMatches<T extends Language>(
             },
           ],
         },
-        // - dynamic with callback: import("mod").then(mod => ...) or import("mod").then(function(mod) { ... })
         {
           all: [
             {
-              kind: "identifier",
-              pattern: "$VAR_NAME",
               any: [
+                // - dynamic with callback: import("mod").then((mod) => ...) or import("mod").then(function(mod) { ... })
                 {
-                  inside: {
-                    kind: "arrow_function",
-                    field: "parameter",
-                  },
-                },
-                {
+                  kind: "identifier",
+                  pattern: "$NAMESPACE_ALIAS",
                   inside: {
                     kind: "formal_parameters",
-                    stopBy: "end",
+                  },
+                },
+                // - dynamic with callback: import("mod").then(mod => ...)
+                {
+                  kind: "identifier",
+                  pattern: "$NAMESPACE_ALIAS",
+                  inside: {
+                    kind: "arrow_function",
+                  },
+                },
+                // - dynamic with destructured callback: import("mod").then(({test}) => ...)
+                {
+                  kind: "shorthand_property_identifier_pattern",
+                  pattern: "$ORIGINAL",
+                  inside: {
+                    kind: "object_pattern",
                     inside: {
-                      any: [{ kind: "arrow_function" }, { kind: "function_expression" }],
+                      kind: "formal_parameters",
                     },
                   },
                 },
+                // - dynamic with destructured + alias callback: import("mod").then(({test: alias}) => ...)
+                {
+                  all: [
+                    { kind: "pair_pattern" },
+                    { has: { field: "key", kind: "property_identifier", pattern: "$ORIGINAL" } },
+                    {
+                      not: { has: { field: "key", kind: "property_identifier", regex: "default" } },
+                    },
+                    { has: { field: "value", kind: "identifier", pattern: "$ALIAS" } },
+                  ],
+                },
+                // - dynamic with destructured callback using default: import("mod").then(({default: test}) => ...)
+                {
+                  all: [
+                    { kind: "pair_pattern" },
+                    { has: { field: "key", kind: "property_identifier", regex: "default" } },
+                    { has: { field: "value", kind: "identifier", pattern: "$VAR_NAME" } },
+                  ],
+                },
               ],
             },
-            dynamicThenRule,
-          ],
-        },
-        // - dynamic with destructured callback: import("mod").then(({test}) => ...)
-        {
-          all: [
-            { kind: "shorthand_property_identifier_pattern" },
-            { pattern: "$ORIGINAL" },
             {
               inside: {
-                kind: "object_pattern",
-                inside: {
-                  kind: "formal_parameters",
-                  stopBy: "end",
-                  inside: {
-                    any: [{ kind: "arrow_function" }, { kind: "function_expression" }],
-                  },
+                stopBy: "end",
+                kind: "call_expression",
+                has: {
+                  field: "function",
+                  kind: "member_expression",
+                  all: [
+                    {
+                      has: {
+                        field: "property",
+                        kind: "property_identifier",
+                        regex: "^then$",
+                      },
+                    },
+                    {
+                      has: {
+                        field: "object",
+                        kind: "call_expression",
+                        has: {
+                          field: "arguments",
+                          kind: "arguments",
+                          has: {
+                            kind: "string",
+                            has: {
+                              kind: "string_fragment",
+                              pattern: "$SOURCE",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  ],
                 },
               },
             },
-            dynamicThenRule,
-          ],
-        },
-        // - dynamic with destructured + alias callback: import("mod").then(({test: alias}) => ...)
-        {
-          all: [
-            { kind: "pair_pattern" },
-            { has: { field: "key", kind: "property_identifier", pattern: "$ORIGINAL" } },
-            { has: { field: "value", kind: "identifier", pattern: "$ALIAS" } },
-            {
-              inside: {
-                kind: "object_pattern",
-                inside: {
-                  kind: "formal_parameters",
-                  stopBy: "end",
-                  inside: {
-                    any: [{ kind: "arrow_function" }, { kind: "function_expression" }],
-                  },
-                },
-              },
-            },
-            dynamicThenRule,
           ],
         },
         // - CJS: const { foo } = require("mod")
@@ -421,6 +417,7 @@ function matchToImportResult<T extends Language>(
 ): ResolvedImport<T> | null {
   if (options.type === "default") {
     const nameNode = match.getMatch("DEFAULT_NAME") ?? match.getMatch("VAR_NAME");
+
     if (!nameNode) return null;
     return {
       alias: nameNode.text(),
@@ -1251,7 +1248,7 @@ export function addImport<T extends Language>(
                         kind: "string",
                         has: {
                           kind: "string_fragment",
-                          regex: options.from,
+                          regex: stringToExactRegexString(options.from),
                         },
                       },
                     },
@@ -1557,11 +1554,32 @@ export function removeImport<T extends Language>(
             has: {
               field: "function",
               kind: "member_expression",
-              has: {
-                field: "property",
-                kind: "property_identifier",
-                regex: "^then$",
-              },
+              all: [
+                {
+                  has: {
+                    field: "object",
+                    kind: "call_expression",
+                    has: {
+                      field: "arguments",
+                      kind: "arguments",
+                      has: {
+                        kind: "string",
+                        has: {
+                          kind: "string_fragment",
+                          pattern: "$SOURCE",
+                        },
+                      },
+                    },
+                  },
+                },
+                {
+                  has: {
+                    field: "property",
+                    kind: "property_identifier",
+                    regex: "^then$",
+                  },
+                },
+              ],
             },
           },
         },
@@ -1569,7 +1587,7 @@ export function removeImport<T extends Language>(
     });
 
     if (!namespaceDynamicImport) return null;
-    const expressStmtDynamicImport = tsProgram.find({
+    const expressStmtDynamicImport = namespaceDynamicImport.find({
       rule: {
         inside: {
           stopBy: "end",

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -642,9 +642,13 @@ function findNamedImports<T extends Language>(importStmt: SgNode<T>): SgNode<T> 
 /**
  * Generate a specifier string like "foo" or "foo as bar".
  */
-function formatSpecifier(spec: ImportSpecifier): string {
+function formatSpecifier(
+  spec: ImportSpecifier,
+  kind: "named_imports" | "object_pattern" = "named_imports",
+): string {
   if (spec.alias && spec.alias !== spec.name) {
-    return `${spec.name} as ${spec.alias}`;
+    if (kind === "named_imports") return `${spec.name} as ${spec.alias}`;
+    if (kind === "object_pattern") return `${spec.name}: ${spec.alias}`;
   }
   return spec.name;
 }
@@ -664,7 +668,7 @@ function generateEsmImport(options: AddImportOptions): string {
   }
 
   // Named imports
-  const specifierStr = options.specifiers.map(formatSpecifier).join(", ");
+  const specifierStr = options.specifiers.map((spec) => formatSpecifier(spec)).join(", ");
   return `import { ${specifierStr} } from '${source}';\n`;
 }
 
@@ -1034,6 +1038,50 @@ function hasTrailingComma<T extends Language>(nodes: SgNode<T>[]) {
   return false;
 }
 
+function mergeSpecifiers<T extends Language>(
+  parentNode: SgNode<T>,
+  newSpecifiers: ImportSpecifier[],
+) {
+  const parentNodeKind =
+    parentNode.kind() === "object_pattern" ? "object_pattern" : "named_imports";
+  const isMultiline = parentNode.range().start.line !== parentNode.range().end.line;
+  const separator = isMultiline ? `,\n  ` : ", ";
+
+  const trailingComma = hasTrailingComma(parentNode.children()) ? "," : "";
+
+  const namedImportNodes = parentNode.children().filter((n) => n.isNamed() || n.is("comment"));
+
+  const namedImportsText: string[] = [];
+
+  for (let i = 0; i < namedImportNodes.length; i++) {
+    if (isMultiline) {
+      if (namedImportNodes[i + 1]?.is("comment")) {
+        namedImportsText[i] = namedImportNodes[i]?.text() + ",";
+        continue;
+      }
+
+      if (namedImportNodes[i]?.is("comment")) {
+        namedImportsText[i] = namedImportNodes[i]?.text() + "\n  ";
+        continue;
+      }
+
+      namedImportsText[i] = namedImportNodes[i]?.text() + ",\n  ";
+      continue;
+    }
+
+    namedImportsText[i] = namedImportNodes[i]?.text() + ", ";
+  }
+
+  const specifierStr = newSpecifiers.map((spec) => formatSpecifier(spec, parentNodeKind));
+
+  const importsUpdatedStr =
+    namedImportsText.join("") + specifierStr.join(separator) + trailingComma;
+
+  return isMultiline
+    ? parentNode.replace(`{\n  ${importsUpdatedStr}\n}`)
+    : parentNode.replace(`{ ${importsUpdatedStr} }`);
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -1143,6 +1191,7 @@ export function addImport<T extends Language>(
         name: spec.name,
         from: options.from,
       });
+
       if (!existing) {
         newSpecifiers.push(spec);
       }
@@ -1158,46 +1207,7 @@ export function addImport<T extends Language>(
       if (existingImport) {
         const namedImports = findNamedImports(existingImport);
         if (namedImports) {
-          // Add to existing named_imports: insert before the closing brace
-
-          const isMultiline = namedImports.range().start.line !== namedImports.range().end.line;
-          const separator = isMultiline ? `,\n  ` : ", ";
-
-          const trailingComma = hasTrailingComma(namedImports.children()) ? "," : "";
-
-          const namedImportNodes = namedImports
-            .children()
-            .filter((n) => n.isNamed() || n.is("comment"));
-
-          const namedImportsText: string[] = [];
-
-          for (let i = 0; i < namedImportNodes.length; i++) {
-            if (isMultiline) {
-              if (namedImportNodes[i + 1]?.is("comment")) {
-                namedImportsText[i] = namedImportNodes[i]?.text() + ",";
-                continue;
-              }
-
-              if (namedImportNodes[i]?.is("comment")) {
-                namedImportsText[i] = namedImportNodes[i]?.text() + "\n  ";
-                continue;
-              }
-
-              namedImportsText[i] = namedImportNodes[i]?.text() + ",\n  ";
-              continue;
-            }
-
-            namedImportsText[i] = namedImportNodes[i]?.text() + ", ";
-          }
-
-          const specifierStr = newSpecifiers.map(formatSpecifier);
-
-          const importsUpdatedStr =
-            namedImportsText.join("") + specifierStr.join(separator) + trailingComma;
-
-          return isMultiline
-            ? namedImports.replace(`{\n  ${importsUpdatedStr}\n}`)
-            : namedImports.replace(`{ ${importsUpdatedStr} }`);
+          return mergeSpecifiers(namedImports, newSpecifiers);
         } else {
           // Import exists but has no named_imports (e.g., default import only)
           // Add named imports to it: import foo from 'mod' -> import foo, { bar } from 'mod'
@@ -1214,6 +1224,47 @@ export function addImport<T extends Language>(
             };
           }
         }
+      }
+
+      const dynamicImportObjectPattern = (program as unknown as SgNode<TS, "program">).find({
+        rule: {
+          kind: "object_pattern",
+          inside: {
+            stopBy: "end",
+            kind: "call_expression",
+            has: {
+              kind: "member_expression",
+              has: {
+                kind: "call_expression",
+                all: [
+                  {
+                    has: {
+                      field: "function",
+                      kind: "import",
+                    },
+                  },
+                  {
+                    has: {
+                      field: "arguments",
+                      kind: "arguments",
+                      has: {
+                        kind: "string",
+                        has: {
+                          kind: "string_fragment",
+                          regex: options.from,
+                        },
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      if (dynamicImportObjectPattern) {
+        return mergeSpecifiers(dynamicImportObjectPattern, newSpecifiers);
       }
     }
 
@@ -1470,7 +1521,6 @@ export function removeImport<T extends Language>(
       },
     });
 
-    // console.log({ namespaceEsmImport: namespaceEsmImport.text() });
     if (namespaceEsmImport) {
       const statement =
         (namespaceEsmImport.ancestors().find((a) => a.kind() === "import_statement") as

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -1553,40 +1553,36 @@ export function removeImport<T extends Language>(
         kind: "identifier",
         inside: {
           stopBy: "end",
-          kind: "arrow_function",
-          inside: {
-            stopBy: "end",
-            kind: "call_expression",
-            has: {
-              field: "function",
-              kind: "member_expression",
-              all: [
-                {
+          kind: "call_expression",
+          has: {
+            field: "function",
+            kind: "member_expression",
+            all: [
+              {
+                has: {
+                  field: "object",
+                  kind: "call_expression",
                   has: {
-                    field: "object",
-                    kind: "call_expression",
+                    field: "arguments",
+                    kind: "arguments",
                     has: {
-                      field: "arguments",
-                      kind: "arguments",
+                      kind: "string",
                       has: {
-                        kind: "string",
-                        has: {
-                          kind: "string_fragment",
-                          pattern: "$SOURCE",
-                        },
+                        kind: "string_fragment",
+                        pattern: "$SOURCE",
                       },
                     },
                   },
                 },
-                {
-                  has: {
-                    field: "property",
-                    kind: "property_identifier",
-                    regex: "^then$",
-                  },
+              },
+              {
+                has: {
+                  field: "property",
+                  kind: "property_identifier",
+                  regex: "^then$",
                 },
-              ],
-            },
+              },
+            ],
           },
         },
       },

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -1570,6 +1570,7 @@ export function removeImport<T extends Language>(
                       has: {
                         kind: "string_fragment",
                         pattern: "$SOURCE",
+                        regex: stringToExactRegexString(options.from),
                       },
                     },
                   },

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -540,26 +540,12 @@ function findAllImportStatements<T extends Language>(program: SgNode<T, "program
         kind: "variable_declarator",
         has: {
           field: "value",
-          any: [
-            {
-              kind: "call_expression",
-              has: {
-                field: "function",
-                kind: "identifier",
-                regex: "^require$",
-              },
-            },
-            {
-              kind: "await_expression",
-              has: {
-                kind: "call_expression",
-                has: {
-                  field: "function",
-                  regex: "^import$",
-                },
-              },
-            },
-          ],
+          kind: "call_expression",
+          has: {
+            field: "function",
+            kind: "identifier",
+            regex: "^require$",
+          },
         },
       },
       not: {
@@ -571,7 +557,50 @@ function findAllImportStatements<T extends Language>(program: SgNode<T, "program
     },
   });
 
-  return [...esmImports, ...cjsImports, ...cjsVarImports] as unknown as SgNode<T>[];
+  // `var foo = await import(...)`
+  // `import(...)`
+  // `import(...).then((...) => void)`
+  const dynamicImports = tsProgram.findAll({
+    rule: {
+      any: [
+        {
+          kind: "variable_declaration",
+          has: {
+            kind: "variable_declarator",
+            has: {
+              field: "value",
+              kind: "await_expression",
+              has: {
+                kind: "call_expression",
+                has: {
+                  field: "function",
+                  regex: "^import$",
+                },
+              },
+            },
+          },
+        },
+        {
+          kind: "expression_statement",
+          has: {
+            kind: "call_expression",
+            has: {
+              stopBy: "end",
+              field: "function",
+              regex: "^import$",
+            },
+          },
+        },
+      ],
+    },
+  });
+
+  return [
+    ...esmImports,
+    ...cjsImports,
+    ...cjsVarImports,
+    ...dynamicImports,
+  ] as unknown as SgNode<T>[];
 }
 
 /**
@@ -818,6 +847,21 @@ function findImportStatementForSpecifier<T extends Language>(
         specifier: cjsSpecifier as unknown as SgNode<T>,
       };
     }
+  }
+
+  const dynamicImportSpecifier = getImport(tsProgram, {
+    type: "named",
+    from: source,
+    name: specifierName,
+  });
+
+  if (dynamicImportSpecifier?.node) {
+    return {
+      statement: dynamicImportSpecifier.node
+        .ancestors()
+        .find((a) => a.is("expression_statement")) as unknown as SgNode<T>,
+      specifier: dynamicImportSpecifier.node as unknown as SgNode<T>,
+    };
   }
 
   return null;
@@ -1250,7 +1294,7 @@ function requireCallFirstArgIsLiteralSpecifier(
 /**
  * `require('pkg');` as a standalone expression statement (e.g. polyfill registration).
  */
-function removeBareRequireSideEffectEdit(
+function removeBareRequireImportSideEffectEdit(
   program: SgNode<TS, "program">,
   packageName: string,
 ): Edit | null {
@@ -1263,7 +1307,7 @@ function removeBareRequireSideEffectEdit(
       continue;
     }
     const fn = expr.field("function");
-    if (fn?.text() !== "require") {
+    if (fn?.text() !== "require" && fn?.text() !== "import") {
       continue;
     }
     if (!requireCallFirstArgIsLiteralSpecifier(expr as SgNode<TS>, packageName)) {
@@ -1396,7 +1440,7 @@ export function removeImport<T extends Language>(
     if (stripSideEffects) {
       const tsProgram = program as unknown as SgNode<TS, "program">;
       return (
-        removeBareRequireSideEffectEdit(tsProgram, options.from) ??
+        removeBareRequireImportSideEffectEdit(tsProgram, options.from) ??
         removeSideEffectImportStatementEdit(tsProgram, options.from)
       );
     }
@@ -1409,7 +1453,7 @@ export function removeImport<T extends Language>(
     // would miss mixed statements like `import foo, * as ns from 'mod'`,
     // where the default match wins over the namespace fallback.
     const tsProgram = program as unknown as SgNode<TS, "program">;
-    const namespaceImport = tsProgram.find({
+    const namespaceEsmImport = tsProgram.find({
       rule: {
         kind: "namespace_import",
         inside: {
@@ -1425,26 +1469,69 @@ export function removeImport<T extends Language>(
         },
       },
     });
-    if (!namespaceImport) return null;
 
-    const statement =
-      (namespaceImport.ancestors().find((a) => a.kind() === "import_statement") as
-        | SgNode<TS>
-        | undefined) ?? null;
-    if (!statement) return null;
+    // console.log({ namespaceEsmImport: namespaceEsmImport.text() });
+    if (namespaceEsmImport) {
+      const statement =
+        (namespaceEsmImport.ancestors().find((a) => a.kind() === "import_statement") as
+          | SgNode<TS>
+          | undefined) ?? null;
+      if (!statement) return null;
 
-    const parts = analyzeImportClause(statement);
-    if (parts.defaultIdent && parts.namespaceImport) {
-      // Mixed: strip ', * as ns' keeping the default binding.
-      return {
-        startPos: parts.defaultIdent.range().end.index,
-        endPos: parts.namespaceImport.range().end.index,
-        insertedText: "",
-      };
+      const parts = analyzeImportClause(statement);
+      if (parts.defaultIdent && parts.namespaceImport) {
+        // Mixed: strip ', * as ns' keeping the default binding.
+        return {
+          startPos: parts.defaultIdent.range().end.index,
+          endPos: parts.namespaceImport.range().end.index,
+          insertedText: "",
+        };
+      }
+
+      const { start, end } = getStatementRangeWithNewline(
+        statement as unknown as SgNode<Language>,
+        programText,
+      );
+      return { startPos: start, endPos: end, insertedText: "" };
     }
 
+    const namespaceDynamicImport = tsProgram.find({
+      rule: {
+        kind: "identifier",
+        inside: {
+          stopBy: "end",
+          kind: "arrow_function",
+          inside: {
+            stopBy: "end",
+            kind: "call_expression",
+            has: {
+              field: "function",
+              kind: "member_expression",
+              has: {
+                field: "property",
+                kind: "property_identifier",
+                regex: "^then$",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!namespaceDynamicImport) return null;
+    const expressStmtDynamicImport = tsProgram.find({
+      rule: {
+        inside: {
+          stopBy: "end",
+          kind: "expression_statement",
+        },
+      },
+    });
+
+    if (!expressStmtDynamicImport) return null;
+
     const { start, end } = getStatementRangeWithNewline(
-      statement as unknown as SgNode<Language>,
+      expressStmtDynamicImport as unknown as SgNode<Language>,
       programText,
     );
     return { startPos: start, endPos: end, insertedText: "" };

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -576,6 +576,12 @@ function findAllImportStatements<T extends Language>(program: SgNode<T, "program
               },
             },
           },
+          not: {
+            has: {
+              kind: "variable_declarator",
+              nthChild: 2,
+            },
+          },
         },
         {
           kind: "expression_statement",

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -1346,7 +1346,7 @@ function requireCallFirstArgIsLiteralSpecifier(
 }
 
 /**
- * `require('pkg');` as a standalone expression statement (e.g. polyfill registration).
+ * `require('pkg');` / `import('pkg');` as a standalone expression statement (e.g. polyfill registration).
  */
 function removeBareRequireImportSideEffectEdit(
   program: SgNode<TS, "program">,

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -835,6 +835,23 @@ function testAddImportAfterMixedImportsUsesLastSourcePosition() {
   );
 }
 
+function testAddNamedImportToDynamicImportCallback() {
+  const source = `import('mod').then(({foo}) => {\n  foo();\n})`;
+  const program = parseProgram("javascript", source);
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "bar" }],
+    from: "mod",
+  });
+
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === `import('mod').then(({ foo, bar }) => {\n  foo();\n})`,
+    "New import should be inserted after the last import by source position",
+  );
+}
+
 // ============================================================================
 // removeImport tests
 // ============================================================================
@@ -1336,6 +1353,7 @@ function run() {
   testAddImportAfterExisting();
   testAddImportAfterExistingKeepsSeparateLines();
   testAddImportAfterMixedImportsUsesLastSourcePosition();
+  testAddNamedImportToDynamicImportCallback();
 
   // removeImport tests
   testRemoveDefaultImportESM();

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -73,7 +73,7 @@ function testSingleNamedDynamicImport() {
 function testSingleNamedDynamicImportWithAlias() {
   const program = parseProgram(
     "javascript",
-    "import('test').then(({fn: test}) => {\n const pair = fn('test');\n });",
+    "import('test').then(({fn: test}) => {\n const pair = test('test');\n });",
   );
 
   const res = getAllImports(program, { type: "named", name: "fn", from: "test" });
@@ -1209,7 +1209,7 @@ function testRemoveNamespace_MixedWithDefault_KeepsDefault() {
 function testRemoveDefaultImportDynamic() {
   const program = parseProgram(
     "javascript",
-    "import('mod').then(({default: test}) => {\n mod();\n});\nconsole.log('test');\n",
+    "import('mod').then(({default: test}) => {\n test();\n});\nconsole.log('test');\n",
   );
 
   const edit = removeImport(program, {

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -498,6 +498,71 @@ function testNamespaceNotReturnedAlongsideTypedResults() {
 }
 
 // ============================================================================
+// getImport — dynamic .then() callback tests
+// ============================================================================
+
+function testGetImport_DynamicThenArrowDefault() {
+  const program = parseProgram("javascript", "import('mod').then(mod => { mod(); });\n");
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Should find default from dynamic .then() arrow");
+  assert(res!.alias === "mod", "Alias should be the callback param name");
+  assert(res!.isNamespace === false, "isNamespace should be false");
+  assert(res!.moduleType === "esm", "moduleType should be esm for dynamic import");
+}
+
+function testGetImport_DynamicThenArrowParensDefault() {
+  const program = parseProgram("javascript", "import('mod').then((mod) => { mod(); });\n");
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Should find default from dynamic .then() arrow with parens");
+  assert(res!.alias === "mod", "Alias should be the callback param name");
+  assert(res!.moduleType === "esm", "moduleType should be esm");
+}
+
+function testGetImport_DynamicThenFunctionExpressionDefault() {
+  const program = parseProgram("javascript", "import('mod').then(function(mod) { mod(); });\n");
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Should find default from dynamic .then() function expression");
+  assert(res!.alias === "mod", "Alias should be the callback param name");
+  assert(res!.moduleType === "esm", "moduleType should be esm");
+}
+
+function testGetImport_DynamicThenDestructuredNamed() {
+  const program = parseProgram("javascript", "import('mod').then(({fn}) => { fn(); });\n");
+  const res = getImport(program, { type: "named", name: "fn", from: "mod" });
+  assert(res !== null, "Should find named from destructured .then() callback");
+  assert(res!.alias === "fn", "Alias should be the destructured name");
+  assert(res!.moduleType === "esm", "moduleType should be esm");
+}
+
+function testGetImport_DynamicThenDestructuredNamedWithAlias() {
+  const program = parseProgram("javascript", "import('mod').then(({fn: myFn}) => { myFn(); });\n");
+  const res = getImport(program, { type: "named", name: "fn", from: "mod" });
+  assert(res !== null, "Should find named from destructured .then() callback with alias");
+  assert(res!.alias === "myFn", "Alias should be the renamed binding");
+  assert(res!.moduleType === "esm", "moduleType should be esm");
+}
+
+function testGetImport_DynamicThenDestructuredFunctionExpression() {
+  const program = parseProgram("javascript", "import('mod').then(function({fn}) { fn(); });\n");
+  const res = getImport(program, { type: "named", name: "fn", from: "mod" });
+  assert(res !== null, "Should find named from destructured .then() function expression");
+  assert(res!.alias === "fn", "Alias should be the destructured name");
+}
+
+function testGetImport_DynamicThenDestructuredAliasedFunctionExpression() {
+  const program = parseProgram("javascript", "import('mod').then(function({fn: myFn}) { myFn(); });\n");
+  const res = getImport(program, { type: "named", name: "fn", from: "mod" });
+  assert(res !== null, "Should find named from destructured .then() function expression with alias");
+  assert(res!.alias === "myFn", "Alias should be the renamed binding");
+}
+
+function testGetImport_DynamicThenNamedNotFound() {
+  const program = parseProgram("javascript", "import('mod').then(({foo}) => { foo(); });\n");
+  const res = getImport(program, { type: "named", name: "bar", from: "mod" });
+  assert(res === null, "Should return null when requested named specifier is not destructured");
+}
+
+// ============================================================================
 // addImport tests
 // ============================================================================
 
@@ -1157,6 +1222,14 @@ function run() {
   testMultipleNamespaceImports_ReturnsFirstOnly();
   testMultipleNamespaceImports_NamedQuery_ReturnsFirstOnly();
   testNamespaceNotReturnedAlongsideTypedResults();
+  testGetImport_DynamicThenArrowDefault();
+  testGetImport_DynamicThenArrowParensDefault();
+  testGetImport_DynamicThenFunctionExpressionDefault();
+  testGetImport_DynamicThenDestructuredNamed();
+  testGetImport_DynamicThenDestructuredNamedWithAlias();
+  testGetImport_DynamicThenDestructuredFunctionExpression();
+  testGetImport_DynamicThenDestructuredAliasedFunctionExpression();
+  testGetImport_DynamicThenNamedNotFound();
 
   // addImport tests
   testAddDefaultImportESM();

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -57,19 +57,6 @@ function testSingleDefaultESMImport() {
   assert(res[0]!.node.text() === "foo", "Node should reflect identifier");
 }
 
-function testSingleDefaultDynamicImport() {
-  const program = parseProgram(
-    "javascript",
-    "import('foo').then(test => {\n const example = test('bar');\n });",
-  );
-
-  const res = getAllImports(program, { type: "default", from: "foo" });
-  assert(res.length === 1, "Should return exactly one result");
-  assert(res[0]!.isNamespace === false, "isNamespace should be false");
-  assert(res[0]!.moduleType === "esm", "moduleType should be esm");
-  assert(res[0]!.node.text() === "test", "Node should reflect identifier");
-}
-
 function testSingleNamedDynamicImport() {
   const program = parseProgram(
     "javascript",
@@ -509,21 +496,13 @@ function testNamespaceNotReturnedAlongsideTypedResults() {
 // getImport — dynamic .then() callback tests
 // ============================================================================
 
-function testGetImport_DynamicThenArrowDefault() {
-  const program = parseProgram("javascript", "import('mod').then(mod => { mod(); });\n");
-  const res = getImport(program, { type: "default", from: "mod" });
-  assert(res !== null, "Should find default from dynamic .then() arrow");
-  assert(res!.alias === "mod", "Alias should be the callback param name");
-  assert(res!.isNamespace === false, "isNamespace should be false");
-  assert(res!.moduleType === "esm", "moduleType should be esm for dynamic import");
-}
-
 function testGetImport_DynamicThenArrowParensDefault() {
   const program = parseProgram("javascript", "import('mod').then((mod) => { mod(); });\n");
   const res = getImport(program, { type: "default", from: "mod" });
   assert(res !== null, "Should find default from dynamic .then() arrow with parens");
   assert(res!.alias === "mod", "Alias should be the callback param name");
   assert(res!.moduleType === "esm", "moduleType should be esm");
+  assert(res!.isNamespace === true, "moduleType should be esm");
 }
 
 function testGetImport_DynamicThenFunctionExpressionDefault() {
@@ -789,7 +768,7 @@ function testAddNamedImportToDynamicImportCallbackMatchesSourceLiterally() {
   assert(edit !== null, "Should return an edit");
   const result = program.commitEdits([edit!]);
   assert(
-    result === "import { b } from 'foo.bar';\nimport('fooXbar').then(({ a }) => a);\n",
+    result === "import('fooXbar').then(({ a }) => a);\nimport { b } from 'foo.bar';\n",
     `Should not merge into a regex-like source match, got: ${JSON.stringify(result)}`,
   );
 }
@@ -1349,7 +1328,6 @@ function testRemoveSideEffectImportOnlyMatchesSourceField() {
 }
 
 function run() {
-  // getAllImports tests
   testReturnsEmptyArrayWhenNoImports();
   testReturnsEmptyArrayWhenModuleNotImported();
   testReturnsEmptyArrayWhenNamedSpecifierNotFound();
@@ -1369,7 +1347,6 @@ function run() {
   testMultipleNamespaceImports_getAllImports_AllReturned();
   testMultipleNamespaceImports_NamedQuery_getAllImports_AllReturned();
   testNamespaceNotReturnedAlongsideTypedResults_getAllImports();
-  testSingleDefaultDynamicImport();
   testSingleNamedDynamicImport();
   testSingleNamedDynamicImportWithAlias();
 
@@ -1388,7 +1365,6 @@ function run() {
   testMultipleNamespaceImports_ReturnsFirstOnly();
   testMultipleNamespaceImports_NamedQuery_ReturnsFirstOnly();
   testNamespaceNotReturnedAlongsideTypedResults();
-  testGetImport_DynamicThenArrowDefault();
   testGetImport_DynamicThenArrowParensDefault();
   testGetImport_DynamicThenFunctionExpressionDefault();
   testGetImport_DynamicThenDestructuredNamed();

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -1327,6 +1327,19 @@ function testRemoveSideEffectImportOnlyMatchesSourceField() {
   assert(program.text() === src, "Source must be unchanged");
 }
 
+function testRemoveImportDoesNotRemoveUnrelatedModule() {
+  const program = parseProgram(
+    "javascript",
+    "foo.then((value) => value);\nimport('mod').then((mod) => {\n mod.fn();\n});\n",
+  );
+
+  const edit = removeImport(program, {
+    type: "namespace",
+    from: "not-mod",
+  });
+  assert(edit === null, "Should return null");
+}
+
 function run() {
   testReturnsEmptyArrayWhenNoImports();
   testReturnsEmptyArrayWhenModuleNotImported();
@@ -1425,6 +1438,7 @@ function run() {
   testRemoveNamedImportDynamicSpecific();
   testRemoveNamespaceImportDynamicIgnoresUnrelatedThen();
   testRemoveDefaultDynamicImportMultiDeclaratorReturnsNull();
+  testRemoveImportDoesNotRemoveUnrelatedModule();
 
   console.log("imports.test.ts: all assertions passed");
 }

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -1209,7 +1209,7 @@ function testRemoveNamespace_MixedWithDefault_KeepsDefault() {
 function testRemoveDefaultImportDynamic() {
   const program = parseProgram(
     "javascript",
-    "import('mod').then(({default: test}) => {\n test();\n});\nconsole.log('test');\n",
+    "import('mod').then(function({default: test}) => {\n test();\n});\nconsole.log('test');\n",
   );
 
   const edit = removeImport(program, {

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -576,6 +576,20 @@ function testGetImport_DynamicThenNamedNotFound() {
   assert(res === null, "Should return null when requested named specifier is not destructured");
 }
 
+function testGetImport_DynamicThenCallbackParamIsNamespaceLike() {
+  const program = parseProgram("javascript", "import('mod').then(mod => { mod.fn(); });\n");
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res !== null, "Should find namespace-like dynamic .then() callback param");
+  assert(res!.alias === "mod", "Alias should be the callback parameter name");
+  assert(res!.isNamespace === true, "Callback param represents the module namespace, not default");
+}
+
+function testGetImport_DynamicThenDestructuredAliasIsNotDefault() {
+  const program = parseProgram("javascript", "import('mod').then(({fn: myFn}) => { myFn(); });\n");
+  const res = getImport(program, { type: "default", from: "mod" });
+  assert(res === null, "Destructured named aliases should not satisfy a default import lookup");
+}
+
 // ============================================================================
 // addImport tests
 // ============================================================================
@@ -762,6 +776,21 @@ function testAddImportMergesMultilineNamedSpecifiersPreservingTrailingComma() {
   assert(
     result === "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more,\n  bar,\n} from 'mod'\n",
     "Should merge bar into existing multiline named imports",
+  );
+}
+
+function testAddNamedImportToDynamicImportCallbackMatchesSourceLiterally() {
+  const program = parseProgram("javascript", "import('fooXbar').then(({ a }) => a);\n");
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "b" }],
+    from: "foo.bar",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "import { b } from 'foo.bar';\nimport('fooXbar').then(({ a }) => a);\n",
+    `Should not merge into a regex-like source match, got: ${JSON.stringify(result)}`,
   );
 }
 
@@ -1273,6 +1302,37 @@ function testRemoveNamedImportDynamicSpecific() {
   );
 }
 
+function testRemoveNamespaceImportDynamicIgnoresUnrelatedThen() {
+  const program = parseProgram(
+    "javascript",
+    "foo.then((value) => value);\nimport('mod').then((mod) => {\n mod.fn();\n});\n",
+  );
+
+  const edit = removeImport(program, {
+    type: "namespace",
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(
+    result === "foo.then((value) => value);\n",
+    `Should remove only the matching dynamic import statement, got: ${JSON.stringify(result)}`,
+  );
+}
+
+function testRemoveDefaultDynamicImportMultiDeclaratorReturnsNull() {
+  const program = parseProgram(
+    "javascript",
+    "var mod = await import('mod'), keep = 1;\nconsole.log(keep);\n",
+  );
+
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+  });
+  assert(edit === null, "Should not remove multi-declarator dynamic import statements");
+}
+
 /** Only the module source string counts — not other string literals (e.g. import attributes). */
 function testRemoveSideEffectImportOnlyMatchesSourceField() {
   const src = "import 'foo' assert { type: 'mod' };\nconsole.log(1);\n";
@@ -1336,6 +1396,8 @@ function run() {
   testGetImport_DynamicThenDestructuredFunctionExpression();
   testGetImport_DynamicThenDestructuredAliasedFunctionExpression();
   testGetImport_DynamicThenNamedNotFound();
+  testGetImport_DynamicThenCallbackParamIsNamespaceLike();
+  testGetImport_DynamicThenDestructuredAliasIsNotDefault();
 
   // addImport tests
   testAddDefaultImportESM();
@@ -1350,6 +1412,7 @@ function run() {
   testAddImportMergesMultilineNamedSpecifiers();
   testAddImportMergesMultilineNamedSpecifiersWithComment();
   testAddImportMergesMultilineNamedSpecifiersPreservingTrailingComma();
+  testAddNamedImportToDynamicImportCallbackMatchesSourceLiterally();
   testAddImportAfterExisting();
   testAddImportAfterExistingKeepsSeparateLines();
   testAddImportAfterMixedImportsUsesLastSourcePosition();
@@ -1384,6 +1447,8 @@ function run() {
   testRemoveNamespaceImportDynamic();
   testRemoveSideEffectImportDynamic();
   testRemoveNamedImportDynamicSpecific();
+  testRemoveNamespaceImportDynamicIgnoresUnrelatedThen();
+  testRemoveDefaultDynamicImportMultiDeclaratorReturnsNull();
 
   console.log("imports.test.ts: all assertions passed");
 }

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -58,7 +58,10 @@ function testSingleDefaultESMImport() {
 }
 
 function testSingleDefaultDynamicImport() {
-  const program = parseProgram("javascript", "import('foo').then(test => {\n const example = test('bar');\n });");
+  const program = parseProgram(
+    "javascript",
+    "import('foo').then(test => {\n const example = test('bar');\n });",
+  );
 
   const res = getAllImports(program, { type: "default", from: "foo" });
   assert(res.length === 1, "Should return exactly one result");
@@ -68,9 +71,12 @@ function testSingleDefaultDynamicImport() {
 }
 
 function testSingleNamedDynamicImport() {
-  const program = parseProgram("javascript", "import('test').then(({fn}) => {\n const pair = fn('test');\n });");
+  const program = parseProgram(
+    "javascript",
+    "import('test').then(({fn}) => {\n const pair = fn('test');\n });",
+  );
 
-  const res = getAllImports(program, { type: "named", name: 'fn' , from: "test" });
+  const res = getAllImports(program, { type: "named", name: "fn", from: "test" });
   assert(res.length === 1, "Should return exactly one result");
   assert(res[0]!.isNamespace === false, "isNamespace should be false");
   assert(res[0]!.moduleType === "esm", "moduleType should be esm");
@@ -78,15 +84,17 @@ function testSingleNamedDynamicImport() {
 }
 
 function testSingleNamedDynamicImportWithAlias() {
-  const program = parseProgram("javascript", "import('test').then(({fn: test}) => {\n const pair = fn('test');\n });");
+  const program = parseProgram(
+    "javascript",
+    "import('test').then(({fn: test}) => {\n const pair = fn('test');\n });",
+  );
 
-  const res = getAllImports(program, { type: "named", name: 'fn' , from: "test" });
+  const res = getAllImports(program, { type: "named", name: "fn", from: "test" });
   assert(res.length === 1, "Should return exactly one result");
   assert(res[0]!.node.text() === "test", "Node should reflect identifier");
   assert(res[0]!.moduleType === "esm", "moduleType should be esm for dynamic()");
   assert(res[0]!.alias === "test", "Alias should be the import name");
 }
-
 
 function testSingleDefaultCJSImport() {
   const program = parseProgram("javascript", "const bar = require('mod');\nconsole.log(bar);\n");
@@ -550,9 +558,15 @@ function testGetImport_DynamicThenDestructuredFunctionExpression() {
 }
 
 function testGetImport_DynamicThenDestructuredAliasedFunctionExpression() {
-  const program = parseProgram("javascript", "import('mod').then(function({fn: myFn}) { myFn(); });\n");
+  const program = parseProgram(
+    "javascript",
+    "import('mod').then(function({fn: myFn}) { myFn(); });\n",
+  );
   const res = getImport(program, { type: "named", name: "fn", from: "mod" });
-  assert(res !== null, "Should find named from destructured .then() function expression with alias");
+  assert(
+    res !== null,
+    "Should find named from destructured .then() function expression with alias",
+  );
   assert(res!.alias === "myFn", "Alias should be the renamed binding");
 }
 
@@ -1205,7 +1219,7 @@ function run() {
   testNamespaceNotReturnedAlongsideTypedResults_getAllImports();
   testSingleDefaultDynamicImport();
   testSingleNamedDynamicImport();
-  testSingleNamedDynamicImportWithAlias()
+  testSingleNamedDynamicImportWithAlias();
 
   // getImport tests
   testReturnsNullWhenNoMatches();

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -1181,6 +1181,81 @@ function testRemoveNamespace_MixedWithDefault_KeepsDefault() {
   );
 }
 
+function testRemoveDefaultImportDynamic() {
+  const program = parseProgram(
+    "javascript",
+    "import('mod').then(({default: test}) => {\n mod();\n});\nconsole.log('test');\n",
+  );
+
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: false,
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(result === `console.log('test');\n`, "Should remove the import statement");
+}
+
+function testRemoveSideEffectImportDynamic() {
+  const program = parseProgram("javascript", "import('mod');\nconsole.log('foo');");
+
+  const edit = removeImport(program, {
+    type: "default",
+    from: "mod",
+  });
+  assert(edit === null, "Should not return an edit");
+
+  const editSideEffect = removeImport(program, {
+    type: "default",
+    from: "mod",
+    removeSideEffectForms: true,
+  });
+
+  assert(editSideEffect !== null, "Should return an edit");
+
+  const result = program.commitEdits([editSideEffect!]);
+
+  assert(result === `console.log('foo');`, "Should remove the import statement");
+}
+
+function testRemoveNamespaceImportDynamic() {
+  const program = parseProgram(
+    "javascript",
+    "import('mod').then((mod) => {\n mod();\n});\nconsole.log('test');\n",
+  );
+
+  const edit = removeImport(program, {
+    type: "namespace",
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit");
+  const result = program.commitEdits([edit!]);
+  assert(result === `console.log('test');\n`, "Should remove the import statement");
+}
+
+function testRemoveNamedImportDynamicSpecific() {
+  const program = parseProgram(
+    "javascript",
+    "import('mod').then(({foo, bar}) => {\n bar();\n});\nconsole.log('test');\n",
+  );
+
+  const edit = removeImport(program, {
+    type: "named",
+    from: "mod",
+    specifiers: ["foo"],
+  });
+
+  assert(edit !== null, "Should return an edit");
+
+  const result = program.commitEdits([edit!]);
+
+  assert(
+    result === `import('mod').then(({bar}) => {\n bar();\n});\nconsole.log('test');\n`,
+    "Should remove the import statement",
+  );
+}
+
 /** Only the module source string counts — not other string literals (e.g. import attributes). */
 function testRemoveSideEffectImportOnlyMatchesSourceField() {
   const src = "import 'foo' assert { type: 'mod' };\nconsole.log(1);\n";
@@ -1287,6 +1362,10 @@ function run() {
   testRemoveNamed_SubsetOfMixed_KeepsBoth();
   testRemoveNamed_OptionsExceedStatement_PureNamedOnlyRemovesMatches();
   testRemoveNamespace_MixedWithDefault_KeepsDefault();
+  testRemoveDefaultImportDynamic();
+  testRemoveNamespaceImportDynamic();
+  testRemoveSideEffectImportDynamic();
+  testRemoveNamedImportDynamicSpecific();
 
   console.log("imports.test.ts: all assertions passed");
 }

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -57,6 +57,37 @@ function testSingleDefaultESMImport() {
   assert(res[0]!.node.text() === "foo", "Node should reflect identifier");
 }
 
+function testSingleDefaultDynamicImport() {
+  const program = parseProgram("javascript", "import('foo').then(test => {\n const example = test('bar');\n });");
+
+  const res = getAllImports(program, { type: "default", from: "foo" });
+  assert(res.length === 1, "Should return exactly one result");
+  assert(res[0]!.isNamespace === false, "isNamespace should be false");
+  assert(res[0]!.moduleType === "esm", "moduleType should be esm");
+  assert(res[0]!.node.text() === "test", "Node should reflect identifier");
+}
+
+function testSingleNamedDynamicImport() {
+  const program = parseProgram("javascript", "import('test').then(({fn}) => {\n const pair = fn('test');\n });");
+
+  const res = getAllImports(program, { type: "named", name: 'fn' , from: "test" });
+  assert(res.length === 1, "Should return exactly one result");
+  assert(res[0]!.isNamespace === false, "isNamespace should be false");
+  assert(res[0]!.moduleType === "esm", "moduleType should be esm");
+  assert(res[0]!.node.text() === "fn", "Node should reflect identifier");
+}
+
+function testSingleNamedDynamicImportWithAlias() {
+  const program = parseProgram("javascript", "import('test').then(({fn: test}) => {\n const pair = fn('test');\n });");
+
+  const res = getAllImports(program, { type: "named", name: 'fn' , from: "test" });
+  assert(res.length === 1, "Should return exactly one result");
+  assert(res[0]!.node.text() === "test", "Node should reflect identifier");
+  assert(res[0]!.moduleType === "esm", "moduleType should be esm for dynamic()");
+  assert(res[0]!.alias === "test", "Alias should be the import name");
+}
+
+
 function testSingleDefaultCJSImport() {
   const program = parseProgram("javascript", "const bar = require('mod');\nconsole.log(bar);\n");
 
@@ -1107,6 +1138,9 @@ function run() {
   testMultipleNamespaceImports_getAllImports_AllReturned();
   testMultipleNamespaceImports_NamedQuery_getAllImports_AllReturned();
   testNamespaceNotReturnedAlongsideTypedResults_getAllImports();
+  testSingleDefaultDynamicImport();
+  testSingleNamedDynamicImport();
+  testSingleNamedDynamicImportWithAlias()
 
   // getImport tests
   testReturnsNullWhenNoMatches();


### PR DESCRIPTION
Adds dynamic `import()` support to `addImport`, `getImport`, `getAllImports`, and `removeImport`.

## What Changed

- `getImport` and `getAllImports` now detect dynamic imports like:
```ts
import("mod").then(mod => {});
import("mod").then(({ fn }) => {});
import("mod").then(({ fn: myFn }) => {});
import("mod").then(function({ fn }) {});
```
  
- addImport can now merge named specifiers into dynamic import callbacks:
```js
import("mod").then(({ foo }) => {});
becomes:
import("mod").then(({ foo, bar }) => {});
```

- removeImport can now remove dynamic import forms:
```js
import("mod").then(mod => {});
import("mod").then(({ foo, bar }) => {});
import("mod");
```

## Examples
```js
getImport(program, { type: "default", from: "mod" });
// finds: import("mod").then(mod => {})

getImport(program, { type: "named", name: "fn", from: "mod" });
// finds: import("mod").then(({ fn }) => {})

getAllImports(program, { type: "named", name: "fn", from: "mod" });
// returns all matching dynamic/static/CJS imports

addImport(program, {
  type: "named",
  specifiers: [{ name: "bar" }],
  from: "mod",
});
// import("mod").then(({ foo }) => {})
// -> import("mod").then(({ foo, bar }) => {})

removeImport(program, {
  type: "named",
  specifiers: ["foo"],
  from: "mod",
});
// import("mod").then(({ foo, bar }) => {})
// -> import("mod").then(({ bar }) => {})

removeImport(program, {
  type: "default",
  from: "mod",
  removeSideEffectForms: true,
});
// import("mod");
// -> removed
```

#### 🔗 Linked Issue
#2156 