### PR TITLE
fix(cli): secure auth token file permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,6 +1084,7 @@ dependencies = [
  "indicatif",
  "inquire",
  "language-core",
+ "libc",
  "libtest-mimic",
  "log",
  "miette",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -79,6 +79,9 @@ futures = { workspace = true }
 toml_edit = "0.22"
 arboard = "3.4"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 portable-pty = "0.9"
 

--- a/crates/cli/src/auth/storage.rs
+++ b/crates/cli/src/auth/storage.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use butterflow_core::registry::RegistryConfig;
 use dirs::config_dir;
 use serde::{Deserialize, Serialize};
@@ -175,7 +175,7 @@ impl TokenStorage {
         let content =
             serde_json::to_string_pretty(auth).context("Failed to serialize auth data")?;
 
-        fs::write(&auth_path, content)
+        write_auth_file(&auth_path, content.as_bytes())
             .with_context(|| format!("Failed to write auth file: {auth_path:?}"))?;
 
         Ok(())
@@ -271,9 +271,44 @@ impl TokenStorage {
     }
 }
 
+#[cfg(unix)]
+fn write_auth_file(path: &std::path::Path, content: &[u8]) -> Result<()> {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    let restricted_permissions = fs::Permissions::from_mode(0o600);
+
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        if !metadata.file_type().is_file() {
+            bail!("Auth path exists but is not a regular file: {path:?}");
+        }
+        fs::set_permissions(path, restricted_permissions.clone())?;
+    }
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(content)?;
+    file.flush()?;
+    fs::set_permissions(path, restricted_permissions)?;
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_auth_file(path: &std::path::Path, content: &[u8]) -> Result<()> {
+    fs::write(path, content)?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::TokenStorage;
+    use super::*;
+    use crate::auth::types::{AuthTokens, UserInfo};
     use std::collections::HashSet;
     use std::fs;
     use std::sync::{Arc, Barrier};
@@ -392,5 +427,99 @@ mod tests {
             .collect::<HashSet<_>>();
 
         assert_eq!(ids.len(), 1);
+    }
+
+    fn stored_auth(registry: &str) -> StoredAuth {
+        StoredAuth {
+            tokens: AuthTokens {
+                access_token: "access-token".to_string(),
+                refresh_token: Some("refresh-token".to_string()),
+                expires_at: None,
+                scope: vec!["read".to_string()],
+                token_type: "Bearer".to_string(),
+            },
+            user: UserInfo {
+                id: "user-id".to_string(),
+                username: "user".to_string(),
+                email: "user@example.com".to_string(),
+                organizations: None,
+            },
+            registry: registry.to_string(),
+        }
+    }
+
+    #[test]
+    fn save_auth_round_trips_stored_auth() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = TokenStorage::with_config_dir(temp_dir.path().join("codemod")).unwrap();
+        let auth = stored_auth("https://app.codemod.com");
+
+        storage.save_auth(&auth).unwrap();
+
+        let loaded = storage
+            .load_auth("https://app.codemod.com")
+            .unwrap()
+            .unwrap();
+        assert_eq!(loaded.tokens.access_token, "access-token");
+        assert_eq!(
+            loaded.tokens.refresh_token.as_deref(),
+            Some("refresh-token")
+        );
+        assert_eq!(loaded.user.email, "user@example.com");
+        assert_eq!(loaded.registry, "https://app.codemod.com");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_auth_creates_token_file_with_user_only_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = TokenStorage::with_config_dir(temp_dir.path().join("codemod")).unwrap();
+        let auth = stored_auth("https://app.codemod.com");
+
+        storage.save_auth(&auth).unwrap();
+
+        let auth_path = storage.get_auth_path("https://app.codemod.com");
+        let mode = fs::metadata(auth_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_auth_restricts_existing_permissive_token_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = TokenStorage::with_config_dir(temp_dir.path().join("codemod")).unwrap();
+        let auth = stored_auth("https://app.codemod.com");
+        let auth_path = storage.get_auth_path("https://app.codemod.com");
+        fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
+        fs::write(&auth_path, "{}").unwrap();
+        fs::set_permissions(&auth_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        storage.save_auth(&auth).unwrap();
+
+        let mode = fs::metadata(auth_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_auth_rejects_non_file_auth_path_without_changing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = TokenStorage::with_config_dir(temp_dir.path().join("codemod")).unwrap();
+        let auth = stored_auth("https://app.codemod.com");
+        let auth_path = storage.get_auth_path("https://app.codemod.com");
+        fs::create_dir_all(&auth_path).unwrap();
+        fs::set_permissions(&auth_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let result = storage.save_auth(&auth);
+
+        assert!(result.is_err());
+        let mode = fs::metadata(auth_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o755);
     }
 }

--- a/crates/cli/src/auth/storage.rs
+++ b/crates/cli/src/auth/storage.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use butterflow_core::registry::RegistryConfig;
 use dirs::config_dir;
 use serde::{Deserialize, Serialize};
@@ -279,22 +279,21 @@ fn write_auth_file(path: &std::path::Path, content: &[u8]) -> Result<()> {
 
     let restricted_permissions = fs::Permissions::from_mode(0o600);
 
-    if let Ok(metadata) = fs::symlink_metadata(path) {
-        if !metadata.file_type().is_file() {
-            bail!("Auth path exists but is not a regular file: {path:?}");
-        }
-        fs::set_permissions(path, restricted_permissions.clone())?;
-    }
-
     let mut file = OpenOptions::new()
         .write(true)
         .create(true)
-        .truncate(true)
         .mode(0o600)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
         .open(path)?;
+
+    if !file.metadata()?.file_type().is_file() {
+        anyhow::bail!("Auth path exists but is not a regular file: {path:?}");
+    }
+
+    file.set_len(0)?;
     file.write_all(content)?;
     file.flush()?;
-    fs::set_permissions(path, restricted_permissions)?;
+    file.set_permissions(restricted_permissions)?;
 
     Ok(())
 }
@@ -521,5 +520,29 @@ mod tests {
         assert!(result.is_err());
         let mode = fs::metadata(auth_path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o755);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_auth_rejects_symlink_auth_path_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let storage = TokenStorage::with_config_dir(temp_dir.path().join("codemod")).unwrap();
+        let auth = stored_auth("https://app.codemod.com");
+        let auth_path = storage.get_auth_path("https://app.codemod.com");
+        fs::create_dir_all(auth_path.parent().unwrap()).unwrap();
+        let symlink_target = temp_dir.path().join("target.json");
+        fs::write(&symlink_target, "do not change").unwrap();
+        symlink(&symlink_target, &auth_path).unwrap();
+
+        let result = storage.save_auth(&auth);
+
+        assert!(result.is_err());
+        assert_eq!(fs::read_to_string(symlink_target).unwrap(), "do not change");
+        assert!(fs::symlink_metadata(auth_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
     }
 }


### PR DESCRIPTION
#### 📚 Description

Fixes auth token file storage so Unix CLI login writes registry auth JSON with user-only permissions (`0600`) instead of inheriting permissive defaults from the process umask. Existing regular auth files are tightened before rewrite, while non-file paths are rejected.

Root cause: `TokenStorage::save_auth` used `fs::write`, which creates files using default process permissions and preserves permissive modes on existing files.

#### 🔗 Linked Issue

- Fixes CDMD-4756

#### 🧪 Test Plan

- `cargo fmt --check`
- `cargo test -p codemod auth::storage`
- `cargo test -p codemod`

#### 📄 Documentation to Update

None. Internal CLI auth storage behavior only.