### PR TITLE
fix(cli): windows rolldown verbatim path

### DIFF
--- a/.github/workflows/jssg-tests-windows.yml
+++ b/.github/workflows/jssg-tests-windows.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches:
       - main
+      - fix/windows-rolldown-verbatim-path
     paths:
       - "crates/cli/src/commands/jssg/test.rs"
+      - "crates/cli/src/commands/publish.rs"
+      - "crates/cli/src/utils/rolldown_bundler.rs"
       - "crates/cli/src/main.rs"
       - "crates/cli/Cargo.toml"
       - "Cargo.toml"
@@ -14,8 +17,11 @@ on:
   pull_request:
     branches:
       - main
+      - fix/windows-rolldown-verbatim-path
     paths:
       - "crates/cli/src/commands/jssg/test.rs"
+      - "crates/cli/src/commands/publish.rs"
+      - "crates/cli/src/utils/rolldown_bundler.rs"
       - "crates/cli/src/main.rs"
       - "crates/cli/Cargo.toml"
       - "Cargo.toml"
@@ -43,10 +49,12 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Run Windows JSSG-related CLI tests
+      - name: Run Windows CLI bundling tests
         shell: pwsh
         run: |
           cargo test -p codemod commands::jssg::test::tests -- --nocapture *>&1 | Tee-Object -FilePath jssg-test.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          cargo test -p codemod utils::rolldown_bundler::tests -- --nocapture *>&1 | Tee-Object -Append -FilePath jssg-test.log
           exit $LASTEXITCODE
 
       - name: Upload test log

--- a/crates/cli/src/utils/rolldown_bundler.rs
+++ b/crates/cli/src/utils/rolldown_bundler.rs
@@ -109,6 +109,10 @@ impl RolldownBundler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(windows)]
+    use std::fs;
+    #[cfg(windows)]
+    use tempfile::TempDir;
 
     #[test]
     fn test_rolldown_bundler_creation() {
@@ -123,5 +127,35 @@ mod tests {
 
         assert_eq!(bundler.config.entry_path, config.entry_path);
         assert_eq!(bundler.config.source_maps, config.source_maps);
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn bundle_succeeds_with_canonicalized_windows_paths() {
+        let temp_dir = TempDir::new().unwrap();
+        let scripts_dir = temp_dir.path().join("scripts");
+        fs::create_dir_all(&scripts_dir).unwrap();
+
+        let entry_path = scripts_dir.join("codemod.ts");
+        fs::write(
+            &entry_path,
+            "export default function codemod() { return 1; }",
+        )
+        .unwrap();
+
+        let config = RolldownBundlerConfig {
+            entry_path: entry_path.canonicalize().unwrap(),
+            base_dir: Some(temp_dir.path().canonicalize().unwrap()),
+            output_path: None,
+            source_maps: false,
+        };
+
+        let bundler = RolldownBundler::new(config);
+        let result = bundler.bundle().await;
+
+        assert!(
+            result.is_ok(),
+            "expected bundling with canonicalized Windows paths to succeed, got: {result:?}"
+        );
     }
 }

--- a/crates/cli/src/utils/rolldown_bundler.rs
+++ b/crates/cli/src/utils/rolldown_bundler.rs
@@ -144,6 +144,19 @@ mod tests {
     }
 
     #[cfg(windows)]
+    #[test]
+    fn normalize_rolldown_path_converts_verbatim_unc_paths() {
+        let normalized = normalize_rolldown_path(Path::new(
+            r"\\?\UNC\server\share\workspace\scripts\codemod.ts",
+        ));
+
+        assert_eq!(
+            normalized,
+            PathBuf::from(r"\\server\share\workspace\scripts\codemod.ts")
+        );
+    }
+
+    #[cfg(windows)]
     #[tokio::test]
     async fn bundle_succeeds_with_canonicalized_windows_paths() {
         let temp_dir = TempDir::new().unwrap();

--- a/crates/cli/src/utils/rolldown_bundler.rs
+++ b/crates/cli/src/utils/rolldown_bundler.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use rolldown::{BundleOutput, Bundler, BundlerOptions, InputItem, SourceMapType};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Simple rolldown-based bundler configuration
 #[derive(Debug, Clone)]
@@ -49,25 +49,24 @@ impl RolldownBundler {
     /// Bundle the entry file and its dependencies into a single JavaScript file
     pub async fn bundle(&self) -> Result<BundleResult> {
         let base_dir = if let Some(base_dir) = &self.config.base_dir {
-            base_dir.clone()
+            normalize_rolldown_path(base_dir)
         } else {
-            self.config
-                .entry_path
+            normalize_rolldown_path(&self.config.entry_path)
                 .parent()
                 .ok_or_else(|| anyhow::anyhow!("Entry path has no parent directory"))?
                 .to_path_buf()
         };
+        let entry_path = normalize_rolldown_path(&self.config.entry_path);
 
         let entry_str = if let Some(base_dir) = &self.config.base_dir {
-            self.config
-                .entry_path
-                .strip_prefix(base_dir)
-                .unwrap_or(&self.config.entry_path)
+            let normalized_base_dir = normalize_rolldown_path(base_dir);
+            entry_path
+                .strip_prefix(&normalized_base_dir)
+                .unwrap_or(&entry_path)
                 .to_str()
                 .ok_or_else(|| anyhow::anyhow!("Entry path is not valid UTF-8"))?
         } else {
-            self.config
-                .entry_path
+            entry_path
                 .to_str()
                 .ok_or_else(|| anyhow::anyhow!("Entry path is not valid UTF-8"))?
         };
@@ -104,6 +103,21 @@ impl RolldownBundler {
             output_path: self.config.output_path.clone(),
         })
     }
+}
+
+fn normalize_rolldown_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let path_str = path.to_string_lossy();
+        if let Some(stripped) = path_str.strip_prefix(r"\\?\UNC\") {
+            return PathBuf::from(format!(r"\\{stripped}"));
+        }
+        if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped);
+        }
+    }
+
+    path.to_path_buf()
 }
 
 #[cfg(test)]

--- a/crates/cli/src/utils/rolldown_bundler.rs
+++ b/crates/cli/src/utils/rolldown_bundler.rs
@@ -157,6 +157,9 @@ mod tests {
         )
         .unwrap();
 
+        // This test relies on the actual path form Windows returns from
+        // canonicalize() on the CI runner. That keeps it realistic, but it
+        // means we don't hard-code or assert the verbatim \\?\ prefix here.
         let config = RolldownBundlerConfig {
             entry_path: entry_path.canonicalize().unwrap(),
             base_dir: Some(temp_dir.path().canonicalize().unwrap()),


### PR DESCRIPTION
#### 📚 Description
This pr fixes the path canonicalization on Windows.
On Windows, canonical paths can contain special characters, e.g., `\\?\C:\repo\project\scripts\codemod.ts`, which Rolldown doesn't like.

Reporduced in https://github.com/codemod/codemod/actions/runs/26455063489/job/77886561996
<img width="792" height="380" alt="Screenshot 2026-05-26 at 6 26 25 PM" src="https://github.com/user-attachments/assets/fc7518d6-ac2c-4827-95ee-6373be4e870a" />


#### 🧪 Test Plan
1. CI green
2. Unit test added
