### PR TITLE
fix(ci): run telemetry validation with bash on Windows

### DIFF
--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -104,6 +104,7 @@ jobs:
         run: test -f crates/cli/report-ui/dist/index.html
 
       - name: Verify telemetry configuration
+        shell: bash
         run: |
           if [[ ! "${POSTHOG_API_KEY}" =~ [^[:space:]] ]]; then
             echo "::error::POSTHOG_API_KEY must be configured for release builds"


### PR DESCRIPTION
#### 📚 Description

The release telemetry-key validation uses Bash condition syntax, but GitHub Actions selected PowerShell for the Windows matrix runner. The Windows release failed during parsing even though the PostHog key was configured.

This change explicitly runs that validation step with Bash, matching the existing cross-platform `Get Binary Path` step in the same job.

Failed run: https://github.com/codemod/codemod/actions/runs/30399056858

#### 🔗 Linked Issue

None.

#### 🧪 Test Plan

- Parsed `.github/workflows/cargo-release.yml` as YAML.
- Ran the validation condition with Bash against populated and whitespace-only values.
- Ran `git diff --check`.

#### 📄 Documentation to Update

None.
