### PR TITLE
Stop automatic codex review reruns on push

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -6,7 +6,6 @@ on:
       - main
     types:
       - opened
-      - synchronize
       - reopened
       - ready_for_review
   workflow_dispatch:


### PR DESCRIPTION
Removes the synchronize trigger from the Codex PR review workflow so reviews only run automatically on open, reopen, or ready-for-review events. Manual reruns remain available through workflow_dispatch.