### PR TITLE
fix(cli): reject unresolved publish dependencies

### DIFF
--- a/crates/cli/src/commands/jssg/bundle.rs
+++ b/crates/cli/src/commands/jssg/bundle.rs
@@ -66,6 +66,8 @@ impl Command {
             base_dir: Some(base_dir),
             output_path: self.output.clone(),
             source_maps: self.source_maps,
+            external_modules: Vec::new(),
+            fail_on_unresolved_imports: false,
         };
 
         // Create and run rolldown bundler

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -9,6 +9,7 @@ use butterflow_core::utils::validate_workflow;
 use butterflow_core::Workflow;
 use butterflow_models::step::StepAction;
 use clap::Args;
+use codemod_llrt_capabilities::module_builder::supported_runtime_external_modules;
 use console::style;
 use log::{debug, info, warn};
 use regex::Regex;
@@ -196,13 +197,22 @@ async fn bundle_js_file(package_path: &Path, js_file: &str) -> Result<String> {
         base_dir: Some(package_path.to_path_buf()),
         output_path: None, // Return code directly, don't write to file
         source_maps: false,
+        external_modules: supported_runtime_external_modules()
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        fail_on_unresolved_imports: true,
     };
 
     let bundler = RolldownBundler::new(config);
     let bundle_result = bundler
         .bundle()
         .await
-        .map_err(|e| anyhow!("Failed to bundle {js_file}:\n{e}"))?;
+        .map_err(|e| {
+            anyhow!(
+                "Cannot publish: JS file {js_file} imports a module that could not be resolved or bundled.\n{e}"
+            )
+        })?;
 
     info!(
         "Successfully bundled {} ({} bytes)",
@@ -959,5 +969,85 @@ nodes:
 
         let error = validate_package_structure(temp_dir.path(), &manifest).unwrap_err();
         assert!(error.to_string().contains("missing compatibility marker"));
+    }
+
+    #[tokio::test]
+    async fn publish_bundle_bundles_installed_dependencies() {
+        let temp_dir = tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("transform.js"),
+            r#"
+import { helper } from "local-helper";
+export default function transform() {
+  return helper();
+}
+"#,
+        )
+        .unwrap();
+        let dependency_dir = temp_dir.path().join("node_modules/local-helper");
+        fs::create_dir_all(&dependency_dir).unwrap();
+        fs::write(
+            dependency_dir.join("package.json"),
+            r#"{"name":"local-helper","version":"1.0.0","main":"index.js"}"#,
+        )
+        .unwrap();
+        fs::write(
+            dependency_dir.join("index.js"),
+            r#"export function helper() { return "bundled"; }"#,
+        )
+        .unwrap();
+
+        let bundled = bundle_js_file(temp_dir.path(), "transform.js")
+            .await
+            .unwrap();
+
+        assert!(bundled.contains("bundled"));
+        assert!(!bundled.contains("\"local-helper\""));
+        assert!(!bundled.contains("'local-helper'"));
+    }
+
+    #[tokio::test]
+    async fn publish_bundle_rejects_missing_dependencies_before_upload() {
+        let temp_dir = tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("transform.js"),
+            r#"import { helper } from "@nodejs/codemod-utils/ast-grep/require-call";"#,
+        )
+        .unwrap();
+
+        let error = bundle_js_file(temp_dir.path(), "transform.js")
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("Cannot publish"));
+        assert!(message.contains("transform.js"));
+        assert!(message.contains("@nodejs/codemod-utils"));
+    }
+
+    #[tokio::test]
+    async fn publish_bundle_allows_only_runtime_modules_as_externals() {
+        let temp_dir = tempdir().unwrap();
+        fs::write(
+            temp_dir.path().join("transform.js"),
+            r#"
+import { format } from "node:util";
+import path from "path";
+import { readFile } from "fs/promises";
+import { parse } from "codemod:ast-grep";
+export default function transform() {
+  return [format("%s", "ok"), path.sep, readFile, parse];
+}
+"#,
+        )
+        .unwrap();
+
+        let bundled = bundle_js_file(temp_dir.path(), "transform.js")
+            .await
+            .unwrap();
+
+        assert!(bundled.contains("node:util"));
+        assert!(bundled.contains("path"));
+        assert!(bundled.contains("fs/promises"));
+        assert!(bundled.contains("codemod:ast-grep"));
     }
 }

--- a/crates/cli/src/utils/rolldown_bundler.rs
+++ b/crates/cli/src/utils/rolldown_bundler.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use rolldown::{BundleOutput, Bundler, BundlerOptions, InputItem, SourceMapType};
+use rolldown::{BundleOutput, Bundler, BundlerOptions, InputItem, IsExternal, SourceMapType};
 use std::path::{Path, PathBuf};
 
 /// Simple rolldown-based bundler configuration
@@ -13,6 +13,10 @@ pub struct RolldownBundlerConfig {
     pub output_path: Option<PathBuf>,
     /// Enable source maps
     pub source_maps: bool,
+    /// Module specifiers that may remain external in the bundle
+    pub external_modules: Vec<String>,
+    /// Treat Rolldown unresolved import diagnostics as bundle failures
+    pub fail_on_unresolved_imports: bool,
 }
 
 /// Result of bundling operation
