### PR TITLE
fix(sandbox): honor withFileTypes Dirents in curated fs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,8 @@
 pnpm lint
 pnpm format
+
+# Match CI's "Rust Format" job. Pre-commit previously only ran JS oxlint/oxfmt,
+# so Rust formatting drift slipped through until GitHub Actions failed.
+if git diff --cached --name-only --diff-filter=ACMR | grep -Eq '\.rs$|^(Cargo\.toml|Cargo\.lock|rustfmt\.toml|rust-toolchain\.toml)$'; then
+  cargo fmt --check
+fi

--- a/crates/AGENTS.md
+++ b/crates/AGENTS.md
@@ -22,6 +22,7 @@ workspace dependencies from the root `Cargo.toml` over adding direct versions in
 
 - Targeted crate: `cargo test -p <crate-name>`
 - Workspace: `cargo test`
-- Format: `cargo fmt --check`
+- Format: `cargo fmt --check` (also enforced by husky when `.rs` / Cargo files are staged;
+  CI "Rust Format" uses the same command on stable rustfmt)
 - Lint: `cargo clippy --tests --no-deps -- -D warnings`
 - If workflow models or schemas changed: `cargo xtask schema`, then inspect `git status --short`.

--- a/crates/codemod-sandbox/src/sandbox/engine/curated_fs.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/curated_fs.rs
@@ -347,6 +347,24 @@ fn recursive_from_options<'js>(options: Opt<Value<'js>>) -> bool {
     }
 }
 
+fn with_file_types_from_options<'js>(options: &Opt<Value<'js>>) -> bool {
+    match &options.0 {
+        Some(value) => value
+            .as_object()
+            .and_then(|obj| obj.get::<_, Option<bool>>("withFileTypes").ok().flatten())
+            .unwrap_or(false),
+        None => false,
+    }
+}
+
+fn child_normalized(parent: &str, entry: &str) -> String {
+    if parent.ends_with('/') {
+        format!("{parent}{entry}")
+    } else {
+        format!("{parent}/{entry}")
+    }
+}
+
 // ---------- sync ops ----------
 
 /// Read raw bytes for `normalized` from `cfg`'s VFS, falling back to
@@ -640,11 +658,38 @@ fn exists_sync(ctx: Ctx<'_>, path: String) -> Result<bool> {
     }
 }
 
