### PR TITLE
refactor(cli): update Registry button styling and logic

### DIFF
--- a/crates/cli/report-ui/src/app.tsx
+++ b/crates/cli/report-ui/src/app.tsx
@@ -51,14 +51,14 @@ export function App() {
       </div>
     );
   }
-
+  const registryLinkUrl = report.registryLinkUrl;
   return (
     <ReportViewer
       data={report}
       actions={
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2.5">
+          {registryLinkUrl ? <RegistryButton url={registryLinkUrl} /> : null}
           <ShareButton report={report} />
-          <RegistryButton url={report.registryLinkUrl} />
           <FeedbackButton />
         </div>
       }

--- a/crates/cli/report-ui/src/components/registry-button.tsx
+++ b/crates/cli/report-ui/src/components/registry-button.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@codemod.com/report-ui";
-import { ExternalLink } from "lucide-react";
+import { SquareArrowOutUpRight } from "lucide-react";
 
 const FALLBACK_REGISTRY_HOME = "https://app.codemod.com/registry";
 
@@ -29,13 +28,14 @@ export function RegistryButton({ url }: RegistryButtonProps) {
   const href = resolveRegistryHref(url);
 
   return (
-    <Button
-      variant="outline"
-      nativeButton={false}
-      render={<a href={href} target="_blank" rel="noopener noreferrer" />}
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-2 text-sm px-1.5 hover:text-foreground transition-colors hover:underline text-muted-foreground"
     >
-      <ExternalLink className="size-4" />
-      Registry
-    </Button>
+      View in Registry
+      <SquareArrowOutUpRight className="size-3.5" />
+    </a>
   );
 }


### PR DESCRIPTION
Enhance the Registry button by using a more semantic anchor tag and updating the icon to SquareArrowOutUpRight. Adjust the layout to improve spacing and ensure the button only renders when a registry link is available.

<img width="2658" height="732" alt="image" src="https://github.com/user-attachments/assets/69a10991-6546-4b86-9a76-83c652d1573a" />
<img width="886" height="282" alt="image" src="https://github.com/user-attachments/assets/48a79cca-9909-4e46-9f75-6ffc6f92d191" />
