### PR TITLE
fix(cli): make codemod run telemetry reliable

### DIFF
--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -103,6 +103,15 @@ jobs:
       - name: Verify report UI build
         run: test -f crates/cli/report-ui/dist/index.html
 
+      - name: Verify telemetry configuration
+        run: |
+          if [[ ! "${POSTHOG_API_KEY}" =~ [^[:space:]] ]]; then
+            echo "::error::POSTHOG_API_KEY must be configured for release builds"
+            exit 1
+          fi
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+
       - name: Build
         run: |
           cargo build --release -p codemod --target ${{ matrix.target }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,6 +1242,7 @@ dependencies = [
  "posthog-rs",
  "serde",
  "serde_json",
+ "thiserror 2.0.16",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,12 +1239,10 @@ version = "1.12.13"
 dependencies = [
  "async-trait",
  "chrono",
- "reqwest 0.12.23",
+ "posthog-rs",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
  "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -2146,12 +2153,6 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
-name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -2469,7 +2470,7 @@ checksum = "ac7bb8710e1f09672102be7ddf39f764d8440ae74a9f4e30aaa4820dcdffa4af"
 dependencies = [
  "compact_str 0.9.0",
  "get-size-derive2",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "smallvec",
 ]
 
@@ -2535,20 +2536,20 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-dependencies = [
- "fallible-iterator 0.2.0",
- "indexmap 1.9.3",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "glob"
@@ -2581,7 +2582,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.11.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2600,7 +2601,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2624,14 +2625,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2650,7 +2645,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "serde",
 ]
 
 [[package]]
@@ -2666,14 +2660,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -3050,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "id-arena"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 dependencies = [
  "rayon",
 ]
@@ -3122,22 +3124,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3396,10 +3388,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.3.103"
+source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi-v0.2.126#069b85e42331a77a6bd3fa5308cb1968e12e5367"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3456,7 +3449,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.16",
 ]
@@ -4123,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -4142,7 +4135,7 @@ version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4515,6 +4508,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4539,6 +4553,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4551,6 +4597,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.10.0",
+ "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -4564,6 +4612,49 @@ dependencies = [
  "bitflags 2.10.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4634,9 +4725,25 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b100f7dd605611822d30e182214d3c02fdefce2d801d23993f6b6ba6ca1392af"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.2",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4744,7 +4851,7 @@ checksum = "71ef2dba21be1ce515378b2b7143eaa2a912f9e6ffe162ae20639d56f53d60e3"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "oxc_data_structures 0.96.0",
  "oxc_estree 0.96.0",
  "rustc-hash",
@@ -4759,7 +4866,7 @@ checksum = "5dd67b29aaa88b44af4d7d7b4752cf1dee9b6bc8b447015aad3470f818c3a24f"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "oxc_data_structures 0.99.0",
  "rustc-hash",
 ]
@@ -5170,7 +5277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ab3f270c313ac7f814ce73a64f4bdf36a183dcae4593b2f96c6e6afea8c99d0"
 dependencies = [
  "cfg-if",
- "indexmap 2.11.3",
+ "indexmap",
  "json-strip-comments",
  "once_cell",
  "papaya",
@@ -5320,7 +5427,7 @@ checksum = "1f6aee257a9750a3beeb8124f1fffcc3a5c2623ac2e36e851fbab8da339e9263"
 dependencies = [
  "base64 0.22.1",
  "compact_str 0.9.0",
- "indexmap 2.11.3",
+ "indexmap",
  "itoa",
  "memchr",
  "oxc_allocator 0.96.0",
@@ -5350,7 +5457,7 @@ checksum = "a18aee09e81fd1c9945c2c33661d3ce11438618454afa2b1a0b751fdf2e8dedb"
 dependencies = [
  "base64 0.22.1",
  "compact_str 0.9.0",
- "indexmap 2.11.3",
+ "indexmap",
  "itoa",
  "memchr",
  "oxc_allocator 0.99.0",
@@ -5621,7 +5728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.3",
+ "indexmap",
 ]
 
 [[package]]
@@ -5632,7 +5739,7 @@ checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.11.3",
+ "indexmap",
  "serde",
 ]
 
@@ -5848,6 +5955,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "posthog-rs"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dc5d94870b23655fceae57574d6741475b114be5a018b25d22dd2aa076fbe13"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "flate2",
+ "os_info",
+ "regex",
+ "reqwest 0.13.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha1",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5959,9 +6087,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -5973,7 +6101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap 2.11.3",
+ "indexmap",
  "nix 0.31.2",
  "tokio",
  "tracing",
@@ -6070,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -6229,7 +6357,7 @@ checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.10.0",
  "compact_str 0.9.0",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "indoc",
  "itertools 0.14.0",
  "kasuari",
@@ -6260,7 +6388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
 dependencies = [
  "bitflags 2.10.0",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools 0.14.0",
@@ -6416,7 +6544,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys 0.3.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys",
  "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
@@ -6462,19 +6590,20 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys 0.3.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-streams 0.4.2",
+ "web-sys",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.12",
@@ -6506,8 +6635,8 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys 0.3.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-streams 0.5.0",
+ "web-sys",
 ]
 
 [[package]]
@@ -6531,7 +6660,7 @@ dependencies = [
  "nanoid",
  "ordered-float",
  "pin-project-lite",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "rig-derive",
  "schemars",
  "serde",
@@ -6656,7 +6785,7 @@ dependencies = [
  "css-module-lexer",
  "dunce",
  "futures",
- "indexmap 2.11.3",
+ "indexmap",
  "itertools 0.14.0",
  "itoa",
  "json-escape-simd",
@@ -7009,7 +7138,7 @@ dependencies = [
  "fast-glob",
  "form_urlencoded",
  "futures",
- "indexmap 2.11.3",
+ "indexmap",
  "infer",
  "itoa",
  "memchr",
@@ -7058,7 +7187,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c50dc6d6c587c339edb4769cf705867497a2baf0eca8b4645fa6ecd22f02c77a"
 dependencies = [
  "either",
- "indexmap 2.11.3",
+ "indexmap",
  "rquickjs-core",
  "rquickjs-macro",
 ]
@@ -7073,8 +7202,8 @@ dependencies = [
  "chrono",
  "dlopen2",
  "either",
- "hashbrown 0.16.0",
- "indexmap 2.11.3",
+ "hashbrown 0.16.1",
+ "indexmap",
  "phf 0.13.1",
  "relative-path",
  "rquickjs-sys",
@@ -7089,7 +7218,7 @@ dependencies = [
  "convert_case 0.10.0",
  "fnv",
  "ident_case",
- "indexmap 2.11.3",
+ "indexmap",
  "phf_generator 0.13.1",
  "phf_shared 0.13.1",
  "proc-macro-crate 3.4.0",
@@ -7363,7 +7492,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.10.0",
- "fallible-iterator 0.3.0",
+ "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
  "libsqlite3-sys",
@@ -7558,7 +7687,7 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.15.5",
  "hashlink 0.10.0",
- "indexmap 2.11.3",
+ "indexmap",
  "intrusive-collections",
  "inventory",
  "parking_lot",
@@ -7814,7 +7943,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",
@@ -7893,7 +8022,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -8291,7 +8420,7 @@ dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
  "either",
- "indexmap 2.11.3",
+ "indexmap",
  "jsonc-parser",
  "once_cell",
  "par-core",
@@ -8415,7 +8544,7 @@ dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
  "globset",
- "indexmap 2.11.3",
+ "indexmap",
  "once_cell",
  "regex",
  "regress",
@@ -8553,7 +8682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "821b58933011407cbc401ff065d1d834cefee9080a2ea4ae0197acac837d8f4f"
 dependencies = [
  "arrayvec",
- "indexmap 2.11.3",
+ "indexmap",
  "is-macro",
  "rustc-hash",
  "serde",
@@ -8787,7 +8916,7 @@ checksum = "a7bbd82682a05972b9333ba4842d6153da88acab73280b13f516c74d7e87d090"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
- "indexmap 2.11.3",
+ "indexmap",
  "num-bigint",
  "num_cpus",
  "once_cell",
@@ -8839,7 +8968,7 @@ checksum = "994b30cf27c462a26f3a4876cc586aac0d304ea0c6d77e7d28eecf2c1d7b5b10"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
- "indexmap 2.11.3",
+ "indexmap",
  "once_cell",
  "precomputed-map",
  "preset_env_base",
@@ -8881,7 +9010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb04f42a6761960e818d85b7b47204422541c83955ea6f38751b23745bbf291"
 dependencies = [
  "better_scoped_tls",
- "indexmap 2.11.3",
+ "indexmap",
  "once_cell",
  "par-core",
  "phf 0.11.3",
@@ -8915,7 +9044,7 @@ version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3863a98e3b91419fe5b17beb14cd5673b2cc9024a4f14a8b833f5dd30239630f"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "par-core",
  "serde",
  "swc_atoms",
@@ -8959,7 +9088,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "bitflags 2.10.0",
- "indexmap 2.11.3",
+ "indexmap",
  "is-macro",
  "path-clean 1.0.1",
  "pathdiff",
@@ -8986,7 +9115,7 @@ checksum = "68bd07e1d548d2a7c7e798b858432aa6f714a6691f69bb6bb0d585609241e57a"
 dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
- "indexmap 2.11.3",
+ "indexmap",
  "once_cell",
  "par-core",
  "petgraph 0.7.1",
@@ -9028,7 +9157,7 @@ checksum = "3fc8e7810dc246c3ee54323719cce2ed8104ebdccd25456315bc2189e885e64f"
 dependencies = [
  "base64 0.22.1",
  "bytes-str",
- "indexmap 2.11.3",
+ "indexmap",
  "once_cell",
  "rustc-hash",
  "serde",
@@ -9069,7 +9198,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808e3f82526825e5fdc12902493069789e986e3323b6e9e59870b89d06bee367"
 dependencies = [
  "bitflags 2.10.0",
- "indexmap 2.11.3",
+ "indexmap",
  "rustc-hash",
  "swc_atoms",
  "swc_common",
@@ -9086,7 +9215,7 @@ version = "19.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bcade4287d4cb7636e47462b423eb6914b0b24e0baf8b4a457e5447fd9a8521"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
@@ -9243,9 +9372,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9651,7 +9780,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.1",
@@ -9681,7 +9810,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -9692,7 +9821,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.13",
@@ -9704,7 +9833,7 @@ version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ad0b7ae9cfeef5605163839cb9221f453399f15cfb5c10be9885fcf56611f9"
 dependencies = [
- "indexmap 2.11.3",
+ "indexmap",
  "toml_datetime 0.7.1",
  "toml_parser",
  "winnow 0.7.13",
@@ -9752,13 +9881,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.10.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -10317,8 +10451,8 @@ dependencies = [
  "compact_str 0.9.0",
  "drop_bomb",
  "get-size2",
- "hashbrown 0.16.0",
- "indexmap 2.11.3",
+ "hashbrown 0.16.1",
+ "indexmap",
  "itertools 0.14.0",
  "memchr",
  "ordermap",
@@ -10712,26 +10846,26 @@ dependencies = [
 
 [[package]]
 name = "walrus"
-version = "0.23.3"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6481311b98508f4bc2d0abbfa5d42172e7a54b4b24d8f15e28b0dc650be0c59f"
+checksum = "3bfa49767bb3a9e1afb02aa95bbcbde8d82f2db4ca377afae94d688f14f62378"
 dependencies = [
  "anyhow",
- "gimli 0.26.2",
+ "gimli 0.32.3",
  "id-arena",
  "leb128",
  "log",
  "rayon",
  "walrus-macro",
- "wasm-encoder 0.214.0",
- "wasmparser 0.214.0",
+ "wasm-encoder 0.245.1",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
 name = "walrus-macro"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439ad39ff894c43c9649fa724cdde9a6fc50b855d517ef071a93e5df82fe51d3"
+checksum = "1a9b0525d7ea6e5f906aca581a172e5c91b4c595290dfa8ad4a2bc9ffef33b44"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -10783,75 +10917,46 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.2.126"
+source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi-v0.2.126#069b85e42331a77a6bd3fa5308cb1968e12e5367"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-cli-support"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.2.126"
+source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi-v0.2.126#069b85e42331a77a6bd3fa5308cb1968e12e5367"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "leb128",
  "log",
  "rustc-demangle",
  "serde",
  "serde_json",
- "tempfile",
  "walrus",
- "wasm-bindgen-externref-xform",
- "wasm-bindgen-multi-value-xform",
  "wasm-bindgen-shared",
- "wasm-bindgen-threads-xform",
- "wasm-bindgen-wasm-conventions",
- "wasm-bindgen-wasm-interpreter",
-]
-
-[[package]]
-name = "wasm-bindgen-externref-xform"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
-dependencies = [
- "anyhow",
- "walrus",
- "wasm-bindgen-wasm-conventions",
+ "wasmparser 0.245.1",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.4.76"
+source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi-v0.2.126#069b85e42331a77a6bd3fa5308cb1968e12e5367"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys 0.3.77 (git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.2.126"
+source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi-v0.2.126#069b85e42331a77a6bd3fa5308cb1968e12e5367"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10859,74 +10964,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.2.126"
+source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi-v0.2.126#069b85e42331a77a6bd3fa5308cb1968e12e5367"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
-name = "wasm-bindgen-multi-value-xform"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
-dependencies = [
- "anyhow",
- "walrus",
- "wasm-bindgen-wasm-conventions",
-]
-
-[[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.2.126"
+source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi-v0.2.126#069b85e42331a77a6bd3fa5308cb1968e12e5367"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-bindgen-threads-xform"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
-dependencies = [
- "anyhow",
- "walrus",
- "wasm-bindgen-wasm-conventions",
-]
-
-[[package]]
-name = "wasm-bindgen-wasm-conventions"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
-dependencies = [
- "anyhow",
- "leb128",
- "log",
- "walrus",
- "wasmparser 0.214.0",
-]
-
-[[package]]
-name = "wasm-bindgen-wasm-interpreter"
-version = "0.2.100"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
-dependencies = [
- "anyhow",
- "log",
- "walrus",
- "wasm-bindgen-wasm-conventions",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.214.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -10940,13 +10993,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.245.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.245.1",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.11.3",
+ "indexmap",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -10961,21 +11024,20 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys 0.3.77 (registry+https://github.com/rust-lang/crates.io-index)",
+ "web-sys",
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.214.0"
+name = "wasm-streams"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
- "ahash",
- "bitflags 2.10.0",
- "hashbrown 0.14.5",
- "indexmap 2.11.3",
- "semver",
- "serde",
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -10986,24 +11048,28 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap 2.11.3",
+ "indexmap",
  "semver",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasmparser"
+version = "0.245.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "bitflags 2.10.0",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "semver",
+ "serde",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
-source = "git+https://github.com/mohebifar/wasm-bindgen.git?branch=wasi#76d375a4556f842734c39a6b282d80c4ba74f1ec"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11600,7 +11666,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.11.3",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -11631,7 +11697,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "indexmap 2.11.3",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -11650,7 +11716,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.11.3",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,6 @@ dependencies = [
  "open",
  "percent-encoding",
  "portable-pty",
- "posthog-rs",
  "rand 0.8.5",
  "ratatui",
  "regex",
@@ -1231,9 +1230,12 @@ version = "1.12.13"
 dependencies = [
  "async-trait",
  "chrono",
- "posthog-rs",
+ "reqwest 0.12.23",
  "serde",
+ "serde_json",
+ "thiserror 2.0.16",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -5843,21 +5845,6 @@ dependencies = [
  "shell-words",
  "winapi",
  "winreg 0.10.1",
-]
-
-[[package]]
-name = "posthog-rs"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610d236077c94c96194b0d2b40989bda4bf8faf60e15a0da6ef8ffd4c78f6c1c"
-dependencies = [
- "chrono",
- "derive_builder",
- "reqwest 0.11.27",
- "semver",
- "serde",
- "serde_json",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,15 +106,15 @@ walkdir = "2.4"
 ratatui = { version = "0.30", default-features = false, features = ["crossterm_0_29"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 
-wasm-bindgen = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-wasm-bindgen-cli-support = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-wasm-bindgen-futures = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-js-sys = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
+wasm-bindgen = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+wasm-bindgen-cli-support = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+wasm-bindgen-futures = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+js-sys = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
 
 [patch.crates-io]
-wasm-bindgen = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-wasm-bindgen-futures = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-wasm-bindgen-macro = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-wasm-bindgen-shared = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-wasm-bindgen-macro-support = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
-js-sys = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi" }
+wasm-bindgen = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+wasm-bindgen-futures = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+wasm-bindgen-macro = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+wasm-bindgen-shared = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+wasm-bindgen-macro-support = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }
+js-sys = { git = "https://github.com/mohebifar/wasm-bindgen.git", branch = "wasi-v0.2.126" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -71,7 +71,6 @@ libtest-mimic = "0.8"
 similar = "2.0"
 ast-grep-language.workspace = true
 tabled = "0.20.0"
-posthog-rs = "0.3.7"
 async-trait.workspace = true
 indicatif = "0.18.0"
 ratatui = { workspace = true }

--- a/crates/cli/src/auth/storage.rs
+++ b/crates/cli/src/auth/storage.rs
@@ -206,6 +206,29 @@ impl TokenStorage {
         self.load_auth(registry)
     }
 
+    pub fn get_or_create_anonymous_telemetry_id(&self) -> Result<String> {
+        let telemetry_id_path = self.config_dir.join("telemetry_id");
+        match fs::read_to_string(&telemetry_id_path) {
+            Ok(stored_id) => {
+                let stored_id = stored_id.trim();
+                if !stored_id.is_empty() {
+                    return Ok(stored_id.to_string());
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed to read telemetry id: {telemetry_id_path:?}")
+                });
+            }
+        }
+
+        let telemetry_id = uuid::Uuid::new_v4().to_string();
+        fs::write(&telemetry_id_path, &telemetry_id)
+            .with_context(|| format!("Failed to write telemetry id: {telemetry_id_path:?}"))?;
+        Ok(telemetry_id)
+    }
+
     fn get_auth_path(&self, registry: &str) -> PathBuf {
         let auth_dir = self.config_dir.join("auth");
         let filename = format!("{}.json", Self::sanitize_registry_name(registry));
@@ -292,5 +315,24 @@ mod tests {
             config.anonymous_feedback.consented_at.as_deref(),
             Some("2026-06-09T12:00:00Z")
         );
+    }
+
+    #[test]
+    fn anonymous_telemetry_id_is_stable_across_cli_invocations() {
+        let temp_dir = tempfile::tempdir().expect("expected temp dir");
+        let first_storage =
+            TokenStorage::with_config_dir(temp_dir.path().to_path_buf()).expect("storage");
+        let first_id = first_storage
+            .get_or_create_anonymous_telemetry_id()
+            .expect("expected telemetry id");
+
+        let second_storage =
+            TokenStorage::with_config_dir(temp_dir.path().to_path_buf()).expect("storage");
+        let second_id = second_storage
+            .get_or_create_anonymous_telemetry_id()
+            .expect("expected persisted telemetry id");
+
+        assert_eq!(first_id, second_id);
+        assert!(uuid::Uuid::parse_str(&first_id).is_ok());
     }
 }

--- a/crates/cli/src/auth/storage.rs
+++ b/crates/cli/src/auth/storage.rs
@@ -4,6 +4,7 @@ use dirs::config_dir;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::auth::types::{AuthTokens, UserInfo};
@@ -214,6 +215,7 @@ impl TokenStorage {
                 if !stored_id.is_empty() {
                     return Ok(stored_id.to_string());
                 }
+                anyhow::bail!("Stored telemetry id is empty: {telemetry_id_path:?}");
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) => {
@@ -224,9 +226,35 @@ impl TokenStorage {
         }
 
         let telemetry_id = uuid::Uuid::new_v4().to_string();
-        fs::write(&telemetry_id_path, &telemetry_id)
-            .with_context(|| format!("Failed to write telemetry id: {telemetry_id_path:?}"))?;
-        Ok(telemetry_id)
+        let mut temporary_id = tempfile::NamedTempFile::new_in(&self.config_dir)
+            .context("Failed to create temporary telemetry id file")?;
+        temporary_id
+            .write_all(telemetry_id.as_bytes())
+            .context("Failed to write temporary telemetry id")?;
+        temporary_id
+            .as_file()
+            .sync_all()
+            .context("Failed to persist temporary telemetry id")?;
+
+        match temporary_id.persist_noclobber(&telemetry_id_path) {
+            Ok(_) => Ok(telemetry_id),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let stored_id = fs::read_to_string(&telemetry_id_path).with_context(|| {
+                    format!(
+                        "Failed to read concurrently created telemetry id: {telemetry_id_path:?}"
+                    )
+                })?;
+                let stored_id = stored_id.trim();
+                if stored_id.is_empty() {
+                    anyhow::bail!(
+                        "Concurrently created telemetry id is empty: {telemetry_id_path:?}"
+                    );
+                }
+                Ok(stored_id.to_string())
+            }
+            Err(error) => Err(error.error)
+                .with_context(|| format!("Failed to persist telemetry id: {telemetry_id_path:?}")),
+        }
     }
 
     fn get_auth_path(&self, registry: &str) -> PathBuf {
@@ -246,7 +274,9 @@ impl TokenStorage {
 #[cfg(test)]
 mod tests {
     use super::TokenStorage;
+    use std::collections::HashSet;
     use std::fs;
+    use std::sync::{Arc, Barrier};
 
     #[test]
     fn missing_feedback_config_defaults_to_disabled() {
@@ -334,5 +364,33 @@ mod tests {
 
         assert_eq!(first_id, second_id);
         assert!(uuid::Uuid::parse_str(&first_id).is_ok());
+    }
+
+    #[test]
+    fn concurrent_anonymous_telemetry_id_initialization_uses_one_id() {
+        let temp_dir = tempfile::tempdir().expect("expected temp dir");
+        let config_dir = Arc::new(temp_dir.path().to_path_buf());
+        let barrier = Arc::new(Barrier::new(8));
+        let handles = (0..8)
+            .map(|_| {
+                let config_dir = Arc::clone(&config_dir);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    let storage = TokenStorage::with_config_dir(config_dir.as_ref().clone())
+                        .expect("storage");
+                    barrier.wait();
+                    storage
+                        .get_or_create_anonymous_telemetry_id()
+                        .expect("expected telemetry id")
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let ids = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("telemetry id thread"))
+            .collect::<HashSet<_>>();
+
+        assert_eq!(ids.len(), 1);
     }
 }

--- a/crates/cli/src/commands/ai/mod.rs
+++ b/crates/cli/src/commands/ai/mod.rs
@@ -10,6 +10,7 @@ use crate::commands::harness_adapter::{
 use crate::commands::output::{
     exit_adapter_error, format_output_path, prompt_for_overwrite_confirmation,
 };
+use crate::commands::TelemetrySenderExt;
 use crate::feedback;
 use crate::{TelemetrySenderMutex, CLI_VERSION};
 use anyhow::{bail, Result};
@@ -502,8 +503,8 @@ async fn send_ai_install_event(
             "unknown"
         };
 
-    let _ = telemetry
-        .send_event(
+    telemetry
+        .send_event_logged(
             BaseEvent {
                 kind: event_kind.to_string(),
                 properties: HashMap::from([
@@ -599,8 +600,8 @@ async fn send_ai_list_event(
     listed_count: usize,
     warnings_count: usize,
 ) {
-    let _ = telemetry
-        .send_event(
+    telemetry
+        .send_event_logged(
             BaseEvent {
                 kind: "aiSkillsListed".to_string(),
                 properties: HashMap::from([

--- a/crates/cli/src/commands/ai/mod.rs
+++ b/crates/cli/src/commands/ai/mod.rs
@@ -502,7 +502,7 @@ async fn send_ai_install_event(
             "unknown"
         };
 
-    telemetry
+    let _ = telemetry
         .send_event(
             BaseEvent {
                 kind: event_kind.to_string(),
@@ -599,7 +599,7 @@ async fn send_ai_list_event(
     listed_count: usize,
     warnings_count: usize,
 ) {
-    telemetry
+    let _ = telemetry
         .send_event(
             BaseEvent {
                 kind: "aiSkillsListed".to_string(),

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -1,3 +1,4 @@
+use crate::commands::TelemetrySenderExt;
 use crate::engine::create_progress_callback;
 use crate::engine::create_registry_client;
 use crate::utils::resolve_capabilities::resolve_capabilities;
@@ -459,8 +460,8 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
     let execution_id = generate_execution_id();
 
-    let _ = telemetry
-        .send_event(
+    telemetry
+        .send_event_logged(
             BaseEvent {
                 kind: "localJssgExecuted".to_string(),
                 properties: HashMap::from([

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -459,7 +459,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
     let execution_id = generate_execution_id();
 
-    telemetry
+    let _ = telemetry
         .send_event(
             BaseEvent {
                 kind: "localJssgExecuted".to_string(),

--- a/crates/cli/src/commands/jssg/test.rs
+++ b/crates/cli/src/commands/jssg/test.rs
@@ -144,7 +144,7 @@ async fn send_failure_event(
     error_category: &str,
     error_message: &str,
 ) {
-    telemetry
+    let _ = telemetry
         .send_event(
             BaseEvent {
                 kind: "failedToExecuteCommand".to_string(),

--- a/crates/cli/src/commands/jssg/test.rs
+++ b/crates/cli/src/commands/jssg/test.rs
@@ -26,6 +26,7 @@ use testing_utils::{
     TransformationResult,
 };
 
+use crate::commands::TelemetrySenderExt;
 use crate::utils::resolve_capabilities::{resolve_capabilities, ResolveCapabilitiesArgs};
 use crate::{TelemetrySenderMutex, CLI_VERSION};
 
@@ -144,8 +145,8 @@ async fn send_failure_event(
     error_category: &str,
     error_message: &str,
 ) {
-    let _ = telemetry
-        .send_event(
+    telemetry
+        .send_event_logged(
             BaseEvent {
                 kind: "failedToExecuteCommand".to_string(),
                 properties: HashMap::from([

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -1,3 +1,8 @@
+use crate::TelemetrySenderMutex;
+use async_trait::async_trait;
+use codemod_telemetry::send_event::{BaseEvent, PartialTelemetrySenderOptions};
+use log::debug;
+
 pub mod ai;
 pub mod cache;
 pub mod harness_adapter;
@@ -15,3 +20,25 @@ pub mod search;
 pub mod unpublish;
 pub mod whoami;
 pub mod workflow;
+
+#[async_trait]
+pub(crate) trait TelemetrySenderExt {
+    async fn send_event_logged(
+        &self,
+        event: BaseEvent,
+        options_override: Option<PartialTelemetrySenderOptions>,
+    );
+}
+
+#[async_trait]
+impl TelemetrySenderExt for TelemetrySenderMutex {
+    async fn send_event_logged(
+        &self,
+        event: BaseEvent,
+        options_override: Option<PartialTelemetrySenderOptions>,
+    ) {
+        if let Err(error) = self.try_send_event(event, options_override).await {
+            debug!("Failed to deliver telemetry event: {error}");
+        }
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod output;
 pub mod package_skill;
 pub mod publish;
 pub mod run;
+mod run_telemetry;
 pub mod search;
 pub mod unpublish;
 pub mod whoami;

--- a/crates/cli/src/commands/package_skill.rs
+++ b/crates/cli/src/commands/package_skill.rs
@@ -6,6 +6,7 @@ use crate::commands::harness_adapter::{
     InstallScope, InstalledSkill, OutputFormat, SkillPackageInstallSpec,
 };
 use crate::commands::output::{format_output_path, prompt_for_overwrite_confirmation};
+use crate::commands::TelemetrySenderExt;
 use crate::engine::create_registry_client_with_env;
 use crate::utils::manifest::CodemodManifest;
 use crate::utils::package_validation::{
@@ -524,8 +525,8 @@ async fn send_package_skill_install_event(
         warnings_count,
     } = input;
 
-    let _ = telemetry
-        .send_event(
+    telemetry
+        .send_event_logged(
             BaseEvent {
                 kind: "packageSkillInstalled".to_string(),
                 properties: HashMap::from([

--- a/crates/cli/src/commands/package_skill.rs
+++ b/crates/cli/src/commands/package_skill.rs
@@ -524,7 +524,7 @@ async fn send_package_skill_install_event(
         warnings_count,
     } = input;
 
-    telemetry
+    let _ = telemetry
         .send_event(
             BaseEvent {
                 kind: "packageSkillInstalled".to_string(),

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -29,6 +29,7 @@ use crate::utils::package_validation::DEFAULT_WORKFLOW_FILE_NAME;
 use crate::utils::skill_layout::expected_authored_skill_file;
 
 use crate::auth::TokenStorage;
+use crate::commands::TelemetrySenderExt;
 use crate::{TelemetrySenderMutex, CLI_VERSION};
 use codemod_telemetry::send_event::BaseEvent;
 
@@ -95,8 +96,8 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         return Err(anyhow!("Failed to publish package"));
     }
 
-    let _ = telemetry
-        .send_event(
+    telemetry
+        .send_event_logged(
             BaseEvent {
                 kind: "codemodPublished".to_string(),
                 properties: HashMap::from([

--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -95,7 +95,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         return Err(anyhow!("Failed to publish package"));
     }
 
-    telemetry
+    let _ = telemetry
         .send_event(
             BaseEvent {
                 kind: "codemodPublished".to_string(),

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::commands::run_telemetry::{
-    send_completed_event, send_event as send_telemetry_event, send_started_event,
-    send_success_events, CodemodRunOutcome, CodemodRunTelemetry,
+    send_completed_event, send_event as send_telemetry_event, send_success_events,
+    spawn_started_event, CodemodRunOutcome, CodemodRunTelemetry,
 };
 use crate::engine::{create_engine, create_registry_client};
 use crate::pro_dry_run::{
@@ -320,6 +320,7 @@ pub async fn handler(
     // Always collect diffs so report output remains available for interactive flows.
     let diff_collector = Some(Arc::new(Mutex::new(Vec::<FileDiff>::new())));
 
+    let started = std::time::Instant::now();
     let output_format = args.format;
 
     // Run workflow using the extracted workflow runner
@@ -363,14 +364,14 @@ pub async fn handler(
         selected_workflow_name.clone(),
         dry_run,
     );
-    send_started_event(&telemetry, &run_telemetry).await;
+    let started_delivery = spawn_started_event(telemetry.clone(), &run_telemetry);
 
-    let started = std::time::Instant::now();
     let run_result = run_workflow(&mut engine, config).await;
+    let duration_ms = started.elapsed().as_millis();
+    let _ = started_delivery.await;
 
     if let Err(e) = run_result {
         let error_msg = format!("Workflow execution failed: {}", e);
-        let duration_ms = started.elapsed().as_millis();
         send_completed_event(
             &telemetry,
             &run_telemetry,
@@ -387,8 +388,6 @@ pub async fn handler(
         send_failure_event(&telemetry, &canonical_codemod_name, &error_msg).await;
         return Err(e);
     }
-
-    let duration_ms = started.elapsed().as_millis();
 
     let metrics_data = engine.metrics_context.get_all();
 

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,3 +1,7 @@
+use crate::commands::run_telemetry::{
+    send_completed_event, send_event as send_telemetry_event, send_started_event,
+    send_success_events, CodemodRunOutcome, CodemodRunTelemetry,
+};
 use crate::engine::{create_engine, create_registry_client};
 use crate::pro_dry_run::{
     apply_pro_dry_run_execution_settings, notify_pro_dry_run_required, ProDryRunReason,
@@ -11,7 +15,7 @@ use crate::TelemetrySenderMutex;
 use crate::CLI_VERSION;
 use anyhow::{anyhow, Result};
 use butterflow_core::diff::{generate_unified_diff, DiffConfig, DiffMetadata, FileDiff};
-use butterflow_core::registry::RegistryError;
+use butterflow_core::registry::{RegistryError, RegistryPackageMetadata};
 use butterflow_core::report::{convert_diffs, convert_metrics, ExecutionReport};
 use butterflow_core::structured_log::OutputFormat;
 use butterflow_core::utils::generate_execution_id;
@@ -30,6 +34,15 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
 const WORKFLOW_FILE_NAME: &str = "workflow.yaml";
+
+fn telemetry_codemod_name(
+    registry_metadata: Option<&RegistryPackageMetadata>,
+    requested_name: &str,
+) -> String {
+    registry_metadata
+        .map(|metadata| metadata.package_web_path.clone())
+        .unwrap_or_else(|| requested_name.to_string())
+}
 
 fn format_file_count(count: usize) -> String {
     if count == 1 {
@@ -154,25 +167,24 @@ async fn send_failure_event(
     codemod_name: &str,
     error_message: &str,
 ) {
-    telemetry
-        .send_event(
-            BaseEvent {
-                kind: "failedToExecuteCommand".to_string(),
-                properties: HashMap::from([
-                    ("codemodName".to_string(), codemod_name.to_string()),
-                    ("cliVersion".to_string(), CLI_VERSION.to_string()),
-                    (
-                        "commandName".to_string(),
-                        "codemod.executeCodemod".to_string(),
-                    ),
-                    ("os".to_string(), std::env::consts::OS.to_string()),
-                    ("arch".to_string(), std::env::consts::ARCH.to_string()),
-                    ("errorMessage".to_string(), error_message.to_string()),
-                ]),
-            },
-            None,
-        )
-        .await;
+    send_telemetry_event(
+        telemetry,
+        BaseEvent {
+            kind: "failedToExecuteCommand".to_string(),
+            properties: HashMap::from([
+                ("codemodName".to_string(), codemod_name.to_string()),
+                ("cliVersion".to_string(), CLI_VERSION.to_string()),
+                (
+                    "commandName".to_string(),
+                    "codemod.executeCodemod".to_string(),
+                ),
+                ("os".to_string(), std::env::consts::OS.to_string()),
+                ("arch".to_string(), std::env::consts::ARCH.to_string()),
+                ("errorMessage".to_string(), error_message.to_string()),
+            ]),
+        },
+    )
+    .await;
 }
 
 pub async fn handler(
@@ -228,6 +240,8 @@ pub async fn handler(
         args.package,
         resolved_package.package_dir.display()
     );
+    let canonical_codemod_name =
+        telemetry_codemod_name(resolved_package.registry_metadata.as_ref(), &args.package);
 
     println!(
         "{} 🏁 Running codemod: {}",
@@ -252,14 +266,14 @@ pub async fn handler(
         Ok(selected) => selected,
         Err(error) => {
             let error_msg = error.to_string();
-            send_failure_event(&telemetry, &args.package, &error_msg).await;
+            send_failure_event(&telemetry, &canonical_codemod_name, &error_msg).await;
             return Err(error);
         }
     };
     if !workflow_path.exists() {
         let error = missing_workflow_error(&args.package, &workflow_path);
         let error_msg = error.to_string();
-        send_failure_event(&telemetry, &args.package, &error_msg).await;
+        send_failure_event(&telemetry, &canonical_codemod_name, &error_msg).await;
         return Err(error);
     }
 
@@ -306,8 +320,6 @@ pub async fn handler(
     // Always collect diffs so report output remains available for interactive flows.
     let diff_collector = Some(Arc::new(Mutex::new(Vec::<FileDiff>::new())));
 
-    let started = std::time::Instant::now();
-
     let output_format = args.format;
 
     // Run workflow using the extracted workflow runner
@@ -329,7 +341,7 @@ pub async fn handler(
     )?;
 
     // Set the package name so it's stored on the WorkflowRun
-    engine.set_name(Some(args.package.clone()));
+    engine.set_name(Some(canonical_codemod_name.clone()));
     apply_package_run_mode_to_config(engine.workflow_run_config_mut(), auto_launch_tui);
     if auto_launch_tui {
         engine.set_quiet(true);
@@ -344,19 +356,39 @@ pub async fn handler(
         apply_pro_dry_run_execution_settings(&mut config);
     }
 
+    let run_telemetry = CodemodRunTelemetry::new(
+        canonical_codemod_name.clone(),
+        resolved_package.version.clone(),
+        generate_execution_id(),
+        selected_workflow_name.clone(),
+        dry_run,
+    );
+    send_started_event(&telemetry, &run_telemetry).await;
+
+    let started = std::time::Instant::now();
     let run_result = run_workflow(&mut engine, config).await;
 
     if let Err(e) = run_result {
+        let error_msg = format!("Workflow execution failed: {}", e);
+        let duration_ms = started.elapsed().as_millis();
+        send_completed_event(
+            &telemetry,
+            &run_telemetry,
+            CodemodRunOutcome::Failed {
+                error_message: error_msg.clone(),
+            },
+            duration_ms,
+        )
+        .await;
         // Clean up cached pro codemod on failure too
         if resolved_package.dry_run_only {
             let _ = std::fs::remove_dir_all(&resolved_package.package_dir);
         }
-        let error_msg = format!("Workflow execution failed: {}", e);
-        send_failure_event(&telemetry, &args.package, &error_msg).await;
+        send_failure_event(&telemetry, &canonical_codemod_name, &error_msg).await;
         return Err(e);
     }
 
-    let duration_ms = started.elapsed().as_millis() as f64;
+    let duration_ms = started.elapsed().as_millis();
 
     let metrics_data = engine.metrics_context.get_all();
 
@@ -364,6 +396,19 @@ pub async fn handler(
     let files_modified = stats.files_modified.load(Ordering::Relaxed);
     let files_unmodified = stats.files_unmodified.load(Ordering::Relaxed);
     let files_with_errors = stats.files_with_errors.load(Ordering::Relaxed);
+
+    send_success_events(
+        &telemetry,
+        &run_telemetry,
+        CodemodRunOutcome::Succeeded {
+            files_modified,
+            files_unmodified,
+            files_with_errors,
+        },
+        files_modified,
+        duration_ms,
+    )
+    .await;
 
     if dry_run {
         print_dry_run_summary(files_modified, files_unmodified, files_with_errors);
@@ -390,7 +435,7 @@ pub async fn handler(
         let report = ExecutionReport::build(
             args.package.clone(),
             Some(resolved_package.version.clone()),
-            duration_ms,
+            duration_ms as f64,
             dry_run,
             target_path.display().to_string(),
             CLI_VERSION.to_string(),
@@ -411,29 +456,6 @@ pub async fn handler(
     } else {
         crate::utils::metrics::print_metrics(&metrics_data);
     }
-
-    let execution_id = generate_execution_id();
-
-    let mut executed_props = HashMap::from([
-        ("codemodName".to_string(), args.package.clone()),
-        ("executionId".to_string(), execution_id.clone()),
-        ("fileCount".to_string(), files_modified.to_string()),
-        ("cliVersion".to_string(), CLI_VERSION.to_string()),
-        ("os".to_string(), std::env::consts::OS.to_string()),
-        ("arch".to_string(), std::env::consts::ARCH.to_string()),
-    ]);
-    if let Some(name) = &selected_workflow_name {
-        executed_props.insert("workflowName".to_string(), name.clone());
-    }
-    telemetry
-        .send_event(
-            BaseEvent {
-                kind: "codemodExecuted".to_string(),
-                properties: executed_props,
-            },
-            None,
-        )
-        .await;
 
     if resolved_package.dry_run_only {
         if let Err(e) = std::fs::remove_dir_all(&resolved_package.package_dir) {
@@ -1061,5 +1083,19 @@ mod tests {
         let workflow = workflow_with_manual_step();
         let auto_launch_tui = should_auto_launch_package_run_tui(false, true, &workflow);
         assert!(!auto_launch_tui);
+    }
+
+    #[test]
+    fn telemetry_uses_canonical_registry_name_instead_of_requested_alias() {
+        let metadata = RegistryPackageMetadata {
+            registry_base_url: "https://app.codemod.com".to_string(),
+            package_web_path: "@codemod/react/19/migration-recipe".to_string(),
+            access: Some("public".to_string()),
+        };
+
+        assert_eq!(
+            telemetry_codemod_name(Some(&metadata), "@alias/react-migration@1.2.3"),
+            "@codemod/react/19/migration-recipe"
+        );
     }
 }

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::commands::run_telemetry::{
-    send_completed_event, send_event as send_telemetry_event, send_success_events,
-    spawn_started_event, CodemodRunOutcome, CodemodRunTelemetry,
+    send_completed_event, send_event as send_telemetry_event, send_started_event,
+    send_success_events, CodemodRunOutcome, CodemodRunTelemetry,
 };
 use crate::engine::{create_engine, create_registry_client};
 use crate::pro_dry_run::{
@@ -320,7 +320,7 @@ pub async fn handler(
     // Always collect diffs so report output remains available for interactive flows.
     let diff_collector = Some(Arc::new(Mutex::new(Vec::<FileDiff>::new())));
 
-    let started = std::time::Instant::now();
+    let setup_started = std::time::Instant::now();
     let output_format = args.format;
 
     // Run workflow using the extracted workflow runner
@@ -364,11 +364,12 @@ pub async fn handler(
         selected_workflow_name.clone(),
         dry_run,
     );
-    let started_delivery = spawn_started_event(telemetry.clone(), &run_telemetry);
+    let setup_duration = setup_started.elapsed();
+    send_started_event(&telemetry, &run_telemetry).await;
 
+    let execution_started = std::time::Instant::now();
     let run_result = run_workflow(&mut engine, config).await;
-    let duration_ms = started.elapsed().as_millis();
-    let _ = started_delivery.await;
+    let duration_ms = (setup_duration + execution_started.elapsed()).as_millis();
 
     if let Err(e) = run_result {
         let error_msg = format!("Workflow execution failed: {}", e);

--- a/crates/cli/src/commands/run_telemetry.rs
+++ b/crates/cli/src/commands/run_telemetry.rs
@@ -102,14 +102,11 @@ pub(super) async fn send_event(telemetry: &TelemetrySenderMutex, event: BaseEven
     telemetry.send_event_logged(event, None).await;
 }
 
-pub(super) fn spawn_started_event(
-    telemetry: TelemetrySenderMutex,
+pub(super) async fn send_started_event(
+    telemetry: &TelemetrySenderMutex,
     run_telemetry: &CodemodRunTelemetry,
-) -> tokio::task::JoinHandle<()> {
-    let event = run_telemetry.started_event();
-    tokio::spawn(async move {
-        send_event(&telemetry, event).await;
-    })
+) {
+    send_event(telemetry, run_telemetry.started_event()).await;
 }
 
 pub(super) async fn send_completed_event(

--- a/crates/cli/src/commands/run_telemetry.rs
+++ b/crates/cli/src/commands/run_telemetry.rs
@@ -1,0 +1,289 @@
+use crate::{TelemetrySenderMutex, CLI_VERSION};
+use codemod_telemetry::send_event::BaseEvent;
+use log::debug;
+use std::collections::HashMap;
+
+pub(super) struct CodemodRunTelemetry {
+    codemod_name: String,
+    package_version: String,
+    execution_id: String,
+    workflow_name: Option<String>,
+    dry_run: bool,
+}
+
+pub(super) enum CodemodRunOutcome {
+    Succeeded {
+        files_modified: usize,
+        files_unmodified: usize,
+        files_with_errors: usize,
+    },
+    Failed {
+        error_message: String,
+    },
+}
+
+impl CodemodRunTelemetry {
+    pub(super) fn new(
+        codemod_name: String,
+        package_version: String,
+        execution_id: String,
+        workflow_name: Option<String>,
+        dry_run: bool,
+    ) -> Self {
+        Self {
+            codemod_name,
+            package_version,
+            execution_id,
+            workflow_name,
+            dry_run,
+        }
+    }
+
+    fn common_properties(&self) -> HashMap<String, String> {
+        let mut properties = HashMap::from([
+            ("codemodName".to_string(), self.codemod_name.clone()),
+            ("packageVersion".to_string(), self.package_version.clone()),
+            ("executionId".to_string(), self.execution_id.clone()),
+            ("dryRun".to_string(), self.dry_run.to_string()),
+            ("cliVersion".to_string(), CLI_VERSION.to_string()),
+            ("os".to_string(), std::env::consts::OS.to_string()),
+            ("arch".to_string(), std::env::consts::ARCH.to_string()),
+        ]);
+        if let Some(workflow_name) = &self.workflow_name {
+            properties.insert("workflowName".to_string(), workflow_name.clone());
+        }
+        properties
+    }
+
+    fn started_event(&self) -> BaseEvent {
+        BaseEvent {
+            kind: "codemodRunStarted".to_string(),
+            properties: self.common_properties(),
+        }
+    }
+
+    fn completed_event(&self, outcome: CodemodRunOutcome, duration_ms: u128) -> BaseEvent {
+        let mut properties = self.common_properties();
+        properties.insert("durationMs".to_string(), duration_ms.to_string());
+        match outcome {
+            CodemodRunOutcome::Succeeded {
+                files_modified,
+                files_unmodified,
+                files_with_errors,
+            } => {
+                properties.insert("outcome".to_string(), "succeeded".to_string());
+                properties.insert("filesModified".to_string(), files_modified.to_string());
+                properties.insert("filesUnmodified".to_string(), files_unmodified.to_string());
+                properties.insert("filesWithErrors".to_string(), files_with_errors.to_string());
+            }
+            CodemodRunOutcome::Failed { error_message } => {
+                properties.insert("outcome".to_string(), "failed".to_string());
+                properties.insert("errorMessage".to_string(), error_message);
+            }
+        }
+        BaseEvent {
+            kind: "codemodRunCompleted".to_string(),
+            properties,
+        }
+    }
+
+    fn legacy_executed_event(&self, files_modified: usize, duration_ms: u128) -> BaseEvent {
+        let mut properties = self.common_properties();
+        properties.insert("fileCount".to_string(), files_modified.to_string());
+        properties.insert("durationMs".to_string(), duration_ms.to_string());
+        BaseEvent {
+            kind: "codemodExecuted".to_string(),
+            properties,
+        }
+    }
+}
+
+pub(super) async fn send_event(telemetry: &TelemetrySenderMutex, event: BaseEvent) {
+    if let Err(error) = telemetry.send_event(event, None).await {
+        debug!("Failed to deliver telemetry event: {error}");
+    }
+}
+
+pub(super) async fn send_started_event(
+    telemetry: &TelemetrySenderMutex,
+    run_telemetry: &CodemodRunTelemetry,
+) {
+    send_event(telemetry, run_telemetry.started_event()).await;
+}
+
+pub(super) async fn send_completed_event(
+    telemetry: &TelemetrySenderMutex,
+    run_telemetry: &CodemodRunTelemetry,
+    outcome: CodemodRunOutcome,
+    duration_ms: u128,
+) {
+    send_event(
+        telemetry,
+        run_telemetry.completed_event(outcome, duration_ms),
+    )
+    .await;
+}
+
+pub(super) async fn send_success_events(
+    telemetry: &TelemetrySenderMutex,
+    run_telemetry: &CodemodRunTelemetry,
+    outcome: CodemodRunOutcome,
+    files_modified: usize,
+    duration_ms: u128,
+) {
+    tokio::join!(
+        send_event(
+            telemetry,
+            run_telemetry.legacy_executed_event(files_modified, duration_ms),
+        ),
+        send_completed_event(telemetry, run_telemetry, outcome, duration_ms),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codemod_telemetry::send_event::{
+        PartialTelemetrySenderOptions, TelemetryError, TelemetrySender,
+    };
+    use std::sync::{Arc, Mutex};
+
+    struct RecordingTelemetrySender {
+        events: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl TelemetrySender for RecordingTelemetrySender {
+        async fn send_event(
+            &self,
+            event: BaseEvent,
+            _options_override: Option<PartialTelemetrySenderOptions>,
+        ) -> Result<(), TelemetryError> {
+            self.events.lock().expect("events lock").push(event.kind);
+            Ok(())
+        }
+
+        async fn initialize_panic_telemetry(&self) {}
+    }
+
+    #[test]
+    fn run_events_share_stable_canonical_properties() {
+        let telemetry = CodemodRunTelemetry::new(
+            "@codemod/react/19/migration-recipe".to_string(),
+            "1.2.3".to_string(),
+            "execution-123".to_string(),
+            Some("migration".to_string()),
+            true,
+        );
+
+        let started = telemetry.started_event();
+        let completed = telemetry.completed_event(
+            CodemodRunOutcome::Succeeded {
+                files_modified: 4,
+                files_unmodified: 2,
+                files_with_errors: 0,
+            },
+            1250,
+        );
+
+        for event in [&started, &completed] {
+            assert_eq!(
+                event.properties.get("codemodName").map(String::as_str),
+                Some("@codemod/react/19/migration-recipe")
+            );
+            assert_eq!(
+                event.properties.get("executionId").map(String::as_str),
+                Some("execution-123")
+            );
+            assert_eq!(
+                event.properties.get("packageVersion").map(String::as_str),
+                Some("1.2.3")
+            );
+            assert_eq!(
+                event.properties.get("workflowName").map(String::as_str),
+                Some("migration")
+            );
+            assert_eq!(
+                event.properties.get("dryRun").map(String::as_str),
+                Some("true")
+            );
+        }
+        assert_eq!(started.kind, "codemodRunStarted");
+        assert_eq!(completed.kind, "codemodRunCompleted");
+        assert_eq!(
+            completed.properties.get("outcome").map(String::as_str),
+            Some("succeeded")
+        );
+        assert_eq!(
+            completed.properties.get("durationMs").map(String::as_str),
+            Some("1250")
+        );
+        assert_eq!(
+            completed
+                .properties
+                .get("filesModified")
+                .map(String::as_str),
+            Some("4")
+        );
+
+        let failed = telemetry.completed_event(
+            CodemodRunOutcome::Failed {
+                error_message: "workflow failed".to_string(),
+            },
+            500,
+        );
+        assert_eq!(
+            failed.properties.get("outcome").map(String::as_str),
+            Some("failed")
+        );
+        assert_eq!(
+            failed.properties.get("errorMessage").map(String::as_str),
+            Some("workflow failed")
+        );
+    }
+
+    #[tokio::test]
+    async fn success_events_are_delivered_before_report_handling() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sender: TelemetrySenderMutex = Arc::new(Box::new(RecordingTelemetrySender {
+            events: Arc::clone(&events),
+        }));
+        let telemetry = CodemodRunTelemetry::new(
+            "@codemod/react/19/migration-recipe".to_string(),
+            "1.2.3".to_string(),
+            "execution-123".to_string(),
+            None,
+            false,
+        );
+
+        send_success_events(
+            &sender,
+            &telemetry,
+            CodemodRunOutcome::Succeeded {
+                files_modified: 1,
+                files_unmodified: 0,
+                files_with_errors: 0,
+            },
+            1,
+            10,
+        )
+        .await;
+        events
+            .lock()
+            .expect("events lock")
+            .push("reportHandlingStarted".to_string());
+
+        let events = events.lock().expect("events lock");
+        let report_position = events
+            .iter()
+            .position(|event| event == "reportHandlingStarted")
+            .expect("report marker");
+        for kind in ["codemodExecuted", "codemodRunCompleted"] {
+            let position = events
+                .iter()
+                .position(|event| event == kind)
+                .expect("telemetry event");
+            assert!(position < report_position);
+        }
+    }
+}

--- a/crates/cli/src/commands/run_telemetry.rs
+++ b/crates/cli/src/commands/run_telemetry.rs
@@ -1,6 +1,6 @@
+use crate::commands::TelemetrySenderExt;
 use crate::{TelemetrySenderMutex, CLI_VERSION};
 use codemod_telemetry::send_event::BaseEvent;
-use log::debug;
 use std::collections::HashMap;
 
 pub(super) struct CodemodRunTelemetry {
@@ -99,16 +99,17 @@ impl CodemodRunTelemetry {
 }
 
 pub(super) async fn send_event(telemetry: &TelemetrySenderMutex, event: BaseEvent) {
-    if let Err(error) = telemetry.send_event(event, None).await {
-        debug!("Failed to deliver telemetry event: {error}");
-    }
+    telemetry.send_event_logged(event, None).await;
 }
 
-pub(super) async fn send_started_event(
-    telemetry: &TelemetrySenderMutex,
+pub(super) fn spawn_started_event(
+    telemetry: TelemetrySenderMutex,
     run_telemetry: &CodemodRunTelemetry,
-) {
-    send_event(telemetry, run_telemetry.started_event()).await;
+) -> tokio::task::JoinHandle<()> {
+    let event = run_telemetry.started_event();
+    tokio::spawn(async move {
+        send_event(&telemetry, event).await;
+    })
 }
 
 pub(super) async fn send_completed_event(
@@ -143,9 +144,7 @@ pub(super) async fn send_success_events(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use codemod_telemetry::send_event::{
-        PartialTelemetrySenderOptions, TelemetryError, TelemetrySender,
-    };
+    use codemod_telemetry::send_event::{PartialTelemetrySenderOptions, TelemetrySender};
     use std::sync::{Arc, Mutex};
 
     struct RecordingTelemetrySender {
@@ -158,9 +157,8 @@ mod tests {
             &self,
             event: BaseEvent,
             _options_override: Option<PartialTelemetrySenderOptions>,
-        ) -> Result<(), TelemetryError> {
+        ) {
             self.events.lock().expect("events lock").push(event.kind);
-            Ok(())
         }
 
         async fn initialize_panic_telemetry(&self) {}

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -16,6 +16,7 @@ use clap::Args;
 use codemod_telemetry::send_event::BaseEvent;
 use std::sync::atomic::Ordering;
 
+use crate::commands::TelemetrySenderExt;
 use crate::engine::{create_engine, create_registry_client};
 use crate::pro_dry_run::{
     apply_pro_dry_run_execution_settings, notify_pro_dry_run_required, ProDryRunReason,
@@ -260,8 +261,8 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     }
 
     // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
-    let _ = telemetry
-        .send_event(
+    telemetry
+        .send_event_logged(
             BaseEvent {
                 kind: "localWorkflowExecuted".to_string(),
                 properties: HashMap::from([

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -260,7 +260,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
     }
 
     // Generate a 20-byte execution ID (160 bits of entropy for collision resistance)
-    telemetry
+    let _ = telemetry
         .send_event(
             BaseEvent {
                 kind: "localWorkflowExecuted".to_string(),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -418,9 +418,14 @@ async fn run_cli() -> Result<()> {
 
             let auth = storage.get_auth_for_registry(&config.default_registry)?;
 
-            let distinct_id = auth
-                .map(|auth| auth.user.id)
-                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            let distinct_id = auth.map(|auth| auth.user.id).unwrap_or_else(|| {
+                storage
+                    .get_or_create_anonymous_telemetry_id()
+                    .unwrap_or_else(|error| {
+                        log::debug!("Failed to persist anonymous telemetry id: {error}");
+                        uuid::Uuid::new_v4().to_string()
+                    })
+            });
 
             Arc::new(Box::new(
                 PostHogSender::new(TelemetrySenderOptions {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -427,13 +427,18 @@ async fn run_cli() -> Result<()> {
                     })
             });
 
-            Arc::new(Box::new(
-                PostHogSender::new(TelemetrySenderOptions {
-                    distinct_id,
-                    cloud_role: "CLI".to_string(),
-                })
-                .await,
-            ))
+            match PostHogSender::new(TelemetrySenderOptions {
+                distinct_id,
+                cloud_role: "CLI".to_string(),
+            })
+            .await
+            {
+                Ok(sender) => Arc::new(Box::new(sender)),
+                Err(error) => {
+                    log::debug!("Failed to initialize telemetry: {error}");
+                    Arc::new(Box::new(NullSender {}))
+                }
+            }
         };
 
     telemetry_sender.initialize_panic_telemetry().await;

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -15,6 +15,7 @@ async-trait.workspace = true
 chrono.workspace = true
 posthog-rs = { version = "0.21", default-features = false, features = ["async-client"] }
 serde.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -13,6 +13,9 @@ build = "build.rs"
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
-posthog-rs = "0.3.7"
+reqwest.workspace = true
 serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
+uuid.workspace = true

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -13,9 +13,9 @@ build = "build.rs"
 [dependencies]
 async-trait.workspace = true
 chrono.workspace = true
-reqwest.workspace = true
+posthog-rs = { version = "0.21", default-features = false, features = ["async-client"] }
 serde.workspace = true
-serde_json.workspace = true
-thiserror.workspace = true
 tokio.workspace = true
-uuid.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/telemetry/build.rs
+++ b/crates/telemetry/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=POSTHOG_API_KEY");
     let api_key = std::env::var("POSTHOG_API_KEY").unwrap_or_else(|_| "".to_string());
     println!("cargo:rustc-env=POSTHOG_API_KEY={api_key}");
 }

--- a/crates/telemetry/src/send_event.rs
+++ b/crates/telemetry/src/send_event.rs
@@ -37,7 +37,15 @@ pub trait TelemetrySender: Send + Sync + 'static {
         &self,
         event: BaseEvent,
         options_override: Option<PartialTelemetrySenderOptions>,
-    ) -> Result<(), TelemetryError>;
+    );
+    async fn try_send_event(
+        &self,
+        event: BaseEvent,
+        options_override: Option<PartialTelemetrySenderOptions>,
+    ) -> Result<(), TelemetryError> {
+        self.send_event(event, options_override).await;
+        Ok(())
+    }
     async fn initialize_panic_telemetry(&self);
 }
 
@@ -66,6 +74,14 @@ impl PostHogSender {
 #[async_trait]
 impl TelemetrySender for PostHogSender {
     async fn send_event(
+        &self,
+        event: BaseEvent,
+        options_override: Option<PartialTelemetrySenderOptions>,
+    ) {
+        let _ = self.try_send_event(event, options_override).await;
+    }
+
+    async fn try_send_event(
         &self,
         event: BaseEvent,
         options_override: Option<PartialTelemetrySenderOptions>,
@@ -138,7 +154,7 @@ impl TelemetrySender for PostHogSender {
 
                     let _ = tokio::time::timeout(
                         Duration::from_secs(5),
-                        sender.send_event(
+                        sender.try_send_event(
                             BaseEvent {
                                 kind: "cliPanic".to_string(),
                                 properties,
@@ -252,7 +268,7 @@ mod tests {
         let (sender, server) = test_sender(vec!["200 OK"]).await;
 
         sender
-            .send_event(
+            .try_send_event(
                 BaseEvent {
                     kind: "codemodRunStarted".to_string(),
                     properties: HashMap::from([(
@@ -285,7 +301,7 @@ mod tests {
         let (sender, server) = test_sender(vec!["400 Bad Request"]).await;
 
         let error = sender
-            .send_event(
+            .try_send_event(
                 BaseEvent {
                     kind: "codemodRunStarted".to_string(),
                     properties: HashMap::new(),
@@ -309,7 +325,7 @@ mod tests {
         .await;
 
         sender
-            .send_event(
+            .try_send_event(
                 BaseEvent {
                     kind: "codemodRunStarted".to_string(),
                     properties: HashMap::new(),
@@ -333,7 +349,7 @@ mod tests {
         .await;
 
         let error = sender
-            .send_event(
+            .try_send_event(
                 BaseEvent {
                     kind: "codemodRunStarted".to_string(),
                     properties: HashMap::new(),

--- a/crates/telemetry/src/send_event.rs
+++ b/crates/telemetry/src/send_event.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
 use chrono::Utc;
+use posthog_rs;
 use serde::Serialize;
-use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
 use std::panic;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::OnceCell;
-use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct TelemetrySenderOptions {
@@ -29,20 +29,7 @@ pub struct BaseEvent {
 }
 
 static RUNTIME_HANDLE: OnceCell<tokio::runtime::Handle> = OnceCell::const_new();
-const POSTHOG_CAPTURE_URL: &str = "https://us.i.posthog.com/i/v0/e/";
-const MAX_CAPTURE_ATTEMPTS: usize = 3;
-const CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
-
-#[derive(Debug, thiserror::Error)]
-pub enum TelemetryError {
-    #[error("PostHog request failed: {0}")]
-    Connection(String),
-    #[error("PostHog rejected the event with HTTP {status}: {body}")]
-    Rejected { status: u16, body: String },
-    #[error("PostHog delivery timed out")]
-    Timeout,
-}
+pub type TelemetryError = posthog_rs::Error;
 
 #[async_trait]
 pub trait TelemetrySender: Send + Sync + 'static {
@@ -56,80 +43,23 @@ pub trait TelemetrySender: Send + Sync + 'static {
 
 #[derive(Clone)]
 pub struct PostHogSender {
-    client: reqwest::Client,
-    capture_url: String,
+    client: Arc<posthog_rs::Client>,
     options: TelemetrySenderOptions,
 }
 
 pub const POSTHOG_API_KEY: &str = env!("POSTHOG_API_KEY");
 
-#[derive(Serialize)]
-struct PostHogCapture {
-    api_key: &'static str,
-    uuid: Uuid,
-    event: String,
-    distinct_id: String,
-    properties: HashMap<String, Value>,
-}
-
 impl PostHogSender {
     pub async fn new(options: TelemetrySenderOptions) -> Self {
-        let client = reqwest::Client::builder()
-            .timeout(REQUEST_TIMEOUT)
-            .build()
-            .expect("static PostHog HTTP client options should be valid");
-        Self::with_client(options, client, POSTHOG_CAPTURE_URL.to_string())
+        let client = posthog_rs::client(POSTHOG_API_KEY).await;
+        Self::with_client(options, client)
     }
 
-    fn with_client(
-        options: TelemetrySenderOptions,
-        client: reqwest::Client,
-        capture_url: String,
-    ) -> Self {
+    fn with_client(options: TelemetrySenderOptions, client: posthog_rs::Client) -> Self {
         Self {
-            client,
-            capture_url,
+            client: Arc::new(client),
             options,
         }
-    }
-
-    async fn capture(&self, event: PostHogCapture) -> Result<(), TelemetryError> {
-        tokio::time::timeout(CAPTURE_TIMEOUT, self.capture_with_retries(event))
-            .await
-            .map_err(|_| TelemetryError::Timeout)?
-    }
-
-    async fn capture_with_retries(&self, event: PostHogCapture) -> Result<(), TelemetryError> {
-        let mut backoff = Duration::from_millis(100);
-
-        for attempt in 1..=MAX_CAPTURE_ATTEMPTS {
-            let response = self
-                .client
-                .post(&self.capture_url)
-                .json(&event)
-                .send()
-                .await;
-            match response {
-                Ok(response) if response.status().is_success() => return Ok(()),
-                Ok(response) => {
-                    let status = response.status().as_u16();
-                    let retryable = matches!(status, 408 | 429 | 500 | 502 | 503 | 504);
-                    let body = response.text().await.unwrap_or_default();
-                    if !retryable || attempt == MAX_CAPTURE_ATTEMPTS {
-                        return Err(TelemetryError::Rejected { status, body });
-                    }
-                }
-                Err(error) if attempt == MAX_CAPTURE_ATTEMPTS => {
-                    return Err(TelemetryError::Connection(error.to_string()));
-                }
-                Err(_) => {}
-            }
-
-            tokio::time::sleep(backoff).await;
-            backoff *= 2;
-        }
-
-        unreachable!("capture attempt loop always returns on its final attempt")
     }
 }
 
@@ -150,25 +80,15 @@ impl TelemetrySender for PostHogSender {
             .and_then(|o| o.cloud_role.clone())
             .unwrap_or_else(|| self.options.cloud_role.clone());
 
-        let mut properties = event
-            .properties
-            .into_iter()
-            .map(|(key, value)| (key, Value::String(value)))
-            .collect::<HashMap<_, _>>();
-        properties.insert("cloudRole".to_string(), Value::String(cloud_role.clone()));
-        properties.insert(
-            "$lib".to_string(),
-            Value::String("codemod-rust-cli".to_string()),
-        );
+        let mut posthog_event =
+            posthog_rs::Event::new(format!("codemod.{cloud_role}.{}", event.kind), distinct_id);
 
-        self.capture(PostHogCapture {
-            api_key: POSTHOG_API_KEY,
-            uuid: Uuid::new_v4(),
-            event: format!("codemod.{cloud_role}.{}", event.kind),
-            distinct_id,
-            properties,
-        })
-        .await
+        for (key, value) in event.properties {
+            posthog_event.insert_prop(key, value)?;
+        }
+
+        self.client.capture_immediate(posthog_event).await?;
+        Ok(())
     }
 
     async fn initialize_panic_telemetry(&self) {
@@ -305,10 +225,16 @@ mod tests {
             requests
         });
 
-        let client = reqwest::Client::builder()
-            .timeout(Duration::from_secs(1))
+        let client_options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key("test-key".to_string())
+            .host(format!("http://{address}"))
+            .request_timeout_seconds(1)
+            .max_capture_attempts(3)
+            .retry_initial_backoff_ms(1)
+            .retry_max_backoff_ms(2)
             .build()
-            .expect("build test HTTP client");
+            .expect("build test PostHog client options");
+        let client = posthog_rs::client(client_options).await;
         (
             PostHogSender::with_client(
                 TelemetrySenderOptions {
@@ -316,14 +242,13 @@ mod tests {
                     cloud_role: "CLI".to_string(),
                 },
                 client,
-                format!("http://{address}/i/v0/e/"),
             ),
             server,
         )
     }
 
     #[tokio::test]
-    async fn send_event_includes_stable_identity_and_cloud_role() {
+    async fn send_event_includes_stable_identity_and_event_name() {
         let (sender, server) = test_sender(vec!["200 OK"]).await;
 
         sender
@@ -346,12 +271,13 @@ mod tests {
             .split_once("\r\n\r\n")
             .map(|(_, body)| body)
             .expect("request should contain a body");
-        let payload: Value = serde_json::from_str(body).expect("request body should be JSON");
+        let payload: serde_json::Value =
+            serde_json::from_str(body).expect("request body should be JSON");
+        let event = &payload["batch"][0];
 
-        assert_eq!(payload["distinct_id"], "installation-123");
-        assert!(payload.get("$distinct_id").is_none());
-        assert_eq!(payload["properties"]["cloudRole"], "CLI");
-        assert_eq!(payload["event"], "codemod.CLI.codemodRunStarted");
+        assert_eq!(event["distinct_id"], "installation-123");
+        assert!(event.get("$distinct_id").is_none());
+        assert_eq!(event["event"], "codemod.CLI.codemodRunStarted");
     }
 
     #[tokio::test]
@@ -369,7 +295,7 @@ mod tests {
             .await
             .expect_err("non-success response should be reported");
 
-        assert!(error.to_string().contains("400"));
+        assert!(matches!(error, posthog_rs::Error::BadRequest(_)));
         server.await.expect("telemetry server should finish");
     }
 

--- a/crates/telemetry/src/send_event.rs
+++ b/crates/telemetry/src/send_event.rs
@@ -29,7 +29,20 @@ pub struct BaseEvent {
 }
 
 static RUNTIME_HANDLE: OnceCell<tokio::runtime::Handle> = OnceCell::const_new();
-pub type TelemetryError = posthog_rs::Error;
+const REQUEST_TIMEOUT_SECONDS: u64 = 2;
+const MAX_CAPTURE_ATTEMPTS: u32 = 3;
+const RETRY_INITIAL_BACKOFF_MS: u64 = 100;
+const RETRY_MAX_BACKOFF_MS: u64 = 200;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TelemetryError {
+    #[error(transparent)]
+    PostHog(#[from] posthog_rs::Error),
+    #[error("PostHog client configuration is invalid: {0}")]
+    Configuration(String),
+    #[error("PostHog accepted the request without submitting the event")]
+    NoEventSubmitted,
+}
 
 #[async_trait]
 pub trait TelemetrySender: Send + Sync + 'static {
@@ -58,9 +71,30 @@ pub struct PostHogSender {
 pub const POSTHOG_API_KEY: &str = env!("POSTHOG_API_KEY");
 
 impl PostHogSender {
-    pub async fn new(options: TelemetrySenderOptions) -> Self {
-        let client = posthog_rs::client(POSTHOG_API_KEY).await;
-        Self::with_client(options, client)
+    pub async fn new(options: TelemetrySenderOptions) -> Result<Self, TelemetryError> {
+        Self::new_with_api_key(options, POSTHOG_API_KEY).await
+    }
+
+    async fn new_with_api_key(
+        options: TelemetrySenderOptions,
+        api_key: &str,
+    ) -> Result<Self, TelemetryError> {
+        if api_key.trim().is_empty() {
+            return Err(TelemetryError::Configuration(
+                "POSTHOG_API_KEY is empty".to_string(),
+            ));
+        }
+
+        let client_options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key(api_key.to_string())
+            .request_timeout_seconds(REQUEST_TIMEOUT_SECONDS)
+            .max_capture_attempts(MAX_CAPTURE_ATTEMPTS)
+            .retry_initial_backoff_ms(RETRY_INITIAL_BACKOFF_MS)
+            .retry_max_backoff_ms(RETRY_MAX_BACKOFF_MS)
+            .build()
+            .map_err(|error| TelemetryError::Configuration(error.to_string()))?;
+        let client = posthog_rs::client(client_options).await;
+        Ok(Self::with_client(options, client))
     }
 
     fn with_client(options: TelemetrySenderOptions, client: posthog_rs::Client) -> Self {
@@ -103,7 +137,10 @@ impl TelemetrySender for PostHogSender {
             posthog_event.insert_prop(key, value)?;
         }
 
-        self.client.capture_immediate(posthog_event).await?;
+        let summary = self.client.capture_immediate(posthog_event).await?;
+        if summary.submitted() != 1 {
+            return Err(TelemetryError::NoEventSubmitted);
+        }
         Ok(())
     }
 
@@ -311,7 +348,10 @@ mod tests {
             .await
             .expect_err("non-success response should be reported");
 
-        assert!(matches!(error, posthog_rs::Error::BadRequest(_)));
+        assert!(matches!(
+            error,
+            TelemetryError::PostHog(posthog_rs::Error::BadRequest(_))
+        ));
         server.await.expect("telemetry server should finish");
     }
 
@@ -362,5 +402,48 @@ mod tests {
         assert!(error.to_string().contains("504"));
         let requests = server.await.expect("telemetry server should finish");
         assert_eq!(requests.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn empty_api_key_is_rejected_instead_of_disabling_delivery() {
+        let result = PostHogSender::new_with_api_key(
+            TelemetrySenderOptions {
+                distinct_id: "installation-123".to_string(),
+                cloud_role: "CLI".to_string(),
+            },
+            " ",
+        )
+        .await;
+
+        assert!(matches!(result, Err(TelemetryError::Configuration(_))));
+    }
+
+    #[tokio::test]
+    async fn disabled_client_is_not_reported_as_successful_delivery() {
+        let client_options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key(" ".to_string())
+            .build()
+            .expect("expected valid disabled-client options");
+        let client = posthog_rs::client(client_options).await;
+        let sender = PostHogSender::with_client(
+            TelemetrySenderOptions {
+                distinct_id: "installation-123".to_string(),
+                cloud_role: "CLI".to_string(),
+            },
+            client,
+        );
+
+        let error = sender
+            .try_send_event(
+                BaseEvent {
+                    kind: "codemodRunStarted".to_string(),
+                    properties: HashMap::new(),
+                },
+                None,
+            )
+            .await
+            .expect_err("disabled client should not report successful delivery");
+
+        assert!(matches!(error, TelemetryError::NoEventSubmitted));
     }
 }

--- a/crates/telemetry/src/send_event.rs
+++ b/crates/telemetry/src/send_event.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
 use chrono::Utc;
-use posthog_rs;
 use serde::Serialize;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
 use std::panic;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::OnceCell;
+use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct TelemetrySenderOptions {
@@ -29,6 +29,20 @@ pub struct BaseEvent {
 }
 
 static RUNTIME_HANDLE: OnceCell<tokio::runtime::Handle> = OnceCell::const_new();
+const POSTHOG_CAPTURE_URL: &str = "https://us.i.posthog.com/i/v0/e/";
+const MAX_CAPTURE_ATTEMPTS: usize = 3;
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug, thiserror::Error)]
+pub enum TelemetryError {
+    #[error("PostHog request failed: {0}")]
+    Connection(String),
+    #[error("PostHog rejected the event with HTTP {status}: {body}")]
+    Rejected { status: u16, body: String },
+    #[error("PostHog delivery timed out")]
+    Timeout,
+}
 
 #[async_trait]
 pub trait TelemetrySender: Send + Sync + 'static {
@@ -36,24 +50,86 @@ pub trait TelemetrySender: Send + Sync + 'static {
         &self,
         event: BaseEvent,
         options_override: Option<PartialTelemetrySenderOptions>,
-    );
+    ) -> Result<(), TelemetryError>;
     async fn initialize_panic_telemetry(&self);
 }
 
+#[derive(Clone)]
 pub struct PostHogSender {
-    client: Arc<posthog_rs::Client>,
+    client: reqwest::Client,
+    capture_url: String,
     options: TelemetrySenderOptions,
 }
 
 pub const POSTHOG_API_KEY: &str = env!("POSTHOG_API_KEY");
 
+#[derive(Serialize)]
+struct PostHogCapture {
+    api_key: &'static str,
+    uuid: Uuid,
+    event: String,
+    distinct_id: String,
+    properties: HashMap<String, Value>,
+}
+
 impl PostHogSender {
     pub async fn new(options: TelemetrySenderOptions) -> Self {
-        let client = posthog_rs::client(POSTHOG_API_KEY).await;
+        let client = reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .expect("static PostHog HTTP client options should be valid");
+        Self::with_client(options, client, POSTHOG_CAPTURE_URL.to_string())
+    }
+
+    fn with_client(
+        options: TelemetrySenderOptions,
+        client: reqwest::Client,
+        capture_url: String,
+    ) -> Self {
         Self {
-            client: Arc::new(client),
+            client,
+            capture_url,
             options,
         }
+    }
+
+    async fn capture(&self, event: PostHogCapture) -> Result<(), TelemetryError> {
+        tokio::time::timeout(CAPTURE_TIMEOUT, self.capture_with_retries(event))
+            .await
+            .map_err(|_| TelemetryError::Timeout)?
+    }
+
+    async fn capture_with_retries(&self, event: PostHogCapture) -> Result<(), TelemetryError> {
+        let mut backoff = Duration::from_millis(100);
+
+        for attempt in 1..=MAX_CAPTURE_ATTEMPTS {
+            let response = self
+                .client
+                .post(&self.capture_url)
+                .json(&event)
+                .send()
+                .await;
+            match response {
+                Ok(response) if response.status().is_success() => return Ok(()),
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    let retryable = matches!(status, 408 | 429 | 500 | 502 | 503 | 504);
+                    let body = response.text().await.unwrap_or_default();
+                    if !retryable || attempt == MAX_CAPTURE_ATTEMPTS {
+                        return Err(TelemetryError::Rejected { status, body });
+                    }
+                }
+                Err(error) if attempt == MAX_CAPTURE_ATTEMPTS => {
+                    return Err(TelemetryError::Connection(error.to_string()));
+                }
+                Err(_) => {}
+            }
+
+            tokio::time::sleep(backoff).await;
+            backoff *= 2;
+        }
+
+        unreachable!("capture attempt loop always returns on its final attempt")
     }
 }
 
@@ -63,7 +139,7 @@ impl TelemetrySender for PostHogSender {
         &self,
         event: BaseEvent,
         options_override: Option<PartialTelemetrySenderOptions>,
-    ) {
+    ) -> Result<(), TelemetryError> {
         let distinct_id = options_override
             .as_ref()
             .and_then(|o| o.distinct_id.clone())
@@ -74,20 +150,25 @@ impl TelemetrySender for PostHogSender {
             .and_then(|o| o.cloud_role.clone())
             .unwrap_or_else(|| self.options.cloud_role.clone());
 
-        let mut posthog_event = posthog_rs::Event::new(
-            format!("codemod.{}.{}", cloud_role, event.kind),
-            distinct_id.clone(),
+        let mut properties = event
+            .properties
+            .into_iter()
+            .map(|(key, value)| (key, Value::String(value)))
+            .collect::<HashMap<_, _>>();
+        properties.insert("cloudRole".to_string(), Value::String(cloud_role.clone()));
+        properties.insert(
+            "$lib".to_string(),
+            Value::String("codemod-rust-cli".to_string()),
         );
 
-        for (key, value) in event.properties {
-            if let Err(e) = posthog_event.insert_prop(key, value) {
-                eprintln!("Failed to insert property into PostHog event: {e}");
-            }
-        }
-
-        if let Err(e) = self.client.capture(posthog_event).await {
-            eprintln!("Failed to send PostHog event: {e}");
-        }
+        self.capture(PostHogCapture {
+            api_key: POSTHOG_API_KEY,
+            uuid: Uuid::new_v4(),
+            event: format!("codemod.{cloud_role}.{}", event.kind),
+            distinct_id,
+            properties,
+        })
+        .await
     }
 
     async fn initialize_panic_telemetry(&self) {
@@ -95,8 +176,7 @@ impl TelemetrySender for PostHogSender {
             let _ = RUNTIME_HANDLE.set(handle);
         }
 
-        let client = self.client.clone();
-        let options = self.options.clone();
+        let sender = self.clone();
 
         panic::set_hook(Box::new(move |panic_info| {
             let timestamp = Utc::now().format("%Y-%m-%d %H:%M:%S UTC").to_string();
@@ -121,15 +201,9 @@ impl TelemetrySender for PostHogSender {
             };
 
             if let Some(handle) = RUNTIME_HANDLE.get() {
-                let client = client.clone();
-                let options = options.clone();
+                let sender = sender.clone();
 
                 handle.spawn(async move {
-                    let mut posthog_event = posthog_rs::Event::new(
-                        format!("codemod.{}.cliPanic", options.cloud_role),
-                        options.distinct_id.clone(),
-                    );
-
                     let properties = HashMap::from([
                         ("timestamp".to_string(), timestamp),
                         ("message".to_string(), panic_message),
@@ -142,13 +216,17 @@ impl TelemetrySender for PostHogSender {
                         ("arch".to_string(), std::env::consts::ARCH.to_string()),
                     ]);
 
-                    for (key, value) in properties {
-                        let _ = posthog_event.insert_prop(key, value);
-                    }
-
-                    let _ =
-                        tokio::time::timeout(Duration::from_secs(5), client.capture(posthog_event))
-                            .await;
+                    let _ = tokio::time::timeout(
+                        Duration::from_secs(5),
+                        sender.send_event(
+                            BaseEvent {
+                                kind: "cliPanic".to_string(),
+                                properties,
+                            },
+                            None,
+                        ),
+                    )
+                    .await;
                 });
 
                 std::thread::sleep(Duration::from_millis(100));
@@ -162,5 +240,185 @@ impl TelemetrySender for PostHogSender {
                 std::panic::resume_unwind(Box::new("Unknown panic"));
             }
         }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    async fn read_request(stream: &mut TcpStream) -> String {
+        let mut request = Vec::new();
+        loop {
+            let mut chunk = [0; 4096];
+            let size = stream
+                .read(&mut chunk)
+                .await
+                .expect("read telemetry request");
+            assert!(size > 0, "connection closed before request completed");
+            request.extend_from_slice(&chunk[..size]);
+
+            let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n")
+            else {
+                continue;
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.split_once(':').and_then(|(name, value)| {
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().ok())
+                            .flatten()
+                    })
+                })
+                .unwrap_or(0);
+            if request.len() >= header_end + 4 + content_length {
+                return String::from_utf8_lossy(&request).into_owned();
+            }
+        }
+    }
+
+    async fn test_sender(
+        statuses: Vec<&'static str>,
+    ) -> (PostHogSender, tokio::task::JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind telemetry test server");
+        let address = listener.local_addr().expect("telemetry test address");
+        let server = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for status in statuses {
+                let (mut stream, _) = listener.accept().await.expect("accept telemetry request");
+                let request = read_request(&mut stream).await;
+                let response = format!(
+                    "HTTP/1.1 {status}\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{{}}"
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .await
+                    .expect("write telemetry response");
+                requests.push(request);
+            }
+            requests
+        });
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(1))
+            .build()
+            .expect("build test HTTP client");
+        (
+            PostHogSender::with_client(
+                TelemetrySenderOptions {
+                    distinct_id: "installation-123".to_string(),
+                    cloud_role: "CLI".to_string(),
+                },
+                client,
+                format!("http://{address}/i/v0/e/"),
+            ),
+            server,
+        )
+    }
+
+    #[tokio::test]
+    async fn send_event_includes_stable_identity_and_cloud_role() {
+        let (sender, server) = test_sender(vec!["200 OK"]).await;
+
+        sender
+            .send_event(
+                BaseEvent {
+                    kind: "codemodRunStarted".to_string(),
+                    properties: HashMap::from([(
+                        "codemodName".to_string(),
+                        "@codemod/react/19/migration-recipe".to_string(),
+                    )]),
+                },
+                None,
+            )
+            .await
+            .expect("event should be accepted");
+
+        let requests = server.await.expect("telemetry server should finish");
+        let request = &requests[0];
+        let body = request
+            .split_once("\r\n\r\n")
+            .map(|(_, body)| body)
+            .expect("request should contain a body");
+        let payload: Value = serde_json::from_str(body).expect("request body should be JSON");
+
+        assert_eq!(payload["distinct_id"], "installation-123");
+        assert!(payload.get("$distinct_id").is_none());
+        assert_eq!(payload["properties"]["cloudRole"], "CLI");
+        assert_eq!(payload["event"], "codemod.CLI.codemodRunStarted");
+    }
+
+    #[tokio::test]
+    async fn send_event_surfaces_non_success_responses() {
+        let (sender, server) = test_sender(vec!["400 Bad Request"]).await;
+
+        let error = sender
+            .send_event(
+                BaseEvent {
+                    kind: "codemodRunStarted".to_string(),
+                    properties: HashMap::new(),
+                },
+                None,
+            )
+            .await
+            .expect_err("non-success response should be reported");
+
+        assert!(error.to_string().contains("400"));
+        server.await.expect("telemetry server should finish");
+    }
+
+    #[tokio::test]
+    async fn send_event_retries_transient_responses() {
+        let (sender, server) = test_sender(vec![
+            "500 Internal Server Error",
+            "503 Unavailable",
+            "200 OK",
+        ])
+        .await;
+
+        sender
+            .send_event(
+                BaseEvent {
+                    kind: "codemodRunStarted".to_string(),
+                    properties: HashMap::new(),
+                },
+                None,
+            )
+            .await
+            .expect("event should succeed after retries");
+
+        let requests = server.await.expect("telemetry server should finish");
+        assert_eq!(requests.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn send_event_reports_exhausted_transient_responses() {
+        let (sender, server) = test_sender(vec![
+            "500 Internal Server Error",
+            "503 Unavailable",
+            "504 Gateway Timeout",
+        ])
+        .await;
+
+        let error = sender
+            .send_event(
+                BaseEvent {
+                    kind: "codemodRunStarted".to_string(),
+                    properties: HashMap::new(),
+                },
+                None,
+            )
+            .await
+            .expect_err("exhausted retries should be reported");
+
+        assert!(error.to_string().contains("504"));
+        let requests = server.await.expect("telemetry server should finish");
+        assert_eq!(requests.len(), 3);
     }
 }

--- a/crates/telemetry/src/send_null.rs
+++ b/crates/telemetry/src/send_null.rs
@@ -1,4 +1,6 @@
-use crate::send_event::{BaseEvent, PartialTelemetrySenderOptions, TelemetrySender};
+use crate::send_event::{
+    BaseEvent, PartialTelemetrySenderOptions, TelemetryError, TelemetrySender,
+};
 use async_trait::async_trait;
 
 pub struct NullSender;
@@ -9,8 +11,8 @@ impl TelemetrySender for NullSender {
         &self,
         _event: BaseEvent,
         _options_override: Option<PartialTelemetrySenderOptions>,
-    ) {
-        // Do nothing
+    ) -> Result<(), TelemetryError> {
+        Ok(())
     }
     async fn initialize_panic_telemetry(&self) {
         // Do nothing

--- a/crates/telemetry/src/send_null.rs
+++ b/crates/telemetry/src/send_null.rs
@@ -1,6 +1,4 @@
-use crate::send_event::{
-    BaseEvent, PartialTelemetrySenderOptions, TelemetryError, TelemetrySender,
-};
+use crate::send_event::{BaseEvent, PartialTelemetrySenderOptions, TelemetrySender};
 use async_trait::async_trait;
 
 pub struct NullSender;
@@ -11,8 +9,7 @@ impl TelemetrySender for NullSender {
         &self,
         _event: BaseEvent,
         _options_override: Option<PartialTelemetrySenderOptions>,
-    ) -> Result<(), TelemetryError> {
-        Ok(())
+    ) {
     }
     async fn initialize_panic_telemetry(&self) {
         // Do nothing


### PR DESCRIPTION
#### 📚 Description

Codemod run analytics could be lost when the report UI blocked or the CLI exited before the previous queued PostHog client flushed. Logged-out runs also received a new identity on every invocation, and package aliases could fragment counts across multiple names.

This change:

- emits `codemodRunStarted` and `codemodRunCompleted` with a shared execution ID, outcome, duration, and canonical registry package name
- preserves `codemodExecuted` so existing dashboards continue to receive their current success event
- awaits immediate delivery before report handling and records failures as well as successes
- uses `posthog-rs` 0.21 with an explicit 2-second request timeout, three attempts, response validation, and transient retries
- rejects release builds without a configured PostHog API key and treats zero submitted events as a delivery error
- persists the generated anonymous telemetry identity atomically across logged-out CLI runs
- upgrades the Rust toolchain to 1.94.1 and the WASI `wasm-bindgen` fork to 0.2.126 so the latest PostHog SDK remains compatible with the sandbox runtime
- adds identity, concurrency, lifecycle, payload, response, and retry regression tests

#### 🔗 Linked Issue

None.

#### 🧪 Test Plan

- `cargo test -p codemod-telemetry`
- `cargo test -p codemod`
- `cargo test -p codemod-sandbox`
- `cargo fmt --all -- --check`
- `cargo clippy --tests --no-deps -- -D warnings`
- `bash ./scripts/check-single-crossterm.sh`
- `WASI_SYSROOT=/opt/homebrew/opt/wasi-libc/share/wasi-sysroot CC_wasm32_wasip1=/opt/homebrew/opt/llvm/bin/clang pnpm --filter @codemod.com/codemod-sandbox build:runtime`
- `git diff --check`

#### 📄 Documentation to Update

None. This change does not alter user-facing CLI behavior or documentation.
