### PR TITLE
fix(jssg-utils): fix addImport output format

### DIFF
--- a/.changeset/deep-insects-take.md
+++ b/.changeset/deep-insects-take.md
@@ -1,0 +1,5 @@
+---
+"@jssg/utils": patch
+---
+
+Fix addImport formatting output by preserving comma placement and existing trailing comma style for both single-line and multiline imports.

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -1027,24 +1027,35 @@ export function addImport<T extends Language>(
 
           const trailingComma = hasTrailingComma(namedImports.children()) ? "," : "";
 
-          const namedImportsNodes = namedImports
+          const namedImportNodes = namedImports
             .children()
-            .filter((n) => n.isNamed() && !n.is("comment"));
+            .filter((n) => n.isNamed() || n.is("comment"));
 
-          const lines = Object.values(
-            Object.groupBy(namedImportsNodes, (node) => {
-              return node.range().start.line;
-            }),
-          );
+          const namedImportsText: string[] = [];
 
-          const namedImportsText = lines.map((line) => {
-            return line?.map((node) => node.text()).join(" ");
-          });
+          for (let i = 0; i < namedImportNodes.length; i++) {
+            if (isMultiline) {
+              if (namedImportNodes[i + 1]?.is("comment")) {
+                namedImportsText[i] = namedImportNodes[i]?.text() + ",";
+                continue;
+              }
+
+              if (namedImportNodes[i]?.is("comment")) {
+                namedImportsText[i] = namedImportNodes[i]?.text() + "\n  ";
+                continue;
+              }
+
+              namedImportsText[i] = namedImportNodes[i]?.text() + ",\n  ";
+              continue;
+            }
+
+            namedImportsText[i] = namedImportNodes[i]?.text() + ", ";
+          }
 
           const specifierStr = newSpecifiers.map(formatSpecifier);
 
           const importsUpdatedStr =
-            namedImportsText.concat(specifierStr).join(separator) + trailingComma;
+            namedImportsText.join("") + specifierStr.join(separator) + trailingComma;
 
           return isMultiline
             ? namedImports.replace(`{\n  ${importsUpdatedStr}\n}`)

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -881,19 +881,19 @@ function getSpecifierRangeWithSeparator<T extends Language>(
 }
 
 function hasTrailingComma<T extends Language>(nodes: SgNode<T>[]) {
-  const closeBraceIdx = nodes.findLastIndex(n => n.is('}'))
+  const closeBraceIdx = nodes.findLastIndex((n) => n.is("}"));
   // check if the node before the closing brace `}` is a comma, ignoring comments.
-  for (let i = closeBraceIdx-1; i > 0; i--) {
-    const node = nodes[i]
+  for (let i = closeBraceIdx - 1; i > 0; i--) {
+    const node = nodes[i];
 
-    if(node?.is('comment')) {
-      continue
+    if (node?.is("comment")) {
+      continue;
     }
 
-    return node?.is(',')
+    return node?.is(",");
   }
 
-  return false
+  return false;
 }
 
 // ============================================================================
@@ -1021,32 +1021,34 @@ export function addImport<T extends Language>(
         const namedImports = findNamedImports(existingImport);
         if (namedImports) {
           // Add to existing named_imports: insert before the closing brace
-          
+
           const isMultiline = namedImports.range().start.line !== namedImports.range().end.line;
-          const separator = isMultiline ? `,\n  ` : ', ';
+          const separator = isMultiline ? `,\n  ` : ", ";
 
-          const trailingComma = hasTrailingComma(namedImports.children()) ? ',' : ''
+          const trailingComma = hasTrailingComma(namedImports.children()) ? "," : "";
 
-          const namedImportsNodes = namedImports.children().filter(n => n.isNamed() && !n.is('comment'));
+          const namedImportsNodes = namedImports
+            .children()
+            .filter((n) => n.isNamed() && !n.is("comment"));
 
-          const lines = Object.values(Object.groupBy(namedImportsNodes, (node) => {
-            return node.range().start.line
-          }));
+          const lines = Object.values(
+            Object.groupBy(namedImportsNodes, (node) => {
+              return node.range().start.line;
+            }),
+          );
 
-          const namedImportsText = lines.map(line => {
-            return line?.map(node => node.text()).join(' ')
-          })
+          const namedImportsText = lines.map((line) => {
+            return line?.map((node) => node.text()).join(" ");
+          });
 
           const specifierStr = newSpecifiers.map(formatSpecifier);
 
-          const importsUpdatedStr = namedImportsText
-            .concat(specifierStr)
-            .join(separator)
-            + trailingComma
+          const importsUpdatedStr =
+            namedImportsText.concat(specifierStr).join(separator) + trailingComma;
 
           return isMultiline
             ? namedImports.replace(`{\n  ${importsUpdatedStr}\n}`)
-            : namedImports.replace(`{ ${importsUpdatedStr} }`)
+            : namedImports.replace(`{ ${importsUpdatedStr} }`);
         } else {
           // Import exists but has no named_imports (e.g., default import only)
           // Add named imports to it: import foo from 'mod' -> import foo, { bar } from 'mod'

--- a/packages/jssg-utils/src/javascript/exports/imports.ts
+++ b/packages/jssg-utils/src/javascript/exports/imports.ts
@@ -880,6 +880,22 @@ function getSpecifierRangeWithSeparator<T extends Language>(
   return { start, end };
 }
 
+function hasTrailingComma<T extends Language>(nodes: SgNode<T>[]) {
+  const closeBraceIdx = nodes.findLastIndex(n => n.is('}'))
+  // check if the node before the closing brace `}` is a comma, ignoring comments.
+  for (let i = closeBraceIdx-1; i > 0; i--) {
+    const node = nodes[i]
+
+    if(node?.is('comment')) {
+      continue
+    }
+
+    return node?.is(',')
+  }
+
+  return false
+}
+
 // ============================================================================
 // Public API
 // ============================================================================
@@ -1005,22 +1021,32 @@ export function addImport<T extends Language>(
         const namedImports = findNamedImports(existingImport);
         if (namedImports) {
           // Add to existing named_imports: insert before the closing brace
-          const namedImportsText = namedImports.text();
-          const closingBraceIdx = namedImportsText.lastIndexOf("}");
-          if (closingBraceIdx > 0) {
-            const insertPos = namedImports.range().start.index + closingBraceIdx;
-            const specifierStr = newSpecifiers.map(formatSpecifier).join(", ");
-            // Check if there are existing specifiers (need comma)
-            const hasExistingSpecifiers =
-              namedImportsText.slice(1, closingBraceIdx).trim().length > 0;
-            const insertText = hasExistingSpecifiers ? `, ${specifierStr}` : ` ${specifierStr} `;
+          
+          const isMultiline = namedImports.range().start.line !== namedImports.range().end.line;
+          const separator = isMultiline ? `,\n  ` : ', ';
 
-            return {
-              startPos: insertPos,
-              endPos: insertPos,
-              insertedText: insertText,
-            };
-          }
+          const trailingComma = hasTrailingComma(namedImports.children()) ? ',' : ''
+
+          const namedImportsNodes = namedImports.children().filter(n => n.isNamed() && !n.is('comment'));
+
+          const lines = Object.values(Object.groupBy(namedImportsNodes, (node) => {
+            return node.range().start.line
+          }));
+
+          const namedImportsText = lines.map(line => {
+            return line?.map(node => node.text()).join(' ')
+          })
+
+          const specifierStr = newSpecifiers.map(formatSpecifier);
+
+          const importsUpdatedStr = namedImportsText
+            .concat(specifierStr)
+            .join(separator)
+            + trailingComma
+
+          return isMultiline
+            ? namedImports.replace(`{\n  ${importsUpdatedStr}\n}`)
+            : namedImports.replace(`{ ${importsUpdatedStr} }`)
         } else {
           // Import exists but has no named_imports (e.g., default import only)
           // Add named imports to it: import foo from 'mod' -> import foo, { bar } from 'mod'

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -577,7 +577,10 @@ function testAddImportMergesNamedSpecifiers() {
 }
 
 function testAddImportMergesMultilineNamedSpecifiers() {
-  const program = parseProgram("javascript", "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more\n} from 'mod'\n");
+  const program = parseProgram(
+    "javascript",
+    "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more\n} from 'mod'\n",
+  );
   const edit = addImport(program, {
     type: "named",
     specifiers: [{ name: "bar" }],
@@ -592,9 +595,11 @@ function testAddImportMergesMultilineNamedSpecifiers() {
   );
 }
 
-
 function testAddImportMergesMultilineNamedSpecifiersPreservingTrailingComma() {
-  const program = parseProgram("javascript", "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more,\n} from 'mod'\n");
+  const program = parseProgram(
+    "javascript",
+    "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more,\n} from 'mod'\n",
+  );
   const edit = addImport(program, {
     type: "named",
     specifiers: [{ name: "bar" }],

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -569,11 +569,44 @@ function testAddImportMergesNamedSpecifiers() {
   const result = program.commitEdits([edit!]);
   // Check that both foo and bar are in the same import statement
   assert(
-    result.includes("foo") && result.includes("bar") && result.includes("from 'mod'"),
+    result === "import { foo, bar } from 'mod';\nconsole.log(foo);\n",
     "Should merge bar into existing named imports",
   );
   // Make sure we didn't create a new import statement
   assert((result.match(/import/g) || []).length === 1, "Should have only one import statement");
+}
+
+function testAddImportMergesMultilineNamedSpecifiers() {
+  const program = parseProgram("javascript", "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more\n} from 'mod'\n");
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "bar" }],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit to merge");
+  const result = program.commitEdits([edit!]);
+
+  assert(
+    result === "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more,\n  bar\n} from 'mod'\n",
+    "Should merge bar into existing multiline named imports",
+  );
+}
+
+
+function testAddImportMergesMultilineNamedSpecifiersPreservingTrailingComma() {
+  const program = parseProgram("javascript", "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more,\n} from 'mod'\n");
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "bar" }],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit to merge");
+  const result = program.commitEdits([edit!]);
+
+  assert(
+    result === "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more,\n  bar,\n} from 'mod'\n",
+    "Should merge bar into existing multiline named imports",
+  );
 }
 
 function testAddImportAfterExisting() {
@@ -1054,6 +1087,8 @@ function run() {
   testAddImportSkipsExistingDefault();
   testAddImportSkipsExistingNamed();
   testAddImportMergesNamedSpecifiers();
+  testAddImportMergesMultilineNamedSpecifiers();
+  testAddImportMergesMultilineNamedSpecifiersPreservingTrailingComma();
   testAddImportAfterExisting();
   testAddImportAfterExistingKeepsSeparateLines();
   testAddImportAfterMixedImportsUsesLastSourcePosition();

--- a/packages/jssg-utils/tests/imports.test.ts
+++ b/packages/jssg-utils/tests/imports.test.ts
@@ -576,6 +576,27 @@ function testAddImportMergesNamedSpecifiers() {
   assert((result.match(/import/g) || []).length === 1, "Should have only one import statement");
 }
 
+function testAddImportMergesNamedSpecifiersWithMultiplePreviousImports() {
+  const program = parseProgram(
+    "javascript",
+    "import { foo, baz } from 'mod';\nconsole.log(foo);\n",
+  );
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "bar" }],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit to merge");
+  const result = program.commitEdits([edit!]);
+  // Check that both foo and bar are in the same import statement
+  assert(
+    result === "import { foo, baz, bar } from 'mod';\nconsole.log(foo);\n",
+    "Should merge bar into existing multiple named imports",
+  );
+  // Make sure we didn't create a new import statement
+  assert((result.match(/import/g) || []).length === 1, "Should have only one import statement");
+}
+
 function testAddImportMergesMultilineNamedSpecifiers() {
   const program = parseProgram(
     "javascript",
@@ -592,6 +613,26 @@ function testAddImportMergesMultilineNamedSpecifiers() {
   assert(
     result === "import {\n  foo,\n  baz,\n  fiz,\n  test,\n  more,\n  bar\n} from 'mod'\n",
     "Should merge bar into existing multiline named imports",
+  );
+}
+
+function testAddImportMergesMultilineNamedSpecifiersWithComment() {
+  const program = parseProgram(
+    "javascript",
+    "import {\n  foo,\n  baz,// this is a comment\n  fiz,\n  test,\n  more\n} from 'mod'\n",
+  );
+  const edit = addImport(program, {
+    type: "named",
+    specifiers: [{ name: "bar" }],
+    from: "mod",
+  });
+  assert(edit !== null, "Should return an edit to merge");
+  const result = program.commitEdits([edit!]);
+
+  assert(
+    result ===
+      "import {\n  foo,\n  baz,// this is a comment\n  fiz,\n  test,\n  more,\n  bar\n} from 'mod'\n",
+    "Should merge bar into existing multiline named imports with comment",
   );
 }
 
@@ -1092,7 +1133,9 @@ function run() {
   testAddImportSkipsExistingDefault();
   testAddImportSkipsExistingNamed();
   testAddImportMergesNamedSpecifiers();
+  testAddImportMergesNamedSpecifiersWithMultiplePreviousImports();
   testAddImportMergesMultilineNamedSpecifiers();
+  testAddImportMergesMultilineNamedSpecifiersWithComment();
   testAddImportMergesMultilineNamedSpecifiersPreservingTrailingComma();
   testAddImportAfterExisting();
   testAddImportAfterExistingKeepsSeparateLines();


### PR DESCRIPTION
This fixes `addImport` formatting when merging new named specifiers into an existing import.
Previously, adding a named import could produce output, such as:

```diff
- import { foo , bar } from 'mod'
+ import { foo, bar } from 'mod'

- import {
-  foo,
-  baz,
-  fiz,
-  test,
-  more,
-,  bar} from 'mod'
+ import {
+  foo,
+  baz,
+  fiz,
+  test,
+  more,
+  bar,
+ } from 'mod'

```

The merge logic now rebuilds the named import list instead of inserting raw text before the closing brace. This preserves correct comma placement for single-line imports and handles multiline imports consistently.

It also adds logic to detect whether the existing import uses trailing commas and preserves that style when adding new specifiers.