-fn readdir_sync(ctx: Ctx<'_>, path: String, _options: Opt<Value<'_>>) -> Result<Vec<String>> {
+/// Node-compatible `fs.accessSync`: succeeds when the path exists inside the
+/// sandbox, throws `ENOENT` when missing, and throws `EACCES` when outside
+/// `target_dir`. Mode bits are accepted and ignored — curated sandbox access
+/// does not model Unix permission bits.
+fn access_sync(ctx: Ctx<'_>, path: String, _mode: Opt<Value<'_>>) -> Result<()> {
     let cfg = config(&ctx)?;
     let (normalized, vfs_path) = cfg
         .resolve(&path)
-        .map_err(|e| throw_fs(&ctx, e, "scandir"))?;
+        .map_err(|e| throw_fs(&ctx, e, "access"))?;
+    if is_deleted(&cfg, &normalized) {
+        return Err(throw_fs(
+            &ctx,
+            FsErrorKind::NotFound { path: normalized },
+            "access",
+        ));
+    }
+    if vfs_path.exists().unwrap_or(false) {
+        return Ok(());
+    }
+    match hydrate_metadata_from_fetcher(&ctx, &cfg, &normalized, &vfs_path, "access")? {
+        Some(_) => Ok(()),
+        None => Err(throw_fs(
+            &ctx,
+            FsErrorKind::NotFound { path: normalized },
+            "access",
+        )),
+    }
+}
+
+fn list_directory_entries(ctx: &Ctx<'_>, path: &str) -> Result<(String, Vec<String>)> {
+    let cfg = config(ctx)?;
+    let (normalized, vfs_path) = cfg.resolve(path).map_err(|e| throw_fs(ctx, e, "scandir"))?;
     let iter = vfs_path
         .read_dir()
         .or_else(|err| {
@@ -660,7 +705,7 @@ fn readdir_sync(ctx: Ctx<'_>, path: String, _options: Opt<Value<'_>>) -> Result<
             }
             vfs_path.read_dir()
         })
-        .map_err(|e| throw_fs(&ctx, map_vfs_err(e, &normalized), "scandir"))?;
+        .map_err(|e| throw_fs(ctx, map_vfs_err(e, &normalized), "scandir"))?;
     let prefix = if normalized.ends_with('/') {
         normalized.clone()
     } else {
@@ -678,7 +723,7 @@ fn readdir_sync(ctx: Ctx<'_>, path: String, _options: Opt<Value<'_>>) -> Result<
             Ok(None) => {}
             Err(message) => {
                 return Err(throw_fs(
-                    &ctx,
+                    ctx,
                     FsErrorKind::Io {
                         message,
                         path: normalized.clone(),
@@ -688,17 +733,95 @@ fn readdir_sync(ctx: Ctx<'_>, path: String, _options: Opt<Value<'_>>) -> Result<
             }
         }
     }
-    entries.retain(|entry| {
-        let child = if normalized.ends_with('/') {
-            format!("{normalized}{entry}")
-        } else {
-            format!("{normalized}/{entry}")
-        };
-        !is_deleted(&cfg, &child)
-    });
+    entries.retain(|entry| !is_deleted(&cfg, &child_normalized(&normalized, entry)));
     entries.sort();
     entries.dedup();
-    Ok(entries)
+    Ok((normalized, entries))
+}
+
+fn resolve_entry_file_type(
+    ctx: &Ctx<'_>,
+    cfg: &CuratedFsConfig,
+    child_path: &str,
+) -> Result<VfsFileType> {
+    let (_, child_vfs) = cfg
+        .resolve(child_path)
+        .map_err(|e| throw_fs(ctx, e, "scandir"))?;
+    match child_vfs.metadata() {
+        Ok(meta) => Ok(meta.file_type),
+        Err(err) if matches!(err.kind(), VfsErrorKind::FileNotFound) => {
+            match hydrate_metadata_from_fetcher(ctx, cfg, child_path, &child_vfs, "scandir")? {
+                Some(meta) => Ok(meta.file_type),
+                // Entry came from readdir but metadata is unavailable — treat
+                // as a file so callers still get a usable Dirent rather than
+                // failing the whole scan.
+                None => Ok(VfsFileType::File),
+            }
+        }
+        Err(err) => Err(throw_fs(ctx, map_vfs_err(err, child_path), "scandir")),
+    }
+}
+
+fn dirent_object<'js>(
+    ctx: &Ctx<'js>,
+    name: &str,
+    parent_path: &str,
+    file_type: VfsFileType,
+) -> Result<Object<'js>> {
+    let obj = Object::new(ctx.clone())?;
+    obj.set("name", name)?;
+    obj.set("parentPath", parent_path)?;
+    // Older Node exposed `path` as an alias of parentPath; LLRT's type surface
+    // still mentions parentPath as the supported field, but setting `path`
+    // keeps Node-flavored walkers compatible.
+    obj.set("path", parent_path)?;
+
+    let is_file = matches!(file_type, VfsFileType::File);
+    let is_dir = matches!(file_type, VfsFileType::Directory);
+    obj.set(
+        "isFile",
+        rquickjs::Function::new(ctx.clone(), move || is_file)?,
+    )?;
+    obj.set(
+        "isDirectory",
+        rquickjs::Function::new(ctx.clone(), move || is_dir)?,
+    )?;
+    // Curated VFS only models plain files and directories.
+    obj.set(
+        "isBlockDevice",
+        rquickjs::Function::new(ctx.clone(), || false)?,
+    )?;
+    obj.set(
+        "isCharacterDevice",
+        rquickjs::Function::new(ctx.clone(), || false)?,
+    )?;
+    obj.set(
+        "isSymbolicLink",
+        rquickjs::Function::new(ctx.clone(), || false)?,
+    )?;
+    obj.set("isFIFO", rquickjs::Function::new(ctx.clone(), || false)?)?;
+    obj.set("isSocket", rquickjs::Function::new(ctx.clone(), || false)?)?;
+    Ok(obj)
+}
+
+fn readdir_sync<'js>(ctx: Ctx<'js>, path: String, options: Opt<Value<'js>>) -> Result<Value<'js>> {
+    let with_file_types = with_file_types_from_options(&options);
+    let (normalized, entries) = list_directory_entries(&ctx, &path)?;
+    let arr = rquickjs::Array::new(ctx.clone())?;
+    if with_file_types {
+        let cfg = config(&ctx)?;
+        for (index, name) in entries.iter().enumerate() {
+            let child = child_normalized(&normalized, name);
+            let file_type = resolve_entry_file_type(&ctx, &cfg, &child)?;
+            let dirent = dirent_object(&ctx, name, &normalized, file_type)?;
+            arr.set(index, dirent)?;
+        }
+    } else {
+        for (index, name) in entries.into_iter().enumerate() {
+            arr.set(index, name)?;
+        }
+    }
+    Ok(arr.into_value())
 }
 
 fn mkdir_sync(ctx: Ctx<'_>, path: String, options: Opt<Value<'_>>) -> Result<()> {
@@ -806,7 +929,11 @@ async fn write_file(
     write_file_sync_impl(&ctx, &path, data)
 }
 
-async fn readdir_async(ctx: Ctx<'_>, path: String, options: Opt<Value<'_>>) -> Result<Vec<String>> {
+async fn readdir_async<'js>(
+    ctx: Ctx<'js>,
+    path: String,
+    options: Opt<Value<'js>>,
+) -> Result<Value<'js>> {
     readdir_sync(ctx, path, options)
 }
 
