### PR TITLE
feat(cli): add anonymous AI feedback

### DIFF
--- a/crates/cli/src/auth/storage.rs
+++ b/crates/cli/src/auth/storage.rs
@@ -12,6 +12,8 @@ use crate::auth::types::{AuthTokens, UserInfo};
 pub struct Config {
     pub default_registry: String,
     pub registries: HashMap<String, RegistryAuthConfig>,
+    #[serde(default)]
+    pub anonymous_feedback: AnonymousFeedbackConfig,
 }
 
 impl Default for Config {
@@ -43,8 +45,15 @@ impl Config {
         Self {
             default_registry: registry_url.to_string(),
             registries,
+            anonymous_feedback: AnonymousFeedbackConfig::default(),
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AnonymousFeedbackConfig {
+    pub enabled: bool,
+    pub consented_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -107,6 +116,33 @@ impl TokenStorage {
         let config: Config =
             serde_json::from_str(&content).context("Failed to parse config file")?;
 
+        Ok(config)
+    }
+
+    pub fn save_config(&self, config: &Config) -> Result<()> {
+        let config_path = self.config_dir.join("config.json");
+        let content =
+            serde_json::to_string_pretty(config).context("Failed to serialize config file")?;
+
+        fs::write(&config_path, content)
+            .with_context(|| format!("Failed to write config file: {config_path:?}"))?;
+
+        Ok(())
+    }
+
+    pub fn enable_anonymous_feedback(&self) -> Result<Config> {
+        let env: HashMap<String, String> = std::env::vars().collect();
+        let mut config = self.load_config_with_env(Some(&env))?;
+        let consented_at = config
+            .anonymous_feedback
+            .consented_at
+            .clone()
+            .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+        config.anonymous_feedback = AnonymousFeedbackConfig {
+            enabled: true,
+            consented_at: Some(consented_at),
+        };
+        self.save_config(&config)?;
         Ok(config)
     }
 
@@ -181,5 +217,80 @@ impl TokenStorage {
             .replace("://", "_")
             .replace("/", "_")
             .replace(":", "_")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TokenStorage;
+    use std::fs;
+
+    #[test]
+    fn missing_feedback_config_defaults_to_disabled() {
+        let temp_dir = tempfile::tempdir().expect("expected temp dir");
+        fs::write(
+            temp_dir.path().join("config.json"),
+            r#"{
+  "default_registry": "https://app.codemod.com",
+  "registries": {}
+}"#,
+        )
+        .expect("expected config write");
+
+        let storage =
+            TokenStorage::with_config_dir(temp_dir.path().to_path_buf()).expect("storage");
+        let config = storage.load_config().expect("config");
+
+        assert!(!config.anonymous_feedback.enabled);
+        assert_eq!(config.anonymous_feedback.consented_at, None);
+    }
+
+    #[test]
+    fn enable_anonymous_feedback_persists_consent() {
+        let temp_dir = tempfile::tempdir().expect("expected temp dir");
+        let storage =
+            TokenStorage::with_config_dir(temp_dir.path().to_path_buf()).expect("storage");
+
+        let config = storage
+            .enable_anonymous_feedback()
+            .expect("expected feedback consent write");
+        let reloaded = storage.load_config().expect("expected config reload");
+
+        assert!(config.anonymous_feedback.enabled);
+        assert!(config.anonymous_feedback.consented_at.is_some());
+        assert!(reloaded.anonymous_feedback.enabled);
+        assert_eq!(
+            reloaded.anonymous_feedback.consented_at,
+            config.anonymous_feedback.consented_at
+        );
+    }
+
+    #[test]
+    fn enable_anonymous_feedback_preserves_existing_consent_date() {
+        let temp_dir = tempfile::tempdir().expect("expected temp dir");
+        fs::write(
+            temp_dir.path().join("config.json"),
+            r#"{
+  "default_registry": "https://app.codemod.com",
+  "registries": {},
+  "anonymous_feedback": {
+    "enabled": true,
+    "consented_at": "2026-06-09T12:00:00Z"
+  }
+}"#,
+        )
+        .expect("expected config write");
+        let storage =
+            TokenStorage::with_config_dir(temp_dir.path().to_path_buf()).expect("storage");
+
+        let config = storage
+            .enable_anonymous_feedback()
+            .expect("expected feedback consent write");
+
+        assert!(config.anonymous_feedback.enabled);
+        assert_eq!(
+            config.anonymous_feedback.consented_at.as_deref(),
+            Some("2026-06-09T12:00:00Z")
+        );
     }
 }

--- a/crates/cli/src/commands/ai/mod.rs
+++ b/crates/cli/src/commands/ai/mod.rs
@@ -10,8 +10,9 @@ use crate::commands::harness_adapter::{
 use crate::commands::output::{
     exit_adapter_error, format_output_path, prompt_for_overwrite_confirmation,
 };
+use crate::feedback;
 use crate::{TelemetrySenderMutex, CLI_VERSION};
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::{Args, Subcommand};
 use codemod_telemetry::send_event::BaseEvent;
 use inquire::Select;
@@ -42,6 +43,9 @@ use update::types::{UpdatePolicyMode, MANAGED_UPDATE_POLICY_LOCAL_SOURCE};
 pub struct Command {
     #[command(subcommand)]
     action: Option<AiAction>,
+    /// Opt in to anonymous Codemod AI and MCP feedback for this OS user
+    #[arg(long, global = true)]
+    allow_feedback: bool,
     #[command(flatten)]
     install: InstallCommand,
 }
@@ -68,6 +72,8 @@ enum AiAction {
     Update(UpdateCommand),
     /// List installed codemod skills for a harness
     List(ListCommand),
+    /// Submit short anonymous platform feedback after recording consent
+    Feedback(FeedbackCommand),
 }
 
 #[derive(Args, Debug)]
@@ -169,8 +175,20 @@ struct ListCommand {
     format: OutputFormat,
 }
 
+#[derive(Args, Debug)]
+struct FeedbackCommand {
+    /// Thematic feedback category, for example jssg, workflow, ai-docs, mcp, cli, registry, or other
+    #[arg(long, value_name = "CATEGORY")]
+    category: String,
+    /// Short feedback message to submit anonymously
+    #[arg(long, value_name = "TEXT")]
+    message: String,
+}
+
 pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<()> {
-    match &args.action {
+    feedback::persist_feedback_consent_if_requested(args.allow_feedback)?;
+
+    let result = match &args.action {
         None => {
             let command = &args.install;
             handle_install_like_action(
@@ -201,6 +219,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         Some(AiAction::Call(command)) => cli_tools::handle_call(command).await,
         Some(AiAction::Resources(command)) => cli_tools::handle_resources(command),
         Some(AiAction::Resource(command)) => cli_tools::handle_resource(command).await,
+        Some(AiAction::Feedback(command)) => handle_feedback_command(command).await,
         Some(AiAction::List(command)) => {
             let resolved_adapter = resolve_adapter(command.harness).unwrap_or_else(|error| {
                 exit_adapter_error(error, command.format);
@@ -228,7 +247,74 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
             .await;
             Ok(())
         }
+    };
+
+    if result.is_ok() && !matches!(args.action, Some(AiAction::Feedback(_))) {
+        send_ai_feedback_event(args).await;
     }
+
+    result
+}
+
+async fn send_ai_feedback_event(args: &Command) {
+    let (event, command_name) = match &args.action {
+        None => ("install", "codemod.ai.install"),
+        Some(AiAction::Update(_)) => ("update", "codemod.ai.update"),
+        Some(AiAction::DumpAst(_)) => ("dump_ast", "codemod.ai.dump_ast"),
+        Some(AiAction::NodeTypes(_)) => ("node_types", "codemod.ai.node_types"),
+        Some(AiAction::Docs(_)) => ("docs", "codemod.ai.docs"),
+        Some(AiAction::Tools(_)) => ("tools", "codemod.ai.tools"),
+        Some(AiAction::Tool(_)) => ("tool", "codemod.ai.tool"),
+        Some(AiAction::Call(_)) => ("call", "codemod.ai.call"),
+        Some(AiAction::Resources(_)) => ("resources", "codemod.ai.resources"),
+        Some(AiAction::Resource(_)) => ("resource", "codemod.ai.resource"),
+        Some(AiAction::List(_)) => ("list", "codemod.ai.list"),
+        Some(AiAction::Feedback(_)) => ("feedback", "codemod.ai.feedback"),
+    };
+
+    feedback::send_anonymous_feedback_event(
+        "cli-ai",
+        event,
+        HashMap::from([("command".to_string(), command_name.to_string())]),
+    )
+    .await;
+}
+
+async fn handle_feedback_command(command: &FeedbackCommand) -> Result<()> {
+    let category = command.category.trim();
+    let message = command.message.trim();
+
+    if category.is_empty() {
+        bail!("Feedback category cannot be empty.");
+    }
+
+    if category.len() > 64
+        || !category.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | '-')
+        })
+    {
+        bail!("Feedback category must be 64 characters or fewer and contain only letters, numbers, '.', '_', or '-'.");
+    }
+
+    if message.is_empty() {
+        bail!("Feedback message cannot be empty.");
+    }
+
+    if message.len() > 4000 {
+        bail!("Feedback message must be 4000 characters or fewer.");
+    }
+
+    let consented_at = feedback::persist_feedback_consent()?;
+    feedback::submit_anonymous_feedback(category.to_string(), message.to_string()).await?;
+
+    match consented_at {
+        Some(consented_at) => {
+            println!("Anonymous feedback submitted. Feedback consent recorded at {consented_at}.")
+        }
+        None => println!("Anonymous feedback submitted."),
+    }
+
+    Ok(())
 }
 
 async fn handle_install_like_action(

--- a/crates/cli/src/commands/ai/mod.rs
+++ b/crates/cli/src/commands/ai/mod.rs
@@ -250,13 +250,13 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     };
 
     if result.is_ok() && !matches!(args.action, Some(AiAction::Feedback(_))) {
-        send_ai_feedback_event(args).await;
+        send_ai_feedback_event(args);
     }
 
     result
 }
 
-async fn send_ai_feedback_event(args: &Command) {
+fn send_ai_feedback_event(args: &Command) {
     let (event, command_name) = match &args.action {
         None => ("install", "codemod.ai.install"),
         Some(AiAction::Update(_)) => ("update", "codemod.ai.update"),
@@ -272,12 +272,11 @@ async fn send_ai_feedback_event(args: &Command) {
         Some(AiAction::Feedback(_)) => ("feedback", "codemod.ai.feedback"),
     };
 
-    feedback::send_anonymous_feedback_event(
-        "cli-ai",
-        event,
-        HashMap::from([("command".to_string(), command_name.to_string())]),
-    )
-    .await;
+    let event = event.to_string();
+    let metadata = HashMap::from([("command".to_string(), command_name.to_string())]);
+    let _handle = tokio::spawn(async move {
+        feedback::send_anonymous_feedback_event("cli-ai", &event, metadata).await;
+    });
 }
 
 async fn handle_feedback_command(command: &FeedbackCommand) -> Result<()> {

--- a/crates/cli/src/commands/mcp.rs
+++ b/crates/cli/src/commands/mcp.rs
@@ -1,3 +1,4 @@
+use crate::feedback;
 use anyhow::Result;
 use clap::Args;
 use codemod_mcp::CodemodMcpServer;
@@ -10,10 +11,15 @@ pub struct Command {
     /// Write MCP usage events to a file for debugging
     #[arg(long)]
     usage_log: Option<PathBuf>,
+    /// Opt in to anonymous Codemod AI and MCP feedback for this OS user
+    #[arg(long)]
+    allow_feedback: bool,
 }
 
 impl Command {
     pub async fn run(&self) -> Result<()> {
+        feedback::persist_feedback_consent_if_requested(self.allow_feedback)?;
+
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .with_writer(std::io::stderr)
@@ -22,12 +28,15 @@ impl Command {
 
         tracing::info!("Starting MCP server");
 
-        let service = CodemodMcpServer::new(self.usage_log.clone())
-            .serve(transport::stdio())
-            .await
-            .inspect_err(|e| {
-                tracing::error! {"serving error: {:?}", e};
-            })?;
+        let service = CodemodMcpServer::new_with_feedback(
+            self.usage_log.clone(),
+            feedback::anonymous_feedback_client("mcp")?,
+        )
+        .serve(transport::stdio())
+        .await
+        .inspect_err(|e| {
+            tracing::error! {"serving error: {:?}", e};
+        })?;
 
         service.waiting().await?;
         Ok(())

--- a/crates/cli/src/commands/mcp.rs
+++ b/crates/cli/src/commands/mcp.rs
@@ -30,7 +30,7 @@ impl Command {
 
         let service = CodemodMcpServer::new_with_feedback(
             self.usage_log.clone(),
-            feedback::anonymous_feedback_client("mcp")?,
+            feedback::anonymous_feedback_client("mcp").unwrap_or(None),
         )
         .serve(transport::stdio())
         .await

--- a/crates/cli/src/feedback.rs
+++ b/crates/cli/src/feedback.rs
@@ -1,0 +1,97 @@
+use crate::auth::TokenStorage;
+use crate::CLI_VERSION;
+use anyhow::{bail, Result};
+use codemod_mcp::AnonymousFeedbackClient;
+use std::collections::HashMap;
+
+const FEEDBACK_ENDPOINT_PATH: &str = "/api/v1/ai/feedback";
+
+pub fn feedback_disabled() -> bool {
+    matches!(
+        std::env::var("DISABLE_ANALYTICS").as_deref(),
+        Ok("true") | Ok("1")
+    )
+}
+
+pub fn feedback_endpoint(registry_url: &str) -> String {
+    format!(
+        "{}{}",
+        registry_url.trim_end_matches('/'),
+        FEEDBACK_ENDPOINT_PATH
+    )
+}
+
+pub fn persist_feedback_consent_if_requested(allow_feedback: bool) -> Result<()> {
+    if allow_feedback {
+        persist_feedback_consent()?;
+    }
+    Ok(())
+}
+
+pub fn persist_feedback_consent() -> Result<Option<String>> {
+    let storage = TokenStorage::new()?;
+    let config = storage.enable_anonymous_feedback()?;
+    Ok(config.anonymous_feedback.consented_at)
+}
+
+pub fn anonymous_feedback_client(source: &'static str) -> Result<Option<AnonymousFeedbackClient>> {
+    if feedback_disabled() {
+        return Ok(None);
+    }
+
+    let storage = TokenStorage::new()?;
+    let env: HashMap<String, String> = std::env::vars().collect();
+    let config = storage.load_config_with_env(Some(&env))?;
+    if !config.anonymous_feedback.enabled {
+        return Ok(None);
+    }
+
+    Ok(AnonymousFeedbackClient::new(
+        feedback_endpoint(&config.default_registry),
+        source,
+        CLI_VERSION.to_string(),
+        config.anonymous_feedback.consented_at.clone(),
+    ))
+}
+
+pub async fn send_anonymous_feedback_event(
+    source: &'static str,
+    event: &str,
+    metadata: HashMap<String, String>,
+) {
+    let Ok(Some(client)) = anonymous_feedback_client(source) else {
+        return;
+    };
+
+    client.submit(event, metadata).await;
+}
+
+pub async fn submit_anonymous_feedback(category: String, message: String) -> Result<()> {
+    if feedback_disabled() {
+        bail!("Anonymous feedback is disabled by DISABLE_ANALYTICS.");
+    }
+
+    let Some(client) = anonymous_feedback_client("cli-ai")? else {
+        bail!("Anonymous feedback is not enabled. Run this command again after allowing feedback.");
+    };
+
+    client
+        .submit_feedback("feedback", Some(category), Some(message), HashMap::new())
+        .await
+        .map_err(|error| anyhow::anyhow!("Failed to submit anonymous feedback: {error}"))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::feedback_endpoint;
+
+    #[test]
+    fn feedback_endpoint_uses_registry_api_path() {
+        assert_eq!(
+            feedback_endpoint("https://app.codemod.com/"),
+            "https://app.codemod.com/api/v1/ai/feedback"
+        );
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,6 +15,7 @@ mod commands;
 mod diagnostics;
 mod dirty_git_check;
 mod engine;
+mod feedback;
 mod progress_bar;
 mod report_server;
 mod suitability;
@@ -602,8 +603,34 @@ mod tests {
     }
 
     #[test]
+    fn parser_accepts_ai_feedback_opt_in() {
+        let parse_result = Cli::try_parse_from(["codemod", "ai", "--allow-feedback"]);
+        assert!(parse_result.is_ok());
+    }
+
+    #[test]
+    fn parser_accepts_ai_feedback_command() {
+        let parse_result = Cli::try_parse_from([
+            "codemod",
+            "ai",
+            "feedback",
+            "--category",
+            "jssg",
+            "--message",
+            "Please add multi-file JSSG examples.",
+        ]);
+        assert!(parse_result.is_ok());
+    }
+
+    #[test]
     fn parser_accepts_ai_list() {
         let parse_result = Cli::try_parse_from(["codemod", "ai", "list"]);
+        assert!(parse_result.is_ok());
+    }
+
+    #[test]
+    fn parser_accepts_mcp_feedback_opt_in() {
+        let parse_result = Cli::try_parse_from(["codemod", "mcp", "--allow-feedback"]);
         assert!(parse_result.is_ok());
     }
 

--- a/crates/cli/src/templates/ai-native-cli/codemod-cli/SKILL.md
+++ b/crates/cli/src/templates/ai-native-cli/codemod-cli/SKILL.md
@@ -32,6 +32,7 @@ Codemod AI tools must be usable without MCP. Prefer the CLI commands below when 
 - Inspect node types for a language: `npx codemod ai node-types tsx`
 - List docs resources: `npx codemod ai docs`
 - Read/search docs: `npx codemod ai docs codemod-creation-workflow`
+- Submit anonymous platform feedback after user consent: `npx codemod ai feedback --category jssg --message "Short feedback"`
 
 If MCP is available, direct MCP calls are acceptable. If MCP is unavailable, do not stop authoring only because MCP is missing; use the `codemod ai` CLI equivalents.
 
@@ -44,6 +45,14 @@ When the user:
 - **Hits errors or unexpected behavior** — Read `codemod-troubleshooting-instructions` via MCP or `npx codemod ai docs codemod-troubleshooting`.
 - **Needs import manipulation helpers** — Read `jssg-utils-instructions` via MCP or `npx codemod ai docs jssg-utils`.
 - **Needs to split a large migration into multiple PRs** — Read `sharding-instructions` via MCP or `npx codemod ai docs sharding`.
+
+## Anonymous feedback
+
+If you discover a Codemod platform gap, ask the user for explicit consent before enabling or submitting anonymous feedback. With consent, run `npx codemod ai feedback --category <category> --message <message>`. The command records the consent timestamp in user-wide Codemod config and submits the short feedback anonymously.
+
+Use these categories when possible: `jssg` for JSSG feature requests or runtime gaps, `workflow` for workflow authoring feedback, `ai-docs` for docs/resource enhancements, `mcp` for MCP tool or resource feedback, `cli`, `registry`, `package-validation`, or `other`.
+
+Keep feedback short and thematic. Do not include source code, secrets, auth tokens, private repository paths, user identity, or long transcripts.
 
 ## Authoring defaults
 

--- a/crates/cli/src/templates/ai-native-cli/codemod-cli/commands/codemod.md
+++ b/crates/cli/src/templates/ai-native-cli/codemod-cli/commands/codemod.md
@@ -15,6 +15,7 @@ Routing:
 - If the authoring request implies a monorepo, maintainer workflow, or multi-hop version series, also read `codemod-maintainer-monorepo-instructions`.
 - For codemod discovery or execution, read `codemod-cli-instructions`.
 - When commands fail or produce unexpected behavior, read `codemod-troubleshooting-instructions`.
+- If a Codemod platform gap is worth reporting, ask for explicit user consent first, then submit short anonymous feedback with `npx codemod ai feedback --category <category> --message <message>`. Use categories such as `jssg`, `workflow`, `ai-docs`, `mcp`, `cli`, `registry`, `package-validation`, or `other`. Do not include source code, secrets, auth tokens, private repository paths, user identity, or long transcripts.
 
 Non-negotiable constraints:
 - For migration, upgrade, update, or deprecation-rollout requests that do not explicitly ask to create a codemod, search the registry first before proposing a custom codemod plan.

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -2902,27 +2902,9 @@ impl Engine {
 
         debug!("Executing AI agent step with prompt: {}", resolved_prompt);
 
-        // 1. Check if running inside a parent coding agent
-        let handoff_detection = detect_parent_coding_agent();
-        let detected_agent = handoff_detection.agent_name.as_deref().unwrap_or("none");
-        debug!(
-            "AI handoff detection confidence={} agent={} reasons={}",
-            handoff_detection.confidence.as_str(),
-            detected_agent,
-            handoff_detection.reasons.join(" | ")
-        );
-
-        if handoff_detection.confidence == DetectionConfidence::Detected {
-            self.emit_ai_instructions(logger, ai_config.system_prompt.as_deref(), &resolved_prompt);
-            debug!(
-                "AI handoff mode=handoff confidence={} agent={}",
-                handoff_detection.confidence.as_str(),
-                detected_agent
-            );
-            return Ok(());
-        }
-
-        // 2. Check if agent was explicitly specified via --agent
+        // 1. Check if agent was explicitly specified via --agent. Explicit
+        // agent selection should not depend on parent-process inspection, which
+        // may be unavailable in slim/containerized runtimes.
         if let Some(ref agent_name) = self.workflow_run_config.interaction.agent {
             if let Some(canonical) = resolve_agent_name(agent_name) {
                 debug!("Agent specified via --agent: {}", canonical);
@@ -2954,7 +2936,7 @@ impl Engine {
             }
         }
 
-        // 2b. Check for LLM_AGENT env var (useful in non-interactive mode)
+        // 1b. Check for LLM_AGENT env var (useful in non-interactive mode).
         if let Ok(env_agent) = std::env::var("LLM_AGENT") {
             if !env_agent.is_empty() {
                 if let Some(canonical) = resolve_agent_name(&env_agent) {
@@ -2991,6 +2973,26 @@ impl Engine {
                     );
                 }
             }
+        }
+
+        // 2. Check if running inside a parent coding agent.
+        let handoff_detection = detect_parent_coding_agent();
+        let detected_agent = handoff_detection.agent_name.as_deref().unwrap_or("none");
+        debug!(
+            "AI handoff detection confidence={} agent={} reasons={}",
+            handoff_detection.confidence.as_str(),
+            detected_agent,
+            handoff_detection.reasons.join(" | ")
+        );
+
+        if handoff_detection.confidence == DetectionConfidence::Detected {
+            self.emit_ai_instructions(logger, ai_config.system_prompt.as_deref(), &resolved_prompt);
+            debug!(
+                "AI handoff mode=handoff confidence={} agent={}",
+                handoff_detection.confidence.as_str(),
+                detected_agent
+            );
+            return Ok(());
         }
 
         // 3. If interactive, discover installed agents and prompt user to select

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -588,6 +588,40 @@ pub struct CapabilitiesData {
     pub capabilities_security_callback: Option<CapabilitiesSecurityCallback>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AiAgentCandidateSource {
+    Explicit,
+    Env,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct AiAgentCandidate<'a> {
+    source: AiAgentCandidateSource,
+    name: &'a str,
+}
+
+fn configured_ai_agent_candidates<'a>(
+    explicit_agent: Option<&'a str>,
+    env_agent: Option<&'a str>,
+) -> Vec<AiAgentCandidate<'a>> {
+    explicit_agent
+        .filter(|agent| !agent.is_empty())
+        .map(|agent| AiAgentCandidate {
+            source: AiAgentCandidateSource::Explicit,
+            name: agent,
+        })
+        .into_iter()
+        .chain(
+            env_agent
+                .filter(|agent| !agent.is_empty())
+                .map(|agent| AiAgentCandidate {
+                    source: AiAgentCandidateSource::Env,
+                    name: agent,
+                }),
+        )
+        .collect()
+}
+
 impl Engine {
     async fn launch_agent(
         &self,
@@ -2902,23 +2936,57 @@ impl Engine {
 
         debug!("Executing AI agent step with prompt: {}", resolved_prompt);
 
-        // 1. Check if agent was explicitly specified via --agent. Explicit
-        // agent selection should not depend on parent-process inspection, which
-        // may be unavailable in slim/containerized runtimes.
-        if let Some(ref agent_name) = self.workflow_run_config.interaction.agent {
-            if let Some(canonical) = resolve_agent_name(agent_name) {
-                debug!("Agent specified via --agent: {}", canonical);
-                if let Some(executable) = find_agent_executable(canonical) {
-                    return self
-                        .launch_agent(
-                            canonical,
-                            &executable,
-                            ai_config.system_prompt.as_deref(),
-                            &resolved_prompt,
-                            logger,
-                        )
-                        .await;
-                } else {
+        // 1. Check explicitly configured agents before inspecting the parent
+        // process. `--agent` has priority over LLM_AGENT so CLI intent is stable
+        // even when the command is run inside another coding agent.
+        let env_agent = std::env::var("LLM_AGENT").ok();
+        for candidate in configured_ai_agent_candidates(
+            self.workflow_run_config.interaction.agent.as_deref(),
+            env_agent.as_deref(),
+        ) {
+            let Some(canonical) = resolve_agent_name(candidate.name) else {
+                let source = match candidate.source {
+                    AiAgentCandidateSource::Explicit => "--agent",
+                    AiAgentCandidateSource::Env => "LLM_AGENT",
+                };
+                slog!(
+                    logger,
+                    warn,
+                    "Unknown agent '{}' specified via {}, ignoring",
+                    candidate.name,
+                    source
+                );
+                continue;
+            };
+
+            match candidate.source {
+                AiAgentCandidateSource::Explicit => {
+                    debug!("Agent specified via --agent: {}", canonical);
+                }
+                AiAgentCandidateSource::Env => {
+                    slog!(
+                        logger,
+                        info,
+                        "Agent specified via LLM_AGENT env var: {}",
+                        canonical
+                    );
+                }
+            }
+
+            if let Some(executable) = find_agent_executable(canonical) {
+                return self
+                    .launch_agent(
+                        canonical,
+                        &executable,
+                        ai_config.system_prompt.as_deref(),
+                        &resolved_prompt,
+                        logger,
+                    )
+                    .await;
+            }
+
+            match candidate.source {
+                AiAgentCandidateSource::Explicit => {
                     slog!(
                         logger,
                         warn,
@@ -2926,50 +2994,12 @@ impl Engine {
                         canonical
                     );
                 }
-            } else {
-                slog!(
-                    logger,
-                    warn,
-                    "Unknown agent '{}' specified via --agent, ignoring",
-                    agent_name
-                );
-            }
-        }
-
-        // 1b. Check for LLM_AGENT env var (useful in non-interactive mode).
-        if let Ok(env_agent) = std::env::var("LLM_AGENT") {
-            if !env_agent.is_empty() {
-                if let Some(canonical) = resolve_agent_name(&env_agent) {
-                    slog!(
-                        logger,
-                        info,
-                        "Agent specified via LLM_AGENT env var: {}",
-                        canonical
-                    );
-                    if let Some(executable) = find_agent_executable(canonical) {
-                        return self
-                            .launch_agent(
-                                canonical,
-                                &executable,
-                                ai_config.system_prompt.as_deref(),
-                                &resolved_prompt,
-                                logger,
-                            )
-                            .await;
-                    } else {
-                        slog!(
-                            logger,
-                            warn,
-                            "Agent '{}' from LLM_AGENT is not installed, falling back to built-in AI",
-                            canonical
-                        );
-                    }
-                } else {
+                AiAgentCandidateSource::Env => {
                     slog!(
                         logger,
                         warn,
-                        "Unknown agent '{}' specified via LLM_AGENT, ignoring",
-                        env_agent
+                        "Agent '{}' from LLM_AGENT is not installed, falling back to built-in AI",
+                        canonical
                     );
                 }
             }
@@ -4105,6 +4135,31 @@ mod tests {
         );
 
         assert_eq!(eligible, vec!["src/changed.ts"]);
+    }
+
+    #[test]
+    fn configured_ai_agent_candidates_prioritize_explicit_agent_over_env() {
+        assert_eq!(
+            configured_ai_agent_candidates(Some("claude-code"), Some("codex")),
+            vec![
+                AiAgentCandidate {
+                    source: AiAgentCandidateSource::Explicit,
+                    name: "claude-code",
+                },
+                AiAgentCandidate {
+                    source: AiAgentCandidateSource::Env,
+                    name: "codex",
+                },
+            ],
+        );
+        assert_eq!(
+            configured_ai_agent_candidates(None, Some("codex")),
+            vec![AiAgentCandidate {
+                source: AiAgentCandidateSource::Env,
+                name: "codex",
+            }],
+        );
+        assert!(configured_ai_agent_candidates(Some(""), Some("")).is_empty());
     }
 
     #[tokio::test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -5,6 +5,7 @@ use rmcp::{
 use serde::de::{IgnoredAny, MapAccess, Visitor};
 use serde::{de, Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::future::Future;
 use std::io::Write;
@@ -377,6 +378,126 @@ fn call_tool_result_text(result: CallToolResult) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+#[derive(Clone, Debug)]
+pub struct AnonymousFeedbackClient {
+    endpoint: String,
+    source: &'static str,
+    cli_version: String,
+    consented_at: Option<String>,
+    os: &'static str,
+    arch: &'static str,
+    client: reqwest::Client,
+}
+
+#[derive(Serialize)]
+struct AnonymousFeedbackPayload<'a> {
+    source: &'a str,
+    event: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    category: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<String>,
+    #[serde(rename = "consentedAt", skip_serializing_if = "Option::is_none")]
+    consented_at: Option<&'a str>,
+    #[serde(rename = "cliVersion")]
+    cli_version: &'a str,
+    os: &'a str,
+    arch: &'a str,
+    metadata: HashMap<String, String>,
+}
+
+impl AnonymousFeedbackClient {
+    pub fn new(
+        endpoint: String,
+        source: &'static str,
+        cli_version: String,
+        consented_at: Option<String>,
+    ) -> Option<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .ok()?;
+
+        Some(Self {
+            endpoint,
+            source,
+            cli_version,
+            consented_at,
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            client,
+        })
+    }
+
+    pub async fn submit(&self, event: &str, metadata: HashMap<String, String>) {
+        let _ = self.submit_feedback(event, None, None, metadata).await;
+    }
+
+    pub async fn submit_feedback(
+        &self,
+        event: &str,
+        category: Option<String>,
+        message: Option<String>,
+        metadata: HashMap<String, String>,
+    ) -> Result<(), String> {
+        let payload = AnonymousFeedbackPayload {
+            source: self.source,
+            event: sanitize_feedback_event(event),
+            category,
+            message,
+            consented_at: self.consented_at.as_deref(),
+            cli_version: &self.cli_version,
+            os: self.os,
+            arch: self.arch,
+            metadata,
+        };
+
+        let response = self
+            .client
+            .post(&self.endpoint)
+            .header(
+                reqwest::header::USER_AGENT,
+                format!("codemod-cli/{}", self.cli_version),
+            )
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|error| format!("request failed: {error}"))?;
+
+        let status = response.status();
+        if status.is_success() {
+            return Ok(());
+        }
+
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|error| format!("failed to read response body: {error}"));
+
+        Err(format!("server returned {status}: {body}"))
+    }
+}
+
+fn sanitize_feedback_event(event: &str) -> String {
+    let sanitized = event
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, ':' | '.' | '_' | '-') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+
+    let trimmed = sanitized.trim_matches('_');
+    if trimmed.is_empty() {
+        "unknown".to_string()
+    } else {
+        trimmed.chars().take(128).collect()
+    }
 }
 
 fn public_docs_client() -> Option<&'static reqwest::Client> {
@@ -866,6 +987,7 @@ pub struct CodemodMcpServer {
     jssg_test_handler: JssgTestHandler,
     package_validation_handler: PackageValidationHandler,
     usage_log_path: Option<PathBuf>,
+    anonymous_feedback: Option<AnonymousFeedbackClient>,
     tool_router: ToolRouter<CodemodMcpServer>,
 }
 
@@ -877,12 +999,20 @@ impl Default for CodemodMcpServer {
 
 impl CodemodMcpServer {
     pub fn new(usage_log_path: Option<PathBuf>) -> Self {
+        Self::new_with_feedback(usage_log_path, None)
+    }
+
+    pub fn new_with_feedback(
+        usage_log_path: Option<PathBuf>,
+        anonymous_feedback: Option<AnonymousFeedbackClient>,
+    ) -> Self {
         Self {
             ast_dump_handler: AstDumpHandler::new(),
             node_types_handler: NodeTypesHandler::new(),
             jssg_test_handler: JssgTestHandler::new(),
             package_validation_handler: PackageValidationHandler::new(),
             usage_log_path,
+            anonymous_feedback,
             tool_router: Self::tool_router(),
         }
     }
@@ -1009,6 +1139,13 @@ impl CodemodMcpServer {
     }
 
     fn log_usage(&self, event: &str) {
+        if let Some(feedback) = self.anonymous_feedback.clone() {
+            let event = event.to_string();
+            let _handle = tokio::spawn(async move {
+                feedback.submit(&event, HashMap::new()).await;
+            });
+        }
+
         let Some(path) = self.usage_log_path.clone() else {
             return;
         };
@@ -1454,7 +1591,7 @@ impl ServerHandler for CodemodMcpServer {
                 .enable_resources()
                 .build(),
             server_info: Implementation::from_build_env(),
-            instructions: Some("This server provides AST dumping, tree-sitter node types, JSSG test execution, and Codemod package validation. Available tools: dump_ast, get_node_types, run_jssg_tests, validate_codemod_package. Available resources: jssg-instructions, jssg-gotchas, ast-grep-gotchas, jssg-utils-instructions, jssg-runtime-capabilities-instructions, codemod-cli-instructions, sharding-instructions, codemod-troubleshooting-instructions, codemod-creation-workflow-instructions, codemod-maintainer-monorepo-instructions. For codemod authoring, read codemod-creation-workflow-instructions first, then read jssg-gotchas and ast-grep-gotchas before writing source-transform code. If registry search finds no exact existing package, run direct codemod init immediately; in non-interactive flows, pass only user- or task-provided metadata flags and rely on CLI defaults/auth-derived author handling for the rest. Call validate_codemod_package before you stop work on a codemod package. Use dump_ast when pattern shape is unclear. If symbol origin matters, use semantic analysis and binding-aware checks.".to_string()),
+            instructions: Some("This server provides AST dumping, tree-sitter node types, JSSG test execution, and Codemod package validation. Available tools: dump_ast, get_node_types, run_jssg_tests, validate_codemod_package. Available resources: jssg-instructions, jssg-gotchas, ast-grep-gotchas, jssg-utils-instructions, jssg-runtime-capabilities-instructions, codemod-cli-instructions, sharding-instructions, codemod-troubleshooting-instructions, codemod-creation-workflow-instructions, codemod-maintainer-monorepo-instructions. For codemod authoring, read codemod-creation-workflow-instructions first, then read jssg-gotchas and ast-grep-gotchas before writing source-transform code. If registry search finds no exact existing package, run direct codemod init immediately; in non-interactive flows, pass only user- or task-provided metadata flags and rely on CLI defaults/auth-derived author handling for the rest. Call validate_codemod_package before you stop work on a codemod package. Use dump_ast when pattern shape is unclear. If symbol origin matters, use semantic analysis and binding-aware checks. If you discover a Codemod platform gap, ask the user for explicit consent before submitting anonymous feedback. With consent, run `codemod ai feedback --category <category> --message <short message>` using categories like jssg, workflow, ai-docs, mcp, cli, registry, package-validation, or other. Do not include source code, secrets, auth tokens, private repository paths, user identity, or long transcripts.".to_string()),
         }
     }
 
@@ -1699,6 +1836,7 @@ mod tests {
         assert!(instructions.contains("codemod-creation-workflow-instructions"));
         assert!(instructions.contains("direct codemod init"));
         assert!(instructions.contains("auth-derived author"));
+        assert!(instructions.contains("anonymous feedback"));
     }
 
     #[tokio::test]
@@ -1848,5 +1986,14 @@ mod tests {
 
         drop(_cwd_guard);
         fs::remove_dir_all(&temp_dir).expect("expected temp dir cleanup");
+    }
+
+    #[test]
+    fn feedback_event_names_are_sanitized() {
+        assert_eq!(
+            sanitize_feedback_event("cli:resource:jssg://instructions"),
+            "cli:resource:jssg:__instructions"
+        );
+        assert_eq!(sanitize_feedback_event("  "), "unknown");
     }
 }

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -124,6 +124,7 @@ The installed skill also points users to CLI fallbacks when MCP is unavailable o
 - `npx codemod ai dump-ast <file>` or `npx codemod ai dump-ast --`: inspect AST shape for a file or stdin
 - `npx codemod ai node-types <language>`: inspect tree-sitter node kinds for a language
 - `npx codemod ai call validate_codemod_package --input '{"package_path":"."}'`: validate whether a codemod package still contains starter scaffold markers or other package-surface issues
+- `npx codemod ai feedback --category <category> --message <message>`: submit short anonymous platform feedback after consent is recorded
 
 `ai` also wires a periodic, cooldown-protected update check trigger:
 - `claude`: `hooks.SessionStart` command in `./.claude/settings.json` (project) or `~/.claude/settings.json` (user)
@@ -138,6 +139,25 @@ Managed update policy is install-flag driven and shared by install-time reconcil
   `--update-source` only accepts `local`, `registry`, or an absolute `http(s)` URL (legacy `registry:`/`url:` aliases are rejected).
 Periodic runs enforce signed manifest verification via `--require-signed-manifest` in the generated runner command.
 After install, restart or reload your harness session so newly installed skills and command entrypoints are picked up.
+
+**`ai feedback`**
+
+Submit short anonymous platform feedback for Codemod AI, MCP, JSSG, workflows, docs, CLI, registry, or related surfaces. The command records anonymous feedback consent in the user-wide Codemod config, including the timestamp at which this OS user allowed feedback submission.
+
+```bash
+npx codemod ai feedback --category <category> --message <message>
+```
+
+Recommended categories are `jssg`, `workflow`, `ai-docs`, `mcp`, `cli`, `registry`, `package-validation`, and `other`.
+
+Examples:
+
+```bash
+npx codemod ai feedback --category jssg --message "I wish JSSG had clearer examples for multi-file transforms."
+npx codemod ai feedback --category ai-docs --message "The docs resource for runtime capabilities should explain which Node APIs are unavailable."
+```
+
+Feedback is anonymous. Do not include source code, secrets, auth tokens, private repository paths, user identity, or long transcripts in the message.
 
 **`ai update`**
 

--- a/docs/model-context-protocol.mdx
+++ b/docs/model-context-protocol.mdx
@@ -109,6 +109,29 @@ When working with AI assistants through Codemod MCP, follow these guidelines for
   </Step>
 </Steps>
 
+## Anonymous platform feedback
+
+Codemod AI and MCP can submit short anonymous platform feedback when the user has explicitly consented. Agents must ask before enabling or submitting feedback.
+
+After the user consents, submit categorized feedback with:
+
+```bash
+npx codemod ai feedback --category <category> --message <message>
+```
+
+Use short, thematic feedback only. Recommended categories are:
+
+- `jssg`: JSSG feature requests, runtime gaps, or transform-authoring friction
+- `workflow`: workflow feature requests or workflow authoring friction
+- `ai-docs`: AI docs resources that should be added, clarified, or reorganized
+- `mcp`: MCP tool, resource, or server behavior feedback
+- `cli`: CLI command or setup feedback
+- `registry`: registry discovery or package metadata feedback
+- `package-validation`: package validation checks that should be added or refined
+- `other`: feedback that does not fit the categories above
+
+Do not include source code, secrets, auth tokens, private repository paths, user identity, or long transcripts. The CLI records and reports the consent timestamp automatically.
+
 ## Troubleshooting
 
 <AccordionGroup>


### PR DESCRIPTION
#### 📚 Description

Adds opt-in anonymous feedback support for Codemod AI surfaces in the CLI and MCP server.

- Stores user-wide anonymous feedback consent with the timestamp when consent was granted.
- Adds `codemod ai feedback --category <category> --message <message>` for short categorized feedback submission.
- Adds `--allow-feedback` handling for `codemod ai` and `codemod mcp`.
- Sends best-effort anonymous MCP/AI feedback events only after consent is enabled.
- Updates the bundled AI CLI skill and docs so agents ask for consent before submitting feedback.
- Improves explicit feedback errors to include the server status/body.

Backend persistence is handled separately in codemod/codemod-app#785.

#### 🔗 Linked Issue

Fixes CDMD-4787

#### 🧪 Test Plan

- `cargo fmt -p codemod -p codemod-mcp -- --check`
- `cargo check -p codemod --bin codemod`
- Verified local feedback submission against `CODEMOD_REGISTRY_URL=http://localhost:3000` after the backend timestamp validation fix.

#### 📄 Documentation to Update

Updated:

- `docs/cli.mdx`
- `docs/model-context-protocol.mdx`
- `crates/cli/src/templates/ai-native-cli/codemod-cli/SKILL.md`
- `crates/cli/src/templates/ai-native-cli/codemod-cli/commands/codemod.md`
