### PR TITLE
Soft-fail Codex review for codemod bot PRs

### DIFF
--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -63,6 +63,7 @@ jobs:
       issues: write
     steps:
       - uses: codemod/codex-review-action@6ee78346401c879c73ab6eb408e1945c65739a19
+        continue-on-error: ${{ github.actor == 'codemod[bot]' }}
         with:
           github_token: ${{ github.token }}
           pr_number: ${{ needs.resolve-pr.outputs.pr_number }}


### PR DESCRIPTION
Makes the Codex PR review step non-blocking when the workflow is triggered by codemod[bot]. This keeps normal human-opened PR review failures hard, while preventing automated docs update PRs from going red because the bot actor does not have write access required by openai/codex-action.