### PR TITLE
feat(jssg): implement runtime event buffering and logging in jssg test and jssg run

### DIFF
--- a/crates/cli/src/commands/jssg/mod.rs
+++ b/crates/cli/src/commands/jssg/mod.rs
@@ -4,3 +4,268 @@ pub mod exec;
 pub mod list_applicable;
 pub mod run;
 pub mod test;
+
+use codemod_sandbox::sandbox::runtime_module::{
+    RuntimeEvent, RuntimeEventCallback, RuntimeEventKind,
+};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Clone, Default)]
+struct RuntimeEventBuffer {
+    entries: Arc<Mutex<BufferedRuntimeEvents>>,
+}
+
+#[derive(Default)]
+struct BufferedRuntimeEvents {
+    order: Vec<String>,
+    entries: HashMap<String, Vec<String>>,
+}
+
+#[derive(Clone)]
+struct RuntimeEventOutput {
+    stream: RuntimeEventOutputStream,
+    lock: Arc<Mutex<()>>,
+}
+
+#[derive(Clone, Copy)]
+enum RuntimeEventOutputStream {
+    Stdout,
+    Stderr,
+}
+
+impl RuntimeEventOutput {
+    fn new(stream: RuntimeEventOutputStream) -> Self {
+        Self {
+            stream,
+            lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    fn stdout() -> Self {
+        Self::new(RuntimeEventOutputStream::Stdout)
+    }
+
+    fn stderr() -> Self {
+        Self::new(RuntimeEventOutputStream::Stderr)
+    }
+
+    fn flush(&self, buffer: &RuntimeEventBuffer) {
+        let groups = buffer.drain();
+        if groups.is_empty() {
+            return;
+        }
+
+        let Ok(_guard) = self.lock.lock() else {
+            return;
+        };
+        for (title, lines) in groups {
+            self.write("");
+            self.write(&title);
+            for line in lines {
+                for line in line.lines() {
+                    self.write(&format!("  {line}"));
+                }
+            }
+        }
+    }
+
+    fn write(&self, line: &str) {
+        match self.stream {
+            RuntimeEventOutputStream::Stdout => println!("{line}"),
+            RuntimeEventOutputStream::Stderr => eprintln!("{line}"),
+        }
+    }
+}
+
+impl RuntimeEventBuffer {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn callback_for_title(&self, title: impl Into<String>) -> RuntimeEventCallback {
+        let title = title.into();
+        let entries = Arc::clone(&self.entries);
+
+        Arc::new(move |event| {
+            let Some(message) = format_runtime_event_log(&event) else {
+                return;
+            };
+            if message.trim().is_empty() {
+                return;
+            }
+
+            let Ok(mut buffer) = entries.lock() else {
+                return;
+            };
+            if !buffer.entries.contains_key(&title) {
+                buffer.order.push(title.clone());
+            }
+            buffer
+                .entries
+                .entry(title.clone())
+                .or_default()
+                .push(message);
+        })
+    }
+
+    fn drain(&self) -> Vec<(String, Vec<String>)> {
+        let buffered = self
+            .entries
+            .lock()
+            .map(|mut buffer| std::mem::take(&mut *buffer))
+            .unwrap_or_default();
+
+        buffered
+            .order
+            .into_iter()
+            .filter_map(|title| {
+                buffered
+                    .entries
+                    .get(&title)
+                    .map(|lines| (title, lines.clone()))
+            })
+            .collect()
+    }
+}
+
+fn display_path_title(path: &Path, base: Option<&Path>) -> String {
+    base.and_then(|base| path.strip_prefix(base).ok())
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn format_runtime_event_log(event: &RuntimeEvent) -> Option<String> {
+    if event.meta.as_deref() == Some("console") {
+        return Some(event.message.clone());
+    }
+
+    let prefix = match event.kind {
+        RuntimeEventKind::Progress => "[progress]",
+        RuntimeEventKind::Warn => "[warn]",
+        RuntimeEventKind::SetCurrentUnit => return None,
+    };
+
+    let mut message = format!("{prefix} {}", event.message);
+    if let Some(meta) = &event.meta {
+        message.push(' ');
+        message.push_str(meta);
+    }
+    Some(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use codemod_sandbox::sandbox::runtime_module::{RuntimeEvent, RuntimeEventKind};
+    use std::path::Path;
+
+    #[test]
+    fn formats_console_events_without_runtime_prefix() {
+        let event = RuntimeEvent {
+            kind: RuntimeEventKind::Progress,
+            message: "hello from transform".to_string(),
+            meta: Some("console".to_string()),
+        };
+
+        assert_eq!(
+            super::format_runtime_event_log(&event),
+            Some("hello from transform".to_string())
+        );
+    }
+
+    #[test]
+    fn formats_runtime_warnings_with_prefix() {
+        let event = RuntimeEvent {
+            kind: RuntimeEventKind::Warn,
+            message: "missing optional data".to_string(),
+            meta: None,
+        };
+
+        assert_eq!(
+            super::format_runtime_event_log(&event),
+            Some("[warn] missing optional data".to_string())
+        );
+    }
+
+    #[test]
+    fn skips_current_unit_events() {
+        let event = RuntimeEvent {
+            kind: RuntimeEventKind::SetCurrentUnit,
+            message: "phase 1".to_string(),
+            meta: None,
+        };
+
+        assert_eq!(super::format_runtime_event_log(&event), None);
+    }
+
+    #[test]
+    fn buffers_runtime_events_by_title_in_first_seen_order() {
+        let buffer = super::RuntimeEventBuffer::new();
+        let first = buffer.callback_for_title("fixtures/a.js");
+        let second = buffer.callback_for_title("fixtures/b.js");
+
+        first(RuntimeEvent {
+            kind: RuntimeEventKind::Progress,
+            message: "a1".to_string(),
+            meta: Some("console".to_string()),
+        });
+        second(RuntimeEvent {
+            kind: RuntimeEventKind::Warn,
+            message: "b1".to_string(),
+            meta: None,
+        });
+        first(RuntimeEvent {
+            kind: RuntimeEventKind::Progress,
+            message: "a2".to_string(),
+            meta: Some("console".to_string()),
+        });
+
+        assert_eq!(
+            buffer.drain(),
+            vec![
+                (
+                    "fixtures/a.js".to_string(),
+                    vec!["a1".to_string(), "a2".to_string()]
+                ),
+                ("fixtures/b.js".to_string(), vec!["[warn] b1".to_string()])
+            ]
+        );
+    }
+
+    #[test]
+    fn draining_runtime_event_buffer_clears_entries() {
+        let buffer = super::RuntimeEventBuffer::new();
+        let callback = buffer.callback_for_title("fixtures/a.js");
+
+        callback(RuntimeEvent {
+            kind: RuntimeEventKind::Progress,
+            message: "a1".to_string(),
+            meta: Some("console".to_string()),
+        });
+
+        assert_eq!(buffer.drain().len(), 1);
+        assert!(buffer.drain().is_empty());
+    }
+
+    #[test]
+    fn display_path_title_prefers_relative_path_inside_base() {
+        assert_eq!(
+            super::display_path_title(
+                Path::new("/tmp/project/src/a.js"),
+                Some(Path::new("/tmp/project"))
+            ),
+            "src/a.js"
+        );
+        assert_eq!(
+            super::display_path_title(
+                Path::new("/tmp/other/a.js"),
+                Some(Path::new("/tmp/project"))
+            ),
+            "/tmp/other/a.js"
+        );
+    }
+}

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -204,6 +204,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     let shared_state_context = SharedStateContext::new();
     let metrics_context_clone = metrics_context.clone();
     let shared_state_context_clone = shared_state_context.clone();
+    let runtime_event_output = super::RuntimeEventOutput::stdout();
 
     // Create diff config for dry-run mode
     let diff_config = DiffConfig::with_color_control(args.no_color);
@@ -222,6 +223,12 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         if !file_path.is_file() {
             return;
         }
+
+        let runtime_event_buffer = super::RuntimeEventBuffer::new();
+        let runtime_event_callback = runtime_event_buffer.callback_for_title(
+            super::display_path_title(file_path, Some(&target_directory)),
+        );
+        let runtime_event_output = runtime_event_output.clone();
 
         // Use a tokio runtime to handle the async execution within the sync callback
         let rt = tokio::runtime::Runtime::new().unwrap();
@@ -248,7 +255,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
                 semantic_provider: semantic_provider.clone(),
                 metrics_context: Some(metrics_context_clone.clone()),
                 shared_state_context: Some(shared_state_context_clone.clone()),
-                runtime_event_callback: None,
+                runtime_event_callback: Some(runtime_event_callback),
                 cancellation_flag: None,
                 test_mode: false,
                 dry_run: false,
@@ -375,6 +382,8 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
                 }
             }
         });