@@ -832,6 +959,7 @@ impl ModuleDef for CuratedFsModule {
         declare.declare("readFileSync")?;
         declare.declare("writeFileSync")?;
         declare.declare("existsSync")?;
+        declare.declare("accessSync")?;
         declare.declare("readdirSync")?;
         declare.declare("mkdirSync")?;
         declare.declare("statSync")?;
@@ -852,6 +980,7 @@ impl ModuleDef for CuratedFsModule {
         default.set("readFileSync", Func::from(read_file_sync))?;
         default.set("writeFileSync", Func::from(write_file_sync))?;
         default.set("existsSync", Func::from(exists_sync))?;
+        default.set("accessSync", Func::from(access_sync))?;
         default.set("readdirSync", Func::from(readdir_sync))?;
         default.set("mkdirSync", Func::from(mkdir_sync))?;
         default.set("statSync", Func::from(stat_sync))?;
@@ -861,6 +990,7 @@ impl ModuleDef for CuratedFsModule {
         exports.export("readFileSync", Func::from(read_file_sync))?;
         exports.export("writeFileSync", Func::from(write_file_sync))?;
         exports.export("existsSync", Func::from(exists_sync))?;
+        exports.export("accessSync", Func::from(access_sync))?;
         exports.export("readdirSync", Func::from(readdir_sync))?;
         exports.export("mkdirSync", Func::from(mkdir_sync))?;
         exports.export("statSync", Func::from(stat_sync))?;

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -1299,10 +1299,7 @@ export default function transform() {
                 }))
             }
 