@@ -81,6 +85,8 @@ impl RolldownBundler {
             }]),
             cwd: Some(base_dir.clone()),
             sourcemap: self.config.source_maps.then_some(SourceMapType::File),
+            external: (!self.config.external_modules.is_empty())
+                .then(|| IsExternal::from(self.config.external_modules.clone())),
             ..Default::default()
         };
 
@@ -90,6 +96,15 @@ impl RolldownBundler {
             .generate()
             .await
             .map_err(|e| anyhow::anyhow!("Rolldown bundling failed: {:?}", e))?;
+        if self.config.fail_on_unresolved_imports {
+            if let Some(warning) = result
+                .warnings
+                .iter()
+                .find(|warning| warning.kind().to_string() == "UNRESOLVED_IMPORT")
+            {
+                return Err(anyhow::anyhow!("Rolldown unresolved import: {}", warning));
+            }
+        }
 
         let bundled_code = Self::extract_js_code(&result)?;
 
@@ -135,6 +150,8 @@ mod tests {
             base_dir: None,
             output_path: None,
             source_maps: false,
+            external_modules: Vec::new(),
+            fail_on_unresolved_imports: false,
         };
 
         let bundler = RolldownBundler::new(config.clone());
@@ -178,6 +195,8 @@ mod tests {
             base_dir: Some(temp_dir.path().canonicalize().unwrap()),
             output_path: None,
             source_maps: false,
+            external_modules: Vec::new(),
+            fail_on_unresolved_imports: false,
         };
 
         let bundler = RolldownBundler::new(config);

--- a/crates/llrt-capabilities/src/module_builder.rs
+++ b/crates/llrt-capabilities/src/module_builder.rs
@@ -7,6 +7,79 @@ use std::collections::HashSet;
 
 use crate::types::LlrtSupportedModules;
 
+pub const CODEMOD_RUNTIME_MODULES: &[&str] = &[
+    "codemod:ast-grep",
+    "codemod:workflow",
+    "codemod:metrics",
+    "codemod:runtime",
+];
+
+const LLRT_RUNTIME_MODULES: &[&str] = &[
+    "assert",
+    "buffer",
+    "child_process",
+    "console",
+    "crypto",
+    "events",
+    "fs",
+    "fs/promises",
+    "module",
+    "os",
+    "path",
+    "perf_hooks",
+    "process",
+    "stream/web",
+    "string_decoder",
+    "tty",
+    "url",
+    "util",
+    "zlib",
+];
+
+pub fn supported_runtime_external_modules() -> Vec<&'static str> {
+    let mut modules =
+        Vec::with_capacity(CODEMOD_RUNTIME_MODULES.len() + LLRT_RUNTIME_MODULES.len() * 2);
+    modules.extend(CODEMOD_RUNTIME_MODULES.iter().copied());
+    for module in LLRT_RUNTIME_MODULES {
+        modules.push(*module);
+        modules.push(match *module {
+            "assert" => "node:assert",
+            "buffer" => "node:buffer",
+            "child_process" => "node:child_process",
+            "console" => "node:console",
+            "crypto" => "node:crypto",
+            "events" => "node:events",
+            "fs" => "node:fs",
+            "fs/promises" => "node:fs/promises",
+            "module" => "node:module",
+            "os" => "node:os",
+            "path" => "node:path",
+            "perf_hooks" => "node:perf_hooks",
+            "process" => "node:process",
+            "stream/web" => "node:stream/web",
+            "string_decoder" => "node:string_decoder",
+            "tty" => "node:tty",
+            "url" => "node:url",
+            "util" => "node:util",
+            "zlib" => "node:zlib",
+            _ => unreachable!("all LLRT runtime modules are covered"),
+        });
+    }
+    modules
+}
+
+pub fn is_supported_runtime_external_module(specifier: &str) -> bool {
+    if CODEMOD_RUNTIME_MODULES.contains(&specifier) {
+        return true;
+    }
+
+    let normalized = specifier
+        .strip_prefix("node:")
+        .unwrap_or(specifier)
+        .trim_end_matches('/');
+    LLRT_RUNTIME_MODULES.contains(&normalized)
+}
+
 macro_rules! define_safe_modules {
     (
         $(


### PR DESCRIPTION
## Summary

Published JSSG codemods now fail during `codemod publish` when Rolldown cannot resolve a bare package import, instead of shipping registry packages that later crash during QuickJS module initialization. Publish only leaves LLRT/Codemod runtime modules external; installed package dependencies are bundled into the transform and `node_modules` remains excluded from the archive.

Linear: [CDMD-4775](https://linear.app/codemod/issue/CDMD-4775/prevent-published-jssg-codemods-from-externalizing-missing)

## Validation

- `cargo test -p codemod publish`
- `cargo test -p codemod rolldown_bundler`
- `cargo fmt --check`
- Manual temp-package checks in `/tmp/codemod-publish-validation.EsgqE1`:
  - missing `@nodejs/codemod-utils/...` import fails before upload with Rolldown `UNRESOLVED_IMPORT`
  - installed `local-helper` dependency is bundled into `scripts/codemod.js`
  - runtime imports `node:util`, `path`, `fs/promises`, and `codemod:ast-grep` remain allowed externals

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