+
+        runtime_event_output.flush(&runtime_event_buffer);
     });
 
     let metrics_data = metrics_context.get_all();

--- a/crates/cli/src/commands/jssg/test.rs
+++ b/crates/cli/src/commands/jssg/test.rs
@@ -22,7 +22,7 @@ use codemod_sandbox::{
     utils::project_discovery::find_tsconfig,
 };
 use testing_utils::{
-    map_execution_result, ExecutionRequest, TestOptions, TestRunner, TestSource,
+    map_execution_result, ExecutionRequest, ReporterType, TestOptions, TestRunner, TestSource,
     TransformationResult,
 };
 
@@ -217,7 +217,7 @@ async fn handler_impl(args: &Command) -> Result<()> {
         max_threads: global_config.max_threads,
         fail_fast: global_config.fail_fast,
         watch: global_config.watch,
-        reporter: global_config.reporter,
+        reporter: global_config.reporter.clone(),
         timeout: std::time::Duration::from_secs(global_config.timeout),
         ignore_whitespace: global_config.ignore_whitespace,
         context_lines: global_config.context_lines,
@@ -225,6 +225,11 @@ async fn handler_impl(args: &Command) -> Result<()> {
         strictness,
         language: global_config.language.clone(),
         expected_extension: global_config.expected_extension.clone(),
+    };
+    let runtime_event_output = if matches!(global_config.reporter, ReporterType::Json) {
+        super::RuntimeEventOutput::stderr()
+    } else {
+        super::RuntimeEventOutput::stdout()
     };
 
     let script_base_dir = codemod_path
@@ -267,6 +272,7 @@ async fn handler_impl(args: &Command) -> Result<()> {
             let current_dir = current_dir_clone.clone();
             let semantic_provider = semantic_provider.clone();
             let shared_metrics = shared_metrics.clone();
+            let runtime_event_output = runtime_event_output.clone();
 
             Box::pin(async move {
                 let logical_input_path = logical_input_path.unwrap_or_else(|| input_path.clone());
@@ -338,6 +344,10 @@ async fn handler_impl(args: &Command) -> Result<()> {
                 } else {
                     semantic_provider
                 };
+                let runtime_event_buffer = super::RuntimeEventBuffer::new();
+                let runtime_event_callback = runtime_event_buffer.callback_for_title(
+                    super::display_path_title(&logical_input_path, Some(&current_dir)),
+                );
 
                 let options = JssgExecutionOptions {
                     script_path: &codemod_path,
@@ -352,7 +362,7 @@ async fn handler_impl(args: &Command) -> Result<()> {
                     semantic_provider,
                     metrics_context: Some(metrics_context.clone()),
                     shared_state_context: None,
-                    runtime_event_callback: None,
+                    runtime_event_callback: Some(runtime_event_callback),
                     cancellation_flag: None,
                     test_mode: true,
                     dry_run: false,
@@ -363,12 +373,16 @@ async fn handler_impl(args: &Command) -> Result<()> {
                     .map(|CodemodOutput { primary, .. }| map_execution_result(primary, input_code))
                     .map_err(anyhow::Error::from);
 
-                if let Some(snapshot) = finish_metrics_collection(
+                let pending_snapshot = finish_metrics_collection(
                     shared_metrics.as_ref(),
                     &metrics_output_path,
                     Some(test_case_dir.join("metrics.json")),
                     execution_result.is_err(),
-                )? {
+                );
+
+                runtime_event_output.flush(&runtime_event_buffer);
+
+                if let Some(snapshot) = pending_snapshot? {
                     if workspace_root.is_some() {
                         write_metrics_output(&snapshot)?;
                     }


### PR DESCRIPTION


<!--
THANK YOU for contributing to Codemod! Let's speed up migration velocity for all, one PR at a time! :)

Before opening this PR, please:
1. Read and accept the contributing guidelines here: https://github.com/codemod/codemod-registry/blob/main/CONTRIBUTING.md
2. Ensure that the PR title follows conventional commits: https://www.conventionalcommits.org

Here are some examples:

feat(studio): add new codemod engine
feat(cli)!: revamp the design (BREAKING CHANGE)
fix(cli): fix a bug for the formatter
chore(backend): upgrade node
docs: improve codemod publish docs
refactor(registry www): modularize filters
test(vsce): add tests for VS Code extension
-->

#### 📚 Description

`jssg test` and `jssg run` swallowed the log events since we decoupled logs from the core and sandbox crates. This fixes that

#### 🔗 Linked Issue
<!-- 
For trivial changes, this can be removed. For non-trivial changes, link to an issue that includes the impact, priority, effort, and more context and discussions. Mention its number here. For example:
- Fixes #XXXX (GitHub issue number for community contributions)
or
- Fixes CDMD-XXXX (Linear issue number for Codemod team contributions)
-->

#### 🧪 Test Plan
<!-- 
Describe the tests you ran to verify your changes. Provide instructions so we can reproduce them.
-->

#### 📄 Documentation to Update
<!--
Please identify the existing or missing docs for your feature and update or create them if needed.
-->