-            fn read_dir(
-                &self,
-                path: &str,
-            ) -> std::result::Result<Option<Vec<String>>, String> {
+            fn read_dir(&self, path: &str) -> std::result::Result<Option<Vec<String>>, String> {
                 if path == "/app" {
                     Ok(Some(vec![
                         "main.ts".to_string(),

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -731,6 +731,57 @@ export default function transform(root) {
         root
     }
 
+    /// Execute a curated-fs transform and return its primary modified content.
+    fn run_fs_sandbox_transform(
+        codemod_source: &str,
+        files: &[(&str, &str)],
+        fetcher: Option<Arc<dyn crate::sandbox::engine::curated_fs::FileFetcher>>,
+    ) -> String {
+        let temp_dir = TempDir::new().expect("tempdir");
+        fs::write(temp_dir.path().join("fs_compat_codemod.js"), codemod_source)
+            .expect("write codemod");
+
+        let root = build_memory_fs_with_files(files);
+        let fs_sandbox = FsSandbox {
+            target_dir: "/app".to_string(),
+            root,
+            fetcher,
+        };
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = files
+            .iter()
+            .find(|(path, _)| *path == "/app/main.ts")
+            .map(|(_, body)| *body)
+            .unwrap_or("const x = 1;");
+        let ast = AstGrep::new(content, js_lang());
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: Some("/app/main.ts"),
+            target_directory: "/app",
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: Some(fs_sandbox),
+        });
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => modified.content,
+                other => panic!("Expected modified result, got: {other:?}"),
+            },
+            Err(e) => panic!("Expected success, got error: {e:?}"),
+        }
+    }
+
     /// Curated fs must expose allowed files to the sandbox while rejecting
     /// paths that escape `target_dir`.
     #[test]
@@ -889,6 +940,398 @@ export default function transform(root) {
             },
             Err(e) => panic!("Expected success, got error: {:?}", e),
         }
+    }
+
+    /// `readdirSync(path, { withFileTypes: true })` must return Dirent-like
+    /// objects with a defined `name` and working `isDirectory`/`isFile`
+    /// predicates. Returning bare strings (the previous curated-fs behaviour)
+    /// makes Node-style walkers crash on `entry.name.startsWith(...)`.
+    #[test]
+    fn test_fs_sandbox_readdir_with_file_types_returns_dirents() {
+        let temp_dir = TempDir::new().expect("Failed to create temp directory");
+
+        let codemod_content = r#"
+import fs from "fs";
+export default function transform(root) {
+  const plain = fs.readdirSync("/app");
+  const entries = fs.readdirSync("/app", { withFileTypes: true });
+  const mapped = entries
+    .map((entry) => {
+      const kind = entry.isDirectory() ? "dir" : entry.isFile() ? "file" : "other";
+      return entry.name + ":" + kind + ":" + typeof entry.name;
+    })
+    .sort()
+    .join(",");
+  let accessOk = false;
+  try {
+    fs.accessSync("/app/nested/child.ts");
+    accessOk = true;
+  } catch {
+    accessOk = false;
+  }
+  let accessMissing = "none";
+  try {
+    fs.accessSync("/app/missing.ts");
+  } catch (e) {
+    accessMissing = e.code;
+  }
+  return [
+    "plain=" + plain.sort().join(","),
+    "dirents=" + mapped,
+    "accessOk=" + accessOk,
+    "accessMissing=" + accessMissing,
+  ].join(";");
+}
+        "#
+        .trim();
+
+        fs::write(
+            temp_dir.path().join("fs_dirent_codemod.js"),
+            codemod_content,
+        )
+        .expect("Failed to write codemod file");
+
+        let root = build_memory_fs_with_files(&[
+            ("/app/main.ts", "const x = 1;"),
+            ("/app/nested/child.ts", "export const y = 2;"),
+            ("/app/readme.md", "# hi"),
+        ]);
+        let fs_sandbox = FsSandbox {
+            target_dir: "/app".to_string(),
+            root: root.clone(),
+            fetcher: None,
+        };
+
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let content = "const x = 1;";
+        let ast = AstGrep::new(content, js_lang());
+
+        let result = execute_codemod_sync(InMemoryExecutionOptions {
+            codemod_source: codemod_content,
+            language: js_lang(),
+            ast,
+            original_sha256: Some(compute_sha256(content)),
+            resolver: Some(resolver),
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            file_path: Some("/app/main.ts"),
+            target_directory: "/app",
+            semantic_provider: None,
+            metrics_context: None,
+            shared_state_context: None,
+            timeout_ms: None,
+            memory_limit: None,
+            process_sandbox: None,
+            fs_sandbox: Some(fs_sandbox),
+        });
+
+        match result {
+            Ok(output) => match output.primary {
+                ExecutionResult::Modified(modified) => {
+                    assert_eq!(
+                        modified.content,
+                        "plain=main.ts,nested,readme.md;dirents=main.ts:file:string,nested:dir:string,readme.md:file:string;accessOk=true;accessMissing=ENOENT",
+                    );
+                }
+                other => panic!("Expected modified result, got: {:?}", other),
+            },
+            Err(e) => panic!("Expected success, got error: {:?}", e),
+        }
+    }
+
+    /// Registry packages such as `@codemod/java-*` and
+    /// `dotnet-packagereference-migrate` treat bare `readdirSync` results as
+    /// strings (`localeCompare`, `for...of`, `.join`, `endsWith`). Returning
+    /// Dirents by default would break them.
+    #[test]
+    fn test_fs_sandbox_readdir_default_remains_string_array() {
+        let content = run_fs_sandbox_transform(
+            r#"
+import { readdirSync } from "fs";
+export default function transform() {
+  const plain = readdirSync("/app");
+  const explicitFalse = readdirSync("/app", { withFileTypes: false });
+  const names = [];
+  for (const entry of plain) {
+    names.push(typeof entry + ":" + entry);
+  }
+  return [
+    "join=" + plain.slice().sort().join("|"),
+    "sorted=" + plain.slice().sort((a, b) => a.localeCompare(b)).join("|"),
+    "types=" + names.sort().join("|"),
+    "falseMode=" + explicitFalse.every((e) => typeof e === "string"),
+    "array=" + Array.isArray(plain),
+  ].join(";");
+}
+            "#
+            .trim(),
+            &[
+                ("/app/main.ts", "const x = 1;"),
+                ("/app/B.ts", "export const b = 1;"),
+                ("/app/a.ts", "export const a = 1;"),
+            ],
+            None,
+        );
+        assert_eq!(
+            content,
+            "join=B.ts|a.ts|main.ts;sorted=B.ts|a.ts|main.ts;types=string:B.ts|string:a.ts|string:main.ts;falseMode=true;array=true",
+        );
+    }
+
+    /// Mirrors debarrel / js-dependency-mining walkers that call
+    /// `readdirSync(..., { withFileTypes: true })` and rely on `entry.name`,
+    /// `entry.name.startsWith`, and recursive `isDirectory()`/`isFile()`.
+    #[test]
+    fn test_fs_sandbox_readdir_dirent_walker_skips_and_recurses() {
+        let content = run_fs_sandbox_transform(
+            r#"
+import fs from "fs";
+import path from "path";
+export default function transform() {
+  const files = [];
+  function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith(".ts")) files.push(entry.name);
+    }
+  }
+  walk("/app");
+  return files.sort().join(",");
+}
+            "#
+            .trim(),
+            &[
+                ("/app/main.ts", "const x = 1;"),
+                ("/app/pkg/index.ts", "export {};"),
+                ("/app/node_modules/lib/index.ts", "export {};"),
+                ("/app/.hidden/secret.ts", "export {};"),
+                ("/app/readme.md", "# hi"),
+            ],
+            None,
+        );
+        assert_eq!(content, "index.ts,main.ts");
+    }
+
+    /// `accessSync` must stay Node-shaped for debarrel-style `fileExists`
+    /// helpers: succeed for present paths, accept ignored mode bits, throw
+    /// `ENOENT` for missing paths, and throw `EACCES` outside target_dir.
+    #[test]
+    fn test_fs_sandbox_access_sync_node_error_codes() {
+        let content = run_fs_sandbox_transform(
+            r#"
+import fs from "fs";
+export default function transform() {
+  fs.accessSync("/app/main.ts");
+  fs.accessSync("/app/main.ts", 0);
+  let missing = "none";
+  try {
+    fs.accessSync("/app/nope.ts");
+  } catch (e) {
+    missing = e.code;
+  }
+  let outside = "none";
+  try {
+    fs.accessSync("/etc/passwd");
+  } catch (e) {
+    outside = e.code;
+  }
+  const existsOk = fs.existsSync("/app/main.ts");
+  const existsMissing = fs.existsSync("/app/nope.ts");
+  const existsOutside = fs.existsSync("/etc/passwd");
+  return [
+    "missing=" + missing,
+    "outside=" + outside,
+    "existsOk=" + existsOk,
+    "existsMissing=" + existsMissing,
+    "existsOutside=" + existsOutside,
+  ].join(";");
+}
+            "#
+            .trim(),
+            &[("/app/main.ts", "const x = 1;")],
+            None,
+        );
+        assert_eq!(
+            content,
+            "missing=ENOENT;outside=EACCES;existsOk=true;existsMissing=false;existsOutside=false",
+        );
+    }
+
+    /// Unlinked paths must disappear from both string and Dirent listings,
+    /// matching dry-run semantics where deleted_paths suppresses rehydration.
+    #[test]
+    fn test_fs_sandbox_readdir_excludes_unlinked_entries() {
+        let content = run_fs_sandbox_transform(
+            r#"
+import fs from "fs";
+export default function transform() {
+  fs.unlinkSync("/app/gone.ts");
+  const plain = fs.readdirSync("/app").sort().join(",");
+  const dirents = fs
+    .readdirSync("/app", { withFileTypes: true })
+    .map((e) => e.name + ":" + (e.isFile() ? "file" : "dir"))
+    .sort()
+    .join(",");
+  let accessGone = "none";
+  try {
+    fs.accessSync("/app/gone.ts");
+  } catch (e) {
+    accessGone = e.code;
+  }
+  return ["plain=" + plain, "dirents=" + dirents, "accessGone=" + accessGone].join(";");
+}
+            "#
+            .trim(),
+            &[
+                ("/app/main.ts", "const x = 1;"),
+                ("/app/gone.ts", "export {};"),
+                ("/app/keep.ts", "export {};"),
+            ],
+            None,
+        );
+        assert_eq!(
+            content,
+            "plain=keep.ts,main.ts;dirents=keep.ts:file,main.ts:file;accessGone=ENOENT",
+        );
+    }
+
+    /// Empty directories and async `fs.promises.readdir` must keep the same
+    /// string/Dirent contract as the sync API.
+    #[test]
+    fn test_fs_sandbox_promises_readdir_and_empty_dir() {
+        let content = run_fs_sandbox_transform(
+            r#"
+import fs from "fs";
+export default async function transform() {
+  fs.mkdirSync("/app/empty", { recursive: true });
+  const emptyPlain = await fs.promises.readdir("/app/empty");
+  const emptyDirents = await fs.promises.readdir("/app/empty", { withFileTypes: true });
+  const rootDirents = await fs.promises.readdir("/app", { withFileTypes: true });
+  const rootPlain = await fs.promises.readdir("/app");
+  return [
+    "emptyPlainLen=" + emptyPlain.length,
+    "emptyDirentsLen=" + emptyDirents.length,
+    "rootPlainAllStrings=" + rootPlain.every((e) => typeof e === "string"),
+    "root=" + rootDirents
+      .map((e) => e.name + ":" + (e.isDirectory() ? "dir" : "file"))
+      .sort()
+      .join(","),
+  ].join(";");
+}
+            "#
+            .trim(),
+            &[("/app/main.ts", "const x = 1;")],
+            None,
+        );
+        assert_eq!(
+            content,
+            "emptyPlainLen=0;emptyDirentsLen=0;rootPlainAllStrings=true;root=empty:dir,main.ts:file",
+        );
+    }
+
+    /// Dirent predicates beyond isFile/isDirectory must be callable (Node
+    /// Dirent surface). Walkers sometimes call these unconditionally.
+    #[test]
+    fn test_fs_sandbox_dirent_predicate_surface() {
+        let content = run_fs_sandbox_transform(
+            r#"
+import fs from "fs";
+export default function transform() {
+  const [entry] = fs.readdirSync("/app", { withFileTypes: true });
+  return [
+    "name=" + entry.name,
+    "parentPath=" + entry.parentPath,
+    "path=" + entry.path,
+    "isFile=" + entry.isFile(),
+    "isDirectory=" + entry.isDirectory(),
+    "isSymbolicLink=" + entry.isSymbolicLink(),
+    "isBlockDevice=" + entry.isBlockDevice(),
+    "isCharacterDevice=" + entry.isCharacterDevice(),
+    "isFIFO=" + entry.isFIFO(),
+    "isSocket=" + entry.isSocket(),
+  ].join(";");
+}
+            "#
+            .trim(),
+            &[("/app/main.ts", "const x = 1;")],
+            None,
+        );
+        assert_eq!(
+            content,
+            "name=main.ts;parentPath=/app;path=/app;isFile=true;isDirectory=false;isSymbolicLink=false;isBlockDevice=false;isCharacterDevice=false;isFIFO=false;isSocket=false",
+        );
+    }
+
+    /// Dry-run / fetcher-backed listings must still produce typed Dirents when
+    /// the VFS miss is filled by `FileFetcher::read_dir` + `metadata`.
+    #[test]
+    fn test_fs_sandbox_readdir_with_file_types_via_fetcher() {
+        struct ListingFetcher;
+
+        impl crate::sandbox::engine::curated_fs::FileFetcher for ListingFetcher {
+            fn fetch(&self, _path: &str) -> std::result::Result<Option<Vec<u8>>, String> {
+                Ok(None)
+            }
+
+            fn metadata(
+                &self,
+                path: &str,
+            ) -> std::result::Result<Option<vfs::VfsMetadata>, String> {
+                Ok(Some(vfs::VfsMetadata {
+                    file_type: if path.ends_with("/pkg") || path == "/app/pkg" {
+                        vfs::VfsFileType::Directory
+                    } else {
+                        vfs::VfsFileType::File
+                    },
+                    len: 0,
+                    created: None,
+                    modified: None,
+                    accessed: None,
+                }))
+            }
+
+            fn read_dir(
+                &self,
+                path: &str,
+            ) -> std::result::Result<Option<Vec<String>>, String> {
+                if path == "/app" {
+                    Ok(Some(vec![
+                        "main.ts".to_string(),
+                        "pkg".to_string(),
+                        "extra.ts".to_string(),
+                    ]))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+
+        let content = run_fs_sandbox_transform(
+            r#"
+import fs from "fs";
+export default function transform() {
+  const entries = fs.readdirSync("/app", { withFileTypes: true });
+  return entries
+    .map((e) => e.name + ":" + (e.isDirectory() ? "dir" : e.isFile() ? "file" : "other"))
+    .sort()
+    .join(",");
+}
+            "#
+            .trim(),
+            // Seed only main.ts in the VFS; pkg + extra.ts come from the fetcher listing.
+            &[("/app/main.ts", "const x = 1;")],
+            Some(Arc::new(ListingFetcher)),
+        );
+        assert_eq!(content, "extra.ts:file,main.ts:file,pkg:dir");
     }
 
     /// Mirror pg_ast_grep's batch flow: run the same fs-using codemod across

--- a/docs/jssg/security.mdx
+++ b/docs/jssg/security.mdx
@@ -21,7 +21,7 @@ Unlike `fetch` and `child_process`, the `fs` module is **always available** but 
   <Card title="Inside target_dir" icon="folder-open">
     **Allowed by default**
 
-    `readFileSync`, `writeFileSync`, `readdirSync`, `mkdirSync`, `statSync`, `existsSync`, `unlinkSync`, and their `fs/promises` equivalents all work.
+    `readFileSync`, `writeFileSync`, `readdirSync` (including `{ withFileTypes: true }` Dirents), `mkdirSync`, `statSync`, `existsSync`, `accessSync`, `unlinkSync`, and their `fs/promises` equivalents all work.
   </Card>
   <Card title="Outside target_dir" icon="shield-halved">
     **Rejected with `EACCES`**

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "lint:fix": "oxlint --fix",
     "format:fix": "oxfmt --write",
     "format": "oxfmt --check",
+    "format:rust": "cargo fmt --check",
+    "format:rust:fix": "cargo fmt",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,4 +3,8 @@ tab_spaces = 4
 edition = "2021"
 newline_style = "Unix"
 use_field_init_shorthand = true
-ignore = ["submodules/**"]
+
+# Note: rustfmt's `ignore = [...]` is nightly-only. CI and rust-toolchain.toml
+# pin stable, so that option was a no-op warning and is intentionally omitted.
+# Submodule crates are kept out of `cargo fmt` via Cargo workspace membership
+# (`exclude` in Cargo.toml) rather than rustfmt ignore lists.


### PR DESCRIPTION
## Summary
- Curated JSSG `fs.readdirSync` / `promises.readdir` now honor `{ withFileTypes: true }` and return Node-compatible Dirent objects (`name`, `parentPath`, `isFile`/`isDirectory`, etc.).
- Add curated `accessSync` for debarrel-style existence checks during dry-run (where `capabilities: ["fs"]` still uses sandboxed fs).
- Add registry-compat regression tests covering string-mode readdir callers, Dirent walkers, access error codes, unlink filtering, promises API, and fetcher-backed listings.

This fixes dry-run crashes like debarrel’s `entry.name.startsWith` on Cal.com, without changing the default string-array readdir contract used by many java/dotnet registry packages.

## Test plan
- [x] `cargo test -p codemod-sandbox test_fs_sandbox`
- [x] `cargo test -p codemod-sandbox curated_fs`
- [x] `cargo clippy -p codemod-sandbox --tests --no-deps -- -D warnings`
- [x] Local dry-run: `target/debug/codemod run debarrel --dry-run -t <cal.com>` no longer crashes on walker
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)