### PR TITLE
feat(cli): enforce pro/dry-run semantics for bundled child codemods

### DIFF
--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,4 +1,7 @@
 use crate::engine::{create_engine, create_registry_client};
+use crate::pro_dry_run::{
+    apply_pro_dry_run_execution_settings, notify_pro_dry_run_required, ProDryRunReason,
+};
 use crate::progress_bar::download_progress_bar;
 use crate::utils::manifest::CodemodManifest;
 use crate::utils::package_validation::{default_workflow_path, select_workflow_path};
@@ -220,37 +223,6 @@ pub async fn handler(
         }
     };
 
-    // Auto-force dry-run for non-pro users accessing pro codemods.
-    // Show an informational notice explaining what free preview covers and
-    // how to unlock applying changes + advanced insights.
-    let (resolved_package, dry_run) = if resolved_package.dry_run_only {
-        if !args.dry_run && !args.no_interactive {
-            let notice = style(
-                "This is a Pro codemod. Preview changes and insights for free with no login or code sharing. \
-                 Applying changes and advanced insights requires a Pro plan and signing in. \
-                 Learn more: codemod.com/contact."
-            )
-            .yellow();
-
-            // Only block for a keypress when both stdin and stdout are attached
-            // to a terminal. Otherwise the notice (or the "press any key" line)
-            // would be hidden from the user — e.g. `codemod run <pro> > out.txt`
-            // would silently hang. In that case, route the notice to stderr so
-            // it stays visible and proceed straight into dry-run.
-            if io::stdin().is_terminal() && io::stdout().is_terminal() {
-                println!("{notice}");
-                println!("{}", style("Press any key to proceed.").dim());
-                wait_for_any_key();
-            } else {
-                eprintln!("{notice}");
-            }
-        }
-
-        (resolved_package, true)
-    } else {
-        (resolved_package, args.dry_run)
-    };
-
     info!(
         "Resolved codemod package: {} -> {}",
         args.package,
@@ -295,6 +267,29 @@ pub async fn handler(
         .map_err(|e| anyhow::anyhow!("Failed to parse parameters: {}", e))?;
     let workflow_definition = butterflow_core::utils::parse_workflow_file(&workflow_path)
         .map_err(|e| anyhow::anyhow!("Failed to parse workflow before run: {}", e))?;
+
+    let dry_run_only_dependency = if resolved_package.dry_run_only {
+        Some(args.package.clone())
+    } else {
+        butterflow_core::utils::find_dry_run_only_codemod_dependency(
+            &workflow_definition,
+            &registry_client,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to inspect bundled codemods: {}", e))?
+    };
+    let pro_dry_run_required = dry_run_only_dependency.is_some();
+    if pro_dry_run_required && !args.dry_run {
+        if resolved_package.dry_run_only {
+            notify_pro_dry_run_required(ProDryRunReason::TopLevelCodemod, args.no_interactive);
+        } else if let Some(source) = dry_run_only_dependency.as_deref() {
+            notify_pro_dry_run_required(
+                ProDryRunReason::BundledChild { source },
+                args.no_interactive,
+            );
+        }
+    }
+    let dry_run = args.dry_run || pro_dry_run_required;
     let auto_launch_tui =
         should_auto_launch_package_run_tui(args.no_interactive, dry_run, &workflow_definition);
 
@@ -316,11 +311,11 @@ pub async fn handler(
     let output_format = args.format;
 
     // Run workflow using the extracted workflow runner
-    let (mut engine, config) = create_engine(
+    let (mut engine, mut config) = create_engine(
         workflow_path,
         target_path.clone(),
         dry_run,
-        args.allow_dirty || resolved_package.dry_run_only,
+        args.allow_dirty || pro_dry_run_required,
         params,
         args.registry.clone(),
         Some(capabilities.clone()),
@@ -344,12 +339,9 @@ pub async fn handler(
     // For pro codemod dry-run: streamline execution — auto-trigger manual
     // steps, skip shards, skip state writes, flatten matrix to one task per node.
     // Set on both engine (used at runtime) and config (passed to run_workflow).
-    if resolved_package.dry_run_only {
-        let engine_config = engine.workflow_run_config_mut();
-        engine_config.execution.auto_trigger_manual_steps = true;
-        engine_config.execution.skip_shard_steps = true;
-        engine_config.execution.skip_state_writes = true;
-        engine_config.execution.flatten_matrix_tasks = true;
+    if pro_dry_run_required {
+        apply_pro_dry_run_execution_settings(engine.workflow_run_config_mut());
+        apply_pro_dry_run_execution_settings(&mut config);
     }
 
     let run_result = run_workflow(&mut engine, config).await;
@@ -452,30 +444,6 @@ fn legacy_command_error(exit_code: Option<i32>) -> anyhow::Error {
         "Legacy codemod command failed with exit code: {:?}",
         exit_code
     )
-}
-
-/// Block until the user presses any key. Falls back to a no-op when either
-/// stdin or stdout isn't a terminal (e.g. piped input or redirected output)
-/// or when raw mode can't be enabled. Callers must ensure any prompt they want
-/// the user to read has already been printed to a stream the user can see.
-fn wait_for_any_key() {
-    use crossterm::event::{read, Event, KeyEventKind};
-    use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-
-    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
-        return;
-    }
-    if enable_raw_mode().is_err() {
-        return;
-    }
-    loop {
-        match read() {
-            Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => break,
-            Ok(_) => continue,
-            Err(_) => break,
-        }
-    }
-    let _ = disable_raw_mode();
 }
 
 fn load_codemod_manifest(codemod_config_path: &Path) -> Result<Option<CodemodManifest>> {

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -16,7 +16,10 @@ use clap::Args;
 use codemod_telemetry::send_event::BaseEvent;
 use std::sync::atomic::Ordering;
 
-use crate::engine::create_engine;
+use crate::engine::{create_engine, create_registry_client};
+use crate::pro_dry_run::{
+    apply_pro_dry_run_execution_settings, notify_pro_dry_run_required, ProDryRunReason,
+};
 use crate::workflow_runner::{
     resolve_workflow_source_with_name, run_workflow, workflow_has_manual_steps,
 };
@@ -155,8 +158,23 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         "Failed to parse workflow file: {}",
         workflow_file_path.display()
     ))?;
+    let registry_client = create_registry_client(None)?;
+    let dry_run_only_dependency =
+        utils::find_dry_run_only_codemod_dependency(&workflow_definition, &registry_client)
+            .await
+            .context("Failed to inspect bundled codemods")?;
+    if let Some(source) = dry_run_only_dependency.as_deref() {
+        if !args.dry_run {
+            notify_pro_dry_run_required(
+                ProDryRunReason::BundledChild { source },
+                args.no_interactive,
+            );
+        }
+    }
+    let pro_dry_run_required = dry_run_only_dependency.is_some();
+    let dry_run = args.dry_run || pro_dry_run_required;
     let auto_launch_tui =
-        should_auto_launch_workflow_tui(args.no_interactive, args.dry_run, &workflow_definition);
+        should_auto_launch_workflow_tui(args.no_interactive, dry_run, &workflow_definition);
 
     // Always collect diffs so we can offer report interactively
     let diff_collector = Some(Arc::new(Mutex::new(Vec::<FileDiff>::new())));
@@ -168,11 +186,11 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         .parse()
         .map_err(|e: String| anyhow::anyhow!(e))?;
 
-    let (mut engine, config) = create_engine(
+    let (mut engine, mut config) = create_engine(
         workflow_file_path,
         target_path.clone(),
-        args.dry_run,
-        args.allow_dirty,
+        dry_run,
+        args.allow_dirty || pro_dry_run_required,
         params,
         None,
         Some(capabilities.clone()),
@@ -187,6 +205,10 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
 
     engine.set_name(Some(workflow_label));
     apply_workflow_run_mode_to_config(engine.workflow_run_config_mut(), auto_launch_tui);
+    if pro_dry_run_required {
+        apply_pro_dry_run_execution_settings(engine.workflow_run_config_mut());
+        apply_pro_dry_run_execution_settings(&mut config);
+    }
     if auto_launch_tui {
         engine.set_quiet(true);
         engine.set_progress_callback(std::sync::Arc::new(None));
@@ -216,7 +238,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
             args.workflow.clone(),
             None,
             duration_ms,
-            args.dry_run,
+            dry_run,
             target_path.display().to_string(),
             CLI_VERSION.to_string(),
             files_modified,
@@ -240,7 +262,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
                     ("executionId".to_string(), generate_execution_id()),
                     ("runTimeSeconds".to_string(), seconds.to_string()),
                     ("dirtyRun".to_string(), args.allow_dirty.to_string()),
-                    ("dryRun".to_string(), args.dry_run.to_string()),
+                    ("dryRun".to_string(), dry_run.to_string()),
                     ("cliVersion".to_string(), CLI_VERSION.to_string()),
                     ("os".to_string(), std::env::consts::OS.to_string()),
                     ("arch".to_string(), std::env::consts::ARCH.to_string()),

--- a/crates/cli/src/engine.rs
+++ b/crates/cli/src/engine.rs
@@ -54,12 +54,17 @@ pub fn create_progress_callback() -> ProgressCallback {
     ProgressCallback {
         callback: Arc::new(Box::new(
             move |task_id: &str, path: &str, status: &str, count: Option<&u64>, index: &u64| {
+                let nested_label = task_id
+                    .split_once(':')
+                    .map(|(_, label)| label.trim())
+                    .filter(|label| !label.is_empty());
                 match status {
                     "start" | "counting" => {
                         progress_reporter(progress_bar::ProgressUpdate {
                             task_id: task_id.to_string(),
                             action: progress_bar::ProgressAction::Start {
                                 total_files: count.cloned(),
+                                label: nested_label.map(str::to_string),
                             },
                         });
                     }
@@ -110,7 +115,7 @@ pub fn create_progress_callback() -> ProgressCallback {
                         });
                     }
                     "finish" => {
-                        let message = if let Some(total) = count {
+                        let processed_message = if let Some(total) = count {
                             if *total == 1 {
                                 "Processed 1 file".to_string()
                             } else {
@@ -119,6 +124,9 @@ pub fn create_progress_callback() -> ProgressCallback {
                         } else {
                             format!("Processed {index} files")
                         };
+                        let message = nested_label
+                            .map(|label| format!("{label}: {processed_message}"))
+                            .unwrap_or(processed_message);
                         progress_reporter(progress_bar::ProgressUpdate {
                             task_id: task_id.to_string(),
                             action: progress_bar::ProgressAction::Finish {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,6 +16,7 @@ mod diagnostics;
 mod dirty_git_check;
 mod engine;
 mod feedback;
+mod pro_dry_run;
 mod progress_bar;
 mod report_server;
 mod suitability;

--- a/crates/cli/src/pro_dry_run.rs
+++ b/crates/cli/src/pro_dry_run.rs
@@ -1,0 +1,91 @@
+use std::io::{self, IsTerminal};
+
+use butterflow_core::config::WorkflowRunConfig;
+use console::style;
+
+pub(crate) enum ProDryRunReason<'a> {
+    TopLevelCodemod,
+    BundledChild { source: &'a str },
+}
+
+pub(crate) fn notify_pro_dry_run_required(reason: ProDryRunReason<'_>, no_interactive: bool) {
+    if no_interactive {
+        return;
+    }
+
+    let notice = match reason {
+        ProDryRunReason::TopLevelCodemod => {
+            "This is a Pro codemod. Preview changes and insights for free with no login or code sharing. \
+             Applying changes and advanced insights requires a Pro plan and signing in. \
+             Learn more: codemod.com/contact."
+                .to_string()
+        }
+        ProDryRunReason::BundledChild { source } => {
+            format!(
+                "This bundle includes a Pro codemod ({source}). Preview changes and insights for free with no login or code sharing. \
+                 Applying changes and advanced insights requires a Pro plan and signing in. \
+                 Learn more: codemod.com/contact."
+            )
+        }
+    };
+    let notice = style(notice).yellow();
+
+    // Only block for a keypress when both stdin and stdout are attached
+    // to a terminal. Otherwise the notice (or the "press any key" line)
+    // would be hidden from the user; route it to stderr and continue.
+    if io::stdin().is_terminal() && io::stdout().is_terminal() {
+        println!("{notice}");
+        println!("{}", style("Press any key to proceed.").dim());
+        wait_for_any_key();
+    } else {
+        eprintln!("{notice}");
+    }
+}
+
+pub(crate) fn apply_pro_dry_run_execution_settings(cfg: &mut WorkflowRunConfig) {
+    cfg.execution.auto_trigger_manual_steps = true;
+    cfg.execution.skip_shard_steps = true;
+    cfg.execution.skip_state_writes = true;
+    cfg.execution.flatten_matrix_tasks = true;
+}
+
+/// Block until the user presses any key. Falls back to a no-op when either
+/// stdin or stdout isn't a terminal (e.g. piped input or redirected output)
+/// or when raw mode can't be enabled. Callers must ensure any prompt they want
+/// the user to read has already been printed to a stream the user can see.
+fn wait_for_any_key() {
+    use crossterm::event::{read, Event, KeyEventKind};
+    use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+
+    if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+        return;
+    }
+    if enable_raw_mode().is_err() {
+        return;
+    }
+    loop {
+        match read() {
+            Ok(Event::Key(key)) if key.kind == KeyEventKind::Press => break,
+            Ok(_) => continue,
+            Err(_) => break,
+        }
+    }
+    let _ = disable_raw_mode();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_pro_dry_run_execution_settings_enables_preview_only_mode() {
+        let mut config = WorkflowRunConfig::default();
+
+        apply_pro_dry_run_execution_settings(&mut config);
+
+        assert!(config.execution.auto_trigger_manual_steps);
+        assert!(config.execution.skip_shard_steps);
+        assert!(config.execution.skip_state_writes);
+        assert!(config.execution.flatten_matrix_tasks);
+    }
+}

--- a/crates/cli/src/progress_bar.rs
+++ b/crates/cli/src/progress_bar.rs
@@ -48,13 +48,28 @@ pub fn download_progress_bar() -> Arc<Box<dyn Fn(u64, u64) + Send + Sync>> {
 }
 
 pub enum ProgressAction {
-    Start { total_files: Option<u64> },
-    Update { current_file: String },
-    Agent { payload: String },
-    Log { title: String, line: String },
-    Diagnostic { title: String, message: String },
+    Start {
+        total_files: Option<u64>,
+        label: Option<String>,
+    },
+    Update {
+        current_file: String,
+    },
+    Agent {
+        payload: String,
+    },
+    Log {
+        title: String,
+        line: String,
+    },
+    Diagnostic {
+        title: String,
+        message: String,
+    },
     Increment,
-    Finish { message: Option<String> },
+    Finish {
+        message: Option<String>,
+    },
 }
 
 pub struct ProgressUpdate {
@@ -98,7 +113,7 @@ pub fn create_multi_progress_reporter() -> (ProgressReporter, Instant) {
         let task_id = update.task_id.clone();
 
         match update.action {
-            ProgressAction::Start { total_files } => {
+            ProgressAction::Start { total_files, label } => {
                 let mut bars_lock = bars.lock().unwrap();
                 *active_log_title.lock().unwrap() = None;
 
@@ -111,13 +126,19 @@ pub fn create_multi_progress_reporter() -> (ProgressReporter, Instant) {
                     let pb = mp.add(ProgressBar::new(total));
                     pb.set_style(progress_style.clone());
                     pb.set_prefix(task_id.clone());
-                    pb.set_message(style("Starting").dim().to_string());
+                    let message = label
+                        .map(|label| format!("Running {label}"))
+                        .unwrap_or_else(|| "Starting".to_string());
+                    pb.set_message(style(message).dim().to_string());
                     pb
                 } else {
                     let pb = mp.add(ProgressBar::new_spinner());
                     pb.set_style(spinner_style.clone());
                     pb.set_prefix(task_id.clone());
-                    pb.set_message(style("Starting").dim().to_string());
+                    let message = label
+                        .map(|label| format!("Running {label}"))
+                        .unwrap_or_else(|| "Starting".to_string());
+                    pb.set_message(style(message).dim().to_string());
                     pb.enable_steady_tick(std::time::Duration::from_millis(120));
                     pb
                 };

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -2902,6 +2902,7 @@ impl Engine {
     pub async fn execute_js_ast_grep_step(
         &self,
         id: String,
+        progress_task_id: Option<String>,
         step_id: String,
         step_name: String,
         report_step_id: Option<String>,
@@ -2921,6 +2922,7 @@ impl Engine {
         JssgExecutionService::new(self)
             .execute(JssgExecutionRequest {
                 id,
+                progress_task_id,
                 step_id,
                 step_name,
                 report_step_id,
@@ -3625,6 +3627,7 @@ impl Engine {
 
         self.execute_js_ast_grep_step(
             task_id.to_string(),
+            None,
             "shard-scan".to_string(),
             "Shard Scan".to_string(),
             None,
@@ -4241,6 +4244,7 @@ export default function transform(ast) {
         engine
             .execute_js_ast_grep_step(
                 "test-node".to_string(),
+                None,
                 "test-step".to_string(),
                 "test-step".to_string(),
                 None,

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -481,6 +481,34 @@ pub(crate) fn log_step_output(logger: &StructuredLogger, output: &str) {
     }
 }
 
+fn notify_nested_codemod_progress(
+    progress_callback: &Arc<Option<ProgressCallback>>,
+    task_id: &Uuid,
+    display_path: &str,
+) {
+    let Some(callback) = progress_callback.as_ref() else {
+        return;
+    };
+
+    let title = "Bundled codemods";
+    let line = format!("Running {display_path}");
+    (callback.callback)(
+        &task_id.to_string(),
+        &format!("{title}\n{line}"),
+        "log",
+        None,
+        &0,
+    );
+}
+
+fn codemod_dependency_display_path(dependency_chain: &[CodemodDependency]) -> String {
+    dependency_chain
+        .iter()
+        .map(|dependency| dependency.source.as_str())
+        .collect::<Vec<_>>()
+        .join(" > ")
+}
+
 fn format_shell_command_notice(request: &ShellCommandExecutionRequest) -> String {
     let mut message = format!(
         "About to execute shell command for step '{}' in node '{}':",
@@ -1774,7 +1802,7 @@ impl Engine {
     ///
     /// # Returns
     /// * `Ok(())` if no cycles are detected
-    /// * `Err(Error::Other)` if a cycle is found, with detailed information about the cycle
+    /// * `Err(Error::Other)` if a cycle is found
     async fn validate_codemod_dependencies(
         &self,
         workflow: &Workflow,
@@ -2416,6 +2444,7 @@ impl Engine {
                     dependency_chain: &[],
                     capabilities: &self.workflow_run_config.execution.capabilities,
                     task_expr_ctx: task_expr_ctx.as_ref(),
+                    progress_task_id: None,
                     logger: &step_logger,
                 },
             ))
@@ -3249,6 +3278,12 @@ impl Engine {
             NestedCodemodService::new(&self.workflow_run_config.execution.registry_client)
                 .resolve(&codemod.source, dependency_chain)
                 .await?;
+        let dependency_display_path = codemod_dependency_display_path(&resolved.dependency_chain);
+        notify_nested_codemod_progress(
+            &self.workflow_run_config.execution.progress_callback,
+            &task.id,
+            &dependency_display_path,
+        );
 
         slog!(
             logger,
@@ -3352,6 +3387,11 @@ impl Engine {
             resolved_package.spec.name,
             codemod_params.len()
         );
+        let nested_progress_task_id = format!(
+            "{}:{}",
+            task.id,
+            codemod_dependency_display_path(dependency_chain)
+        );
 
         // Execute the codemod workflow synchronously by running its steps directly
         // This avoids the recursive engine execution cycle
@@ -3409,6 +3449,7 @@ impl Engine {
                         dependency_chain,
                         capabilities,
                         task_expr_ctx: Some(&codemod_task_expr_ctx),
+                        progress_task_id: Some(&nested_progress_task_id),
                         logger,
                     })
                     .await?;

--- a/crates/core/src/jssg_execution_service.rs
+++ b/crates/core/src/jssg_execution_service.rs
@@ -53,6 +53,7 @@ use crate::{
 
 pub(crate) struct JssgExecutionRequest<'a> {
     pub id: String,
+    pub progress_task_id: Option<String>,
     pub step_id: String,
     pub step_name: String,
     pub report_step_id: Option<String>,
@@ -414,7 +415,11 @@ impl<'a> JssgExecutionService<'a> {
         let js_file_path_clone = js_file_path.clone();
         let resolver_clone = resolver.clone();
         let request_id = request.id.clone();
-        let id_clone = Arc::new(request_id.clone());
+        let progress_task_id = request
+            .progress_task_id
+            .clone()
+            .unwrap_or_else(|| request_id.clone());
+        let id_clone = Arc::new(progress_task_id.clone());
         let progress_callback = self
             .engine
             .workflow_run_config()
@@ -553,7 +558,7 @@ impl<'a> JssgExecutionService<'a> {
 
         let execute_result = config
             .execute_with_task_id_before_finish(
-                &request_id,
+                &progress_task_id,
                 move |file_path, config| {
                     if canceled_flag_for_closure.load(Ordering::Acquire)
                         || idle_timed_out_for_closure.load(Ordering::Acquire)

--- a/crates/core/src/jssg_execution_service.rs
+++ b/crates/core/src/jssg_execution_service.rs
@@ -552,7 +552,8 @@ impl<'a> JssgExecutionService<'a> {
         let failed_file_count_for_closure = Arc::clone(&failed_file_count);
 
         let execute_result = config
-            .execute_before_finish(
+            .execute_with_task_id_before_finish(
+                &request_id,
                 move |file_path, config| {
                     if canceled_flag_for_closure.load(Ordering::Acquire)
                         || idle_timed_out_for_closure.load(Ordering::Acquire)

--- a/crates/core/src/nested_codemod_service.rs
+++ b/crates/core/src/nested_codemod_service.rs
@@ -120,7 +120,16 @@ impl<'a> NestedCodemodService<'a> {
         for node in &workflow.nodes {
             for step in &node.steps {
                 if let butterflow_models::step::StepAction::Codemod(codemod) = &step.action {
-                    let resolved = self.resolve(&codemod.source, dependency_chain).await?;
+                    let resolved = match self.resolve(&codemod.source, dependency_chain).await {
+                        Ok(resolved) => resolved,
+                        Err(error) => {
+                            warn!(
+                                "Failed to inspect codemod dependency {} for dry-run-only status: {}",
+                                codemod.source, error
+                            );
+                            continue;
+                        }
+                    };
 
                     if resolved.package.dry_run_only {
                         return Ok(Some(codemod.source.clone()));
@@ -254,6 +263,39 @@ mod tests {
             .find_dry_run_only_dependency(&workflow, &[])
             .await
             .expect("dry-run-only scan should succeed");
+
+        assert_eq!(dry_run_only_dependency.as_deref(), Some("child-pro"));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn find_dry_run_only_dependency_skips_unresolved_children() {
+        let packages = HashMap::from([(
+            "child-pro".to_string(),
+            MockPackage {
+                workflow: workflow_yaml_without_children(),
+                dry_run_only: true,
+            },
+        )]);
+        let (registry_url, server) = spawn_registry_server(packages).await;
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let registry_client = RegistryClient::new(
+            crate::registry::RegistryConfig {
+                default_registry: registry_url,
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+        let workflow: Workflow = serde_yaml::from_str(&workflow_yaml_with_children(&[
+            "missing-child",
+            "child-pro",
+        ]))
+        .expect("workflow yaml");
+
+        let dry_run_only_dependency = NestedCodemodService::new(&registry_client)
+            .find_dry_run_only_dependency(&workflow, &[])
+            .await
+            .expect("dry-run-only scan should skip unresolved children");
 
         assert_eq!(dry_run_only_dependency.as_deref(), Some("child-pro"));
         server.abort();
@@ -430,6 +472,15 @@ mod tests {
         format!(
             "version: '1'\nnodes:\n- id: test\n  name: Test\n  steps:\n  - name: Run child\n    codemod:\n      source: {source}\n"
         )
+    }
+
+    fn workflow_yaml_with_children(sources: &[&str]) -> String {
+        let steps = sources
+            .iter()
+            .map(|source| format!("  - name: Run {source}\n    codemod:\n      source: {source}\n"))
+            .collect::<String>();
+
+        format!("version: '1'\nnodes:\n- id: test\n  name: Test\n  steps:\n{steps}")
     }
 
     fn workflow_yaml_without_children() -> String {

--- a/crates/core/src/nested_codemod_service.rs
+++ b/crates/core/src/nested_codemod_service.rs
@@ -39,24 +39,14 @@ impl<'a> NestedCodemodService<'a> {
     ) -> Error {
         let cycle_start =
             Self::find_cycle_in_chain(source, dependency_chain).unwrap_or_else(|| source.into());
-        let chain_str = dependency_chain
-            .iter()
-            .map(|d| d.source.as_str())
-            .collect::<Vec<_>>()
-            .join(" → ");
 
         Error::Other(format!(
             "{prefix}\n\
-            Cycle: {} → {} → {}\n\
+            Cycle detected while resolving codemod dependency \"{}\".\n\
             {validation_message}\n\
-            Please review your codemod dependencies to remove the circular reference.",
-            cycle_start,
-            if chain_str.is_empty() {
-                "(root)"
-            } else {
-                &chain_str
-            },
-            source
+            This bundle cannot be executed because one of its nested codemod dependencies forms a cycle. \
+            Contact the package owner or try a different bundle version.",
+            cycle_start
         ))
     }
 
@@ -122,6 +112,35 @@ impl<'a> NestedCodemodService<'a> {
         Ok(())
     }
 
+    pub(crate) async fn find_dry_run_only_dependency(
+        &self,
+        workflow: &Workflow,
+        dependency_chain: &[CodemodDependency],
+    ) -> Result<Option<String>> {
+        for node in &workflow.nodes {
+            for step in &node.steps {
+                if let butterflow_models::step::StepAction::Codemod(codemod) = &step.action {
+                    let resolved = self.resolve(&codemod.source, dependency_chain).await?;
+
+                    if resolved.package.dry_run_only {
+                        return Ok(Some(codemod.source.clone()));
+                    }
+
+                    if let Some(source) = Box::pin(self.find_dry_run_only_dependency(
+                        &resolved.workflow,
+                        &resolved.dependency_chain,
+                    ))
+                    .await?
+                    {
+                        return Ok(Some(source));
+                    }
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     async fn resolve_and_validate(
         &self,
         source: &str,
@@ -163,5 +182,258 @@ impl<'a> NestedCodemodService<'a> {
             source: source.to_string(),
         });
         chain
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::{write::GzEncoder, Compression};
+    use std::{collections::HashMap, io::Write, sync::Arc};
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn format_cycle_error_does_not_expose_dependency_chain() {
+        let error = NestedCodemodService::format_cycle_error(
+            "Runtime codemod dependency cycle detected!",
+            "public-child",
+            &[
+                CodemodDependency {
+                    source: "public-child".to_string(),
+                },
+                CodemodDependency {
+                    source: "private-child".to_string(),
+                },
+            ],
+            "This cycle was not caught during validation, indicating a dynamic dependency.",
+        );
+        let message = error.to_string();
+
+        assert!(message.contains("Runtime codemod dependency cycle detected!"));
+        assert!(message.contains("Cycle detected while resolving codemod dependency"));
+        assert!(message.contains(
+            "This bundle cannot be executed because one of its nested codemod dependencies forms a cycle."
+        ));
+        assert!(!message.contains("Please review your codemod dependencies"));
+        assert!(message.contains("public-child"));
+        assert!(!message.contains("private-child"));
+        assert!(!message.contains("→"));
+    }
+
+    #[tokio::test]
+    async fn find_dry_run_only_dependency_detects_nested_registry_child() {
+        let packages = HashMap::from([
+            (
+                "child-public".to_string(),
+                MockPackage {
+                    workflow: workflow_yaml_with_child("child-pro"),
+                    dry_run_only: false,
+                },
+            ),
+            (
+                "child-pro".to_string(),
+                MockPackage {
+                    workflow: workflow_yaml_without_children(),
+                    dry_run_only: true,
+                },
+            ),
+        ]);
+        let (registry_url, server) = spawn_registry_server(packages).await;
+        let cache_dir = tempfile::tempdir().expect("cache dir");
+        let registry_client = RegistryClient::new(
+            crate::registry::RegistryConfig {
+                default_registry: registry_url,
+                cache_dir: cache_dir.path().to_path_buf(),
+            },
+            None,
+        );
+        let workflow: Workflow =
+            serde_yaml::from_str(&workflow_yaml_with_child("child-public")).expect("workflow yaml");
+
+        let dry_run_only_dependency = NestedCodemodService::new(&registry_client)
+            .find_dry_run_only_dependency(&workflow, &[])
+            .await
+            .expect("dry-run-only scan should succeed");
+
+        assert_eq!(dry_run_only_dependency.as_deref(), Some("child-pro"));
+        server.abort();
+    }
+
+    #[derive(Clone)]
+    struct MockPackage {
+        workflow: String,
+        dry_run_only: bool,
+    }
+
+    async fn spawn_registry_server(
+        packages: HashMap<String, MockPackage>,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test registry");
+        let addr = listener.local_addr().expect("test registry address");
+        let registry_url = format!("http://{addr}");
+        let packages = Arc::new(packages);
+        let server_url = registry_url.clone();
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+
+                let packages = Arc::clone(&packages);
+                let server_url = server_url.clone();
+                tokio::spawn(async move {
+                    let mut buffer = [0; 4096];
+                    let Ok(size) = stream
+                        .readable()
+                        .await
+                        .and_then(|_| stream.try_read(&mut buffer))
+                    else {
+                        return;
+                    };
+                    let request = String::from_utf8_lossy(&buffer[..size]);
+                    let Some(request_line) = request.lines().next() else {
+                        return;
+                    };
+                    let mut parts = request_line.split_whitespace();
+                    let method = parts.next().unwrap_or_default();
+                    let path = parts.next().unwrap_or_default();
+
+                    let (status, content_type, body) =
+                        registry_response(method, path, &server_url, &packages).unwrap_or_else(
+                            || ("404 Not Found", "text/plain", b"not found".to_vec()),
+                        );
+
+                    let response = format!(
+                        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+
+                    let _ = stream.writable().await;
+                    let _ = stream.try_write(response.as_bytes());
+                    if method != "HEAD" && !body.is_empty() {
+                        let _ = stream.writable().await;
+                        let _ = stream.try_write(&body);
+                    }
+                });
+            }
+        });
+
+        (registry_url, handle)
+    }
+
+    fn registry_response(
+        method: &str,
+        path: &str,
+        registry_url: &str,
+        packages: &HashMap<String, MockPackage>,
+    ) -> Option<(&'static str, &'static str, Vec<u8>)> {
+        if let Some(package_name) = path.strip_prefix("/cdn/") {
+            let package_name = package_name.strip_suffix(".tgz")?;
+            let package = packages.get(package_name)?;
+            return match method {
+                "HEAD" => Some(("200 OK", "application/gzip", Vec::new())),
+                "GET" => Some((
+                    "200 OK",
+                    "application/gzip",
+                    package_archive(&package.workflow),
+                )),
+                _ => None,
+            };
+        }
+
+        let package_name = path.strip_prefix("/api/v1/registry/packages/")?;
+
+        if method == "GET" && !package_name.contains("/download/") {
+            packages.get(package_name)?;
+            return Some((
+                "200 OK",
+                "application/json",
+                package_info_response(package_name).into_bytes(),
+            ));
+        }
+
+        if let Some((package_name, version)) = package_name.split_once("/download/") {
+            let package = packages.get(package_name)?;
+            if version != "1.0.0" {
+                return None;
+            }
+
+            return match method {
+                "HEAD" => Some(("200 OK", "application/json", Vec::new())),
+                "GET" => Some((
+                    "200 OK",
+                    "application/json",
+                    download_response(registry_url, package_name, package.dry_run_only)
+                        .into_bytes(),
+                )),
+                _ => None,
+            };
+        }
+
+        None
+    }
+
+    fn package_info_response(package_name: &str) -> String {
+        serde_json::json!({
+            "id": format!("pkg_{package_name}"),
+            "name": package_name,
+            "scope": null,
+            "is_legacy": false,
+            "latest_version": "1.0.0",
+            "versions": {
+                "1.0.0": {
+                    "version": "1.0.0",
+                    "description": null,
+                    "checksum": "sha256:test",
+                    "size": 1
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn download_response(registry_url: &str, package_name: &str, dry_run_only: bool) -> String {
+        serde_json::json!({
+            "download_url": format!("{registry_url}/cdn/{package_name}.tgz"),
+            "expires_at": "2099-01-01T00:00:00Z",
+            "dry_run_only": dry_run_only
+        })
+        .to_string()
+    }
+
+    fn package_archive(workflow: &str) -> Vec<u8> {
+        let mut tar_buffer = Vec::new();
+        {
+            let mut archive = tar::Builder::new(&mut tar_buffer);
+            append_tar_file(&mut archive, "codemod.yaml", b"name: test\n");
+            append_tar_file(&mut archive, "workflow.yaml", workflow.as_bytes());
+            archive.finish().expect("finish tar");
+        }
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar_buffer).expect("write gzip");
+        encoder.finish().expect("finish gzip")
+    }
+
+    fn append_tar_file(archive: &mut tar::Builder<&mut Vec<u8>>, path: &str, contents: &[u8]) {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(path).expect("set tar path");
+        header.set_size(contents.len() as u64);
+        header.set_cksum();
+        archive.append(&header, contents).expect("append tar file");
+    }
+
+    fn workflow_yaml_with_child(source: &str) -> String {
+        format!(
+            "version: '1'\nnodes:\n- id: test\n  name: Test\n  steps:\n  - name: Run child\n    codemod:\n      source: {source}\n"
+        )
+    }
+
+    fn workflow_yaml_without_children() -> String {
+        "version: '1'\nnodes:\n- id: test\n  name: Test\n  steps:\n  - name: Done\n    run: echo done\n"
+            .to_string()
     }
 }

--- a/crates/core/src/step_executor.rs
+++ b/crates/core/src/step_executor.rs
@@ -39,6 +39,7 @@ pub(crate) struct StepExecutionRequest<'a> {
     pub dependency_chain: &'a [CodemodDependency],
     pub capabilities: &'a Option<HashSet<LlrtSupportedModules>>,
     pub task_expr_ctx: Option<&'a TaskExpressionContext>,
+    pub progress_task_id: Option<&'a str>,
     pub logger: &'a StructuredLogger,
 }
 
@@ -134,6 +135,7 @@ impl<'a> StepExecutor<'a> {
                             dependency_chain: request.dependency_chain,
                             capabilities: request.capabilities,
                             task_expr_ctx: request.task_expr_ctx,
+                            progress_task_id: request.progress_task_id,
                             logger: request.logger,
                         })
                         .await?;
@@ -161,16 +163,23 @@ impl<'a> StepExecutor<'a> {
                     )?;
                     self.engine
                         .execute_ast_grep_step(
-                            request.node.id.clone(),
+                            request
+                                .progress_task_id
+                                .unwrap_or(&request.node.id)
+                                .to_string(),
                             &resolved_ast_grep,
                             request.logger,
                         )
                         .await
                 }
                 StepAction::JSAstGrep(js_ast_grep) => {
+                    let progress_task_id = request
+                        .progress_task_id
+                        .map(str::to_string)
+                        .unwrap_or_else(|| request.task.id.to_string());
                     self.engine
                         .execute_js_ast_grep_step(
-                            request.task.id.to_string(),
+                            progress_task_id,
                             request.step_id.clone().unwrap_or_default(),
                             request.step_name.to_string(),
                             request.report_step_id.cloned(),

--- a/crates/core/src/step_executor.rs
+++ b/crates/core/src/step_executor.rs
@@ -179,7 +179,8 @@ impl<'a> StepExecutor<'a> {
                         .unwrap_or_else(|| request.task.id.to_string());
                     self.engine
                         .execute_js_ast_grep_step(
-                            progress_task_id,
+                            request.task.id.to_string(),
+                            Some(progress_task_id),
                             request.step_id.clone().unwrap_or_default(),
                             request.step_name.to_string(),
                             request.report_step_id.cloned(),

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -8,6 +8,11 @@ use serde_yaml;
 
 use butterflow_models::{Error, Node, Result, Workflow};
 
+use crate::{
+    engine::CodemodDependency, nested_codemod_service::NestedCodemodService,
+    registry::RegistryClient,
+};
+
 fn has_parent_path_components(path: &Path) -> bool {
     path.components().any(|component| {
         matches!(
@@ -43,6 +48,15 @@ pub fn parse_workflow_file<P: AsRef<Path>>(path: P) -> Result<Workflow> {
             }
         }
     }
+}
+
+pub async fn find_dry_run_only_codemod_dependency(
+    workflow: &Workflow,
+    registry_client: &RegistryClient,
+) -> Result<Option<String>> {
+    NestedCodemodService::new(registry_client)
+        .find_dry_run_only_dependency(workflow, &[] as &[CodemodDependency])
+        .await
 }
 
 /// Validate a workflow definition

--- a/crates/core/tests/engine_tests.rs
+++ b/crates/core/tests/engine_tests.rs
@@ -4714,6 +4714,7 @@ function helper() {
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -4811,6 +4812,7 @@ interface ApiResponse {
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -4888,6 +4890,7 @@ function main() {
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -4950,6 +4953,7 @@ export default function (
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -5024,6 +5028,7 @@ export default function transform(ast) {
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -5093,6 +5098,7 @@ export default function transform() {
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -5177,6 +5183,7 @@ var count = 0;
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -5232,6 +5239,7 @@ async fn test_execute_js_ast_grep_step_nonexistent_js_file() {
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -5313,6 +5321,7 @@ export default function transform(root) {
     let result = engine
         .execute_js_ast_grep_step(
             "matrix-meta-files".to_string(),
+            None,
             "matrix-step".to_string(),
             "matrix-step".to_string(),
             None,
@@ -5708,6 +5717,7 @@ build/
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -5749,6 +5759,7 @@ build/
     let result_no_gitignore = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,
@@ -5820,6 +5831,7 @@ export default function transform(ast) {
     let result = engine
         .execute_js_ast_grep_step(
             "test-node".to_string(),
+            None,
             "test-step".to_string(),
             "test-step".to_string(),
             None,


### PR DESCRIPTION
#### 📚 Description
This PR introduces Pro codemods dry-run semantics to codemod bundles.

- The CLI now recursively inspects bundled codemod dependencies before running a package or workflow. If the top-level codemod or any bundled child resolves as dry_run_only, the entire run is forced into Pro preview mode, with the existing preview-only execution settings applied consistently.

**Also improved bundle runtime UX:**
- Nested bundle execution now shows which codemod is running.
- Nested transform progress is labeled with the full dependency path, e.g., child1 > child-pro.
- JS ast-grep progress now respects the nested progress ID instead of falling back to the generic "main" ID.
- Runtime cycle errors are sanitized to prevent the disclosure of full dependency chains to unauthorized users.


#### 🧪 Test Plan
Manual test cases:

- Run a normal bundle with only public children, and confirm it applies as expected.
- Run a bundle with a Pro child as a non-Pro/anonymous user and confirm the whole run is forced to dry-run preview.
Run the same bundle as the Pro child/package owner and confirm it can run normally.
- Run a nested bundle like parent -> child1 -> child-pro and confirm the terminal shows the nested path, e.g., child1 > child-pro.
- Run a nested bundle with a JS ast-grep child and confirm the progress bar is labeled with the nested path.
- Run a bundle with a dependency cycle and confirm the error is sanitized, and no full private dependency chain is leaked.
- Run the codemod workflow with a workflow containing a Pro-bundled child, and confirm it matches the codemod <package> behavior.