### PR TITLE
fix(cli): keep feedback consent from persisting registry override

### DIFF
--- a/crates/cli/src/auth/storage.rs
+++ b/crates/cli/src/auth/storage.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use butterflow_core::registry::RegistryConfig;
 use dirs::config_dir;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -7,6 +6,8 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::auth::types::{AuthTokens, UserInfo};
+
+const DEFAULT_REGISTRY_URL: &str = "https://app.codemod.com";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -18,7 +19,7 @@ pub struct Config {
 
 impl Default for Config {
     fn default() -> Self {
-        Self::with_default_registry(RegistryConfig::default().default_registry.to_string())
+        Self::with_default_registry(DEFAULT_REGISTRY_URL.to_string())
     }
 }
 
@@ -106,7 +107,7 @@ impl TokenStorage {
                 .map(|value| value.trim())
                 .filter(|value| !value.is_empty())
                 .map(|value| value.to_string())
-                .unwrap_or_else(|| RegistryConfig::default().default_registry);
+                .unwrap_or_else(|| DEFAULT_REGISTRY_URL.to_string());
             return Ok(Config::with_default_registry(default_registry));
         }
 
@@ -131,8 +132,7 @@ impl TokenStorage {
     }
 
     pub fn enable_anonymous_feedback(&self) -> Result<Config> {
-        let env: HashMap<String, String> = std::env::vars().collect();
-        let mut config = self.load_config_with_env(Some(&env))?;
+        let mut config = self.load_config()?;
         let consented_at = config
             .anonymous_feedback
             .consented_at
@@ -225,6 +225,29 @@ mod tests {
     use super::TokenStorage;
     use std::fs;
 
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(original) = &self.original {
+                std::env::set_var(self.key, original);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
     #[test]
     fn missing_feedback_config_defaults_to_disabled() {
         let temp_dir = tempfile::tempdir().expect("expected temp dir");
@@ -262,6 +285,27 @@ mod tests {
         assert_eq!(
             reloaded.anonymous_feedback.consented_at,
             config.anonymous_feedback.consented_at
+        );
+    }
+
+    #[test]
+    fn enable_anonymous_feedback_does_not_persist_registry_env_override() {
+        let temp_dir = tempfile::tempdir().expect("expected temp dir");
+        let storage =
+            TokenStorage::with_config_dir(temp_dir.path().to_path_buf()).expect("storage");
+        let _registry_url_guard = EnvVarGuard::set("CODEMOD_REGISTRY_URL", "http://localhost:3000");
+
+        let config = storage
+            .enable_anonymous_feedback()
+            .expect("expected feedback consent write");
+
+        assert_eq!(config.default_registry, "https://app.codemod.com");
+        assert_eq!(
+            storage
+                .load_config()
+                .expect("expected config reload")
+                .default_registry,
+            "https://app.codemod.com"
         );
     }
 

--- a/crates/cli/src/feedback.rs
+++ b/crates/cli/src/feedback.rs
@@ -21,6 +21,13 @@ pub fn feedback_endpoint(registry_url: &str) -> String {
     )
 }
 
+fn env_registry_url() -> Option<String> {
+    std::env::var("CODEMOD_REGISTRY_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
 pub fn persist_feedback_consent_if_requested(allow_feedback: bool) -> Result<()> {
     if allow_feedback {
         persist_feedback_consent()?;
@@ -40,14 +47,14 @@ pub fn anonymous_feedback_client(source: &'static str) -> Result<Option<Anonymou
     }
 
     let storage = TokenStorage::new()?;
-    let env: HashMap<String, String> = std::env::vars().collect();
-    let config = storage.load_config_with_env(Some(&env))?;
+    let config = storage.load_config()?;
     if !config.anonymous_feedback.enabled {
         return Ok(None);
     }
+    let registry_url = env_registry_url().unwrap_or_else(|| config.default_registry.clone());
 
     Ok(AnonymousFeedbackClient::new(
-        feedback_endpoint(&config.default_registry),
+        feedback_endpoint(&registry_url),
         source,
         CLI_VERSION.to_string(),
         config.anonymous_feedback.consented_at.clone(),
@@ -85,7 +92,30 @@ pub async fn submit_anonymous_feedback(category: String, message: String) -> Res
 
 #[cfg(test)]
 mod tests {
-    use super::feedback_endpoint;
+    use super::{env_registry_url, feedback_endpoint};
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            if let Some(original) = &self.original {
+                std::env::set_var(self.key, original);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 
     #[test]
     fn feedback_endpoint_uses_registry_api_path() {
@@ -93,5 +123,15 @@ mod tests {
             feedback_endpoint("https://app.codemod.com/"),
             "https://app.codemod.com/api/v1/ai/feedback"
         );
+    }
+
+    #[test]
+    fn env_registry_url_trims_and_ignores_empty_values() {
+        let _registry_url_guard =
+            EnvVarGuard::set("CODEMOD_REGISTRY_URL", " http://localhost:3000 ");
+        assert_eq!(env_registry_url().as_deref(), Some("http://localhost:3000"));
+
+        std::env::set_var("CODEMOD_REGISTRY_URL", " ");
+        assert_eq!(env_registry_url(), None);
     }
 }


### PR DESCRIPTION
#### 📚 Description

Fixes the anonymous feedback consent path so it does not persist `CODEMOD_REGISTRY_URL` into the user-wide `default_registry` setting.

- Uses the production registry URL as the persisted config default instead of the env-sensitive `RegistryConfig::default()`.
- Loads persisted config without env overrides when saving anonymous feedback consent.
- Keeps `CODEMOD_REGISTRY_URL` available as a runtime-only endpoint override for feedback submission.
- Adds regression tests for both the consent persistence behavior and the runtime feedback endpoint override helper.

#### 🔗 Linked Issue

Fixes CDMD-4787

#### 🧪 Test Plan

- `cargo test -p codemod auth::storage::tests::enable_anonymous_feedback_does_not_persist_registry_env_override -- --exact`
- `cargo test -p codemod feedback::tests::env_registry_url_trims_and_ignores_empty_values -- --exact`
- `cargo check -p codemod --bin codemod`
- pre-commit hook: `oxlint`, `oxfmt --check`

#### 📄 Documentation to Update

No documentation changes needed. This preserves the documented registry behavior while fixing config persistence.
