### PR TITLE
feat(cli): meter nested codemod LLM usage

### DIFF
--- a/.changeset/calm-llamas-count.md
+++ b/.changeset/calm-llamas-count.md
@@ -1,0 +1,5 @@
+---
+"@codemod.com/jssg-types": patch
+---
+
+Add types for the engine-owned `codemod:llm` runtime module.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,6 +1132,7 @@ dependencies = [
  "rig-core",
  "rmcp 0.13.0",
  "rusqlite",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 
 [dependencies]
 rig-core = { version = "0.31.0", features = ["derive"] }
+schemars = "1"
 rmcp = { version = "0.13", features = ["client", "transport-child-process"] }
 tree-sitter = "0.25"
 tree-sitter-rust = "0.24"

--- a/crates/ai/src/lib.rs
+++ b/crates/ai/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod execute;
+pub mod llm;
 pub(crate) mod memory;
 pub(crate) mod prompt;
 pub(crate) mod tools;

--- a/crates/ai/src/llm.rs
+++ b/crates/ai/src/llm.rs
@@ -77,7 +77,10 @@ fn output_schema(value: Option<Value>) -> Result<Option<schemars::Schema>, Gener
         .transpose()
 }
 
-async fn generate_openai(request: GenerateRequest) -> Result<GenerateResponse, GenerateError> {
+async fn generate_openai(
+    request: GenerateRequest,
+    provider: String,
+) -> Result<GenerateResponse, GenerateError> {
     use rig::providers::openai;
 
     let client: openai::Client = openai::Client::builder()
@@ -121,7 +124,7 @@ async fn generate_openai(request: GenerateRequest) -> Result<GenerateResponse, G
 
     Ok(GenerateResponse {
         output,
-        provider: "openai".to_string(),
+        provider,
         model,
         usage,
     })
@@ -174,8 +177,9 @@ async fn generate_anthropic(request: GenerateRequest) -> Result<GenerateResponse
 }
 
 pub async fn generate(request: GenerateRequest) -> Result<GenerateResponse, GenerateError> {
-    match request.provider.trim().to_ascii_lowercase().as_str() {
-        "openai" | "openai_compatible" => generate_openai(request).await,
+    let provider = request.provider.trim().to_ascii_lowercase();
+    match provider.as_str() {
+        "openai" | "openai_compatible" => generate_openai(request, provider).await,
         "anthropic" => generate_anthropic(request).await,
         provider => Err(GenerateError::UnsupportedProvider(provider.to_string())),
     }
@@ -328,6 +332,42 @@ mod tests {
                 total_tokens: Some(120),
             })
         );
+    }
+
+    #[tokio::test]
+    async fn preserves_openai_compatible_provider_name() {
+        let (endpoint, server) = serve_once(json!({
+            "id": "resp_test",
+            "object": "response",
+            "created_at": 1,
+            "status": "completed",
+            "error": null,
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": 128,
+            "model": "compatible-model",
+            "usage": null,
+            "output": [{
+                "type": "message",
+                "id": "msg_test",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": "welcomeTitle"
+                }]
+            }],
+            "tools": []
+        }))
+        .await;
+
+        let response = generate(request(" OpenAI_Compatible ", endpoint))
+            .await
+            .expect("OpenAI-compatible response should succeed");
+        server.await.expect("mock server should finish");
+
+        assert_eq!(response.provider, "openai_compatible");
+        assert_eq!(response.model, "compatible-model");
     }
 
     #[tokio::test]

--- a/crates/ai/src/llm.rs
+++ b/crates/ai/src/llm.rs
@@ -1,0 +1,433 @@
+use rig::client::CompletionClient;
+use rig::completion::{AssistantContent, CompletionModel};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use thiserror::Error;
+
+#[derive(Debug, Clone)]
+pub struct GenerateRequest {
+    pub endpoint: String,
+    pub api_key: String,
+    pub model: String,
+    pub provider: String,
+    pub system_prompt: Option<String>,
+    pub prompt: String,
+    pub output_schema: Option<Value>,
+    pub max_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub uncached_input_tokens: Option<u64>,
+    pub cache_read_input_tokens: Option<u64>,
+    pub cache_write_input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub reasoning_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerateResponse {
+    pub output: String,
+    pub provider: String,
+    pub model: String,
+    pub usage: Option<TokenUsage>,
+}
+
+#[derive(Debug, Error)]
+pub enum GenerateError {
+    #[error("Unsupported LLM provider: {0}")]
+    UnsupportedProvider(String),
+    #[error("Failed to configure LLM provider: {0}")]
+    Configuration(String),
+    #[error("LLM request failed: {0}")]
+    Request(String),
+    #[error("LLM response did not contain text")]
+    MissingText,
+    #[error("Invalid output schema: {0}")]
+    InvalidSchema(String),
+}
+
+fn response_text(
+    choices: impl IntoIterator<Item = AssistantContent>,
+) -> Result<String, GenerateError> {
+    let output = choices
+        .into_iter()
+        .filter_map(|choice| match choice {
+            AssistantContent::Text(text) => Some(text.text),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if output.is_empty() {
+        Err(GenerateError::MissingText)
+    } else {
+        Ok(output)
+    }
+}
+
+fn output_schema(value: Option<Value>) -> Result<Option<schemars::Schema>, GenerateError> {
+    value
+        .map(|value| {
+            value
+                .try_into()
+                .map_err(|error| GenerateError::InvalidSchema(format!("{error:?}")))
+        })
+        .transpose()
+}
+
+async fn generate_openai(request: GenerateRequest) -> Result<GenerateResponse, GenerateError> {
+    use rig::providers::openai;
+
+    let client: openai::Client = openai::Client::builder()
+        .api_key(request.api_key)
+        .base_url(request.endpoint)
+        .build()
+        .map_err(|error| GenerateError::Configuration(error.to_string()))?;
+    let model = client.completion_model(request.model.clone());
+    let mut completion = model
+        .completion_request(request.prompt)
+        .max_tokens_opt(request.max_tokens)
+        .output_schema_opt(output_schema(request.output_schema)?);
+    if let Some(system_prompt) = request.system_prompt {
+        completion = completion.preamble(system_prompt);
+    }
+    let response = completion
+        .send()
+        .await
+        .map_err(|error| GenerateError::Request(error.to_string()))?;
+    let output = response_text(response.choice)?;
+    let raw = response.raw_response;
+    let model = raw.model;
+    let usage = raw.usage.map(|usage| {
+        let cache_read_input_tokens = usage
+            .input_tokens_details
+            .as_ref()
+            .map(|details| details.cached_tokens);
+        TokenUsage {
+            uncached_input_tokens: Some(
+                usage
+                    .input_tokens
+                    .saturating_sub(cache_read_input_tokens.unwrap_or(0)),
+            ),
+            cache_read_input_tokens,
+            cache_write_input_tokens: None,
+            output_tokens: Some(usage.output_tokens),
+            reasoning_tokens: Some(usage.output_tokens_details.reasoning_tokens),
+            total_tokens: Some(usage.total_tokens),
+        }
+    });
+
+    Ok(GenerateResponse {
+        output,
+        provider: "openai".to_string(),
+        model,
+        usage,
+    })
+}
+
+async fn generate_anthropic(request: GenerateRequest) -> Result<GenerateResponse, GenerateError> {
+    use rig::providers::anthropic;
+
+    let client: anthropic::Client = anthropic::Client::builder()
+        .api_key(request.api_key)
+        .base_url(request.endpoint)
+        .build()
+        .map_err(|error| GenerateError::Configuration(error.to_string()))?;
+    let model = client.completion_model(request.model.clone());
+    let mut completion = model
+        .completion_request(request.prompt)
+        .max_tokens(request.max_tokens.unwrap_or(4096))
+        .output_schema_opt(output_schema(request.output_schema)?);
+    if let Some(system_prompt) = request.system_prompt {
+        completion = completion.preamble(system_prompt);
+    }
+    let response = completion
+        .send()
+        .await
+        .map_err(|error| GenerateError::Request(error.to_string()))?;
+    let output = response_text(response.choice)?;
+    let raw = response.raw_response;
+    let model = raw.model;
+    let usage = raw.usage;
+    let cache_read_input_tokens = usage.cache_read_input_tokens;
+    let cache_write_input_tokens = usage.cache_creation_input_tokens;
+    let total_tokens = usage.input_tokens
+        + cache_read_input_tokens.unwrap_or(0)
+        + cache_write_input_tokens.unwrap_or(0)
+        + usage.output_tokens;
+
+    Ok(GenerateResponse {
+        output,
+        provider: "anthropic".to_string(),
+        model,
+        usage: Some(TokenUsage {
+            uncached_input_tokens: Some(usage.input_tokens),
+            cache_read_input_tokens,
+            cache_write_input_tokens,
+            output_tokens: Some(usage.output_tokens),
+            reasoning_tokens: None,
+            total_tokens: Some(total_tokens),
+        }),
+    })
+}
+
+pub async fn generate(request: GenerateRequest) -> Result<GenerateResponse, GenerateError> {
+    match request.provider.trim().to_ascii_lowercase().as_str() {
+        "openai" | "openai_compatible" => generate_openai(request).await,
+        "anthropic" => generate_anthropic(request).await,
+        provider => Err(GenerateError::UnsupportedProvider(provider.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+
+    async fn serve_once_with_status(status: &str, response: Value) -> (String, JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mock server should bind");
+        let address = listener
+            .local_addr()
+            .expect("mock server should have an address");
+        let status = status.to_string();
+        let handle = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("request should connect");
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            let header_end = loop {
+                let read = stream
+                    .read(&mut chunk)
+                    .await
+                    .expect("request should be readable");
+                assert!(read > 0, "request ended before its headers");
+                request.extend_from_slice(&chunk[..read]);
+                if let Some(position) = request.windows(4).position(|bytes| bytes == b"\r\n\r\n") {
+                    break position + 4;
+                }
+            };
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    line.split_once(':').and_then(|(name, value)| {
+                        name.eq_ignore_ascii_case("content-length")
+                            .then(|| value.trim().parse::<usize>().expect("valid content length"))
+                    })
+                })
+                .unwrap_or_default();
+            while request.len() < header_end + content_length {
+                let read = stream
+                    .read(&mut chunk)
+                    .await
+                    .expect("request body should be readable");
+                assert!(read > 0, "request ended before its body");
+                request.extend_from_slice(&chunk[..read]);
+            }
+
+            let response = serde_json::to_vec(&response).expect("response should serialize");
+            let headers = format!(
+                "HTTP/1.1 {status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+                response.len()
+            );
+            stream
+                .write_all(headers.as_bytes())
+                .await
+                .expect("response headers should write");
+            stream
+                .write_all(&response)
+                .await
+                .expect("response body should write");
+            stream.shutdown().await.expect("response should finish");
+
+            String::from_utf8(request).expect("request should be UTF-8")
+        });
+        (format!("http://{address}"), handle)
+    }
+
+    async fn serve_once(response: Value) -> (String, JoinHandle<String>) {
+        serve_once_with_status("200 OK", response).await
+    }
+
+    fn request(provider: &str, endpoint: String) -> GenerateRequest {
+        GenerateRequest {
+            endpoint,
+            api_key: "test-key".to_string(),
+            model: "requested-model".to_string(),
+            provider: provider.to_string(),
+            system_prompt: Some("Return JSON".to_string()),
+            prompt: "Generate an identifier".to_string(),
+            output_schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "identifier": { "type": "string" }
+                },
+                "required": ["identifier"],
+                "additionalProperties": false
+            })),
+            max_tokens: Some(128),
+        }
+    }
+
+    #[tokio::test]
+    async fn captures_openai_responses_usage_without_javascript_telemetry() {
+        let (endpoint, server) = serve_once(json!({
+            "id": "resp_test",
+            "object": "response",
+            "created_at": 1,
+            "status": "completed",
+            "error": null,
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": 128,
+            "model": "gpt-test",
+            "usage": {
+                "input_tokens": 100,
+                "input_tokens_details": { "cached_tokens": 40 },
+                "output_tokens": 20,
+                "output_tokens_details": { "reasoning_tokens": 5 },
+                "total_tokens": 120
+            },
+            "output": [{
+                "type": "message",
+                "id": "msg_test",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": "{\"identifier\":\"welcomeTitle\"}"
+                }]
+            }],
+            "tools": []
+        }))
+        .await;
+
+        let response = generate(request("openai", endpoint))
+            .await
+            .expect("OpenAI response should succeed");
+        let captured_request = server.await.expect("mock server should finish");
+
+        assert!(captured_request.starts_with("POST /responses "));
+        assert_eq!(response.output, "{\"identifier\":\"welcomeTitle\"}");
+        assert_eq!(response.provider, "openai");
+        assert_eq!(response.model, "gpt-test");
+        assert_eq!(
+            response.usage,
+            Some(TokenUsage {
+                uncached_input_tokens: Some(60),
+                cache_read_input_tokens: Some(40),
+                cache_write_input_tokens: None,
+                output_tokens: Some(20),
+                reasoning_tokens: Some(5),
+                total_tokens: Some(120),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn captures_anthropic_cache_usage_without_javascript_telemetry() {
+        let (endpoint, server) = serve_once(json!({
+            "id": "msg_test",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-test",
+            "content": [{
+                "type": "text",
+                "text": "{\"identifier\":\"welcomeTitle\"}"
+            }],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {
+                "input_tokens": 10,
+                "cache_read_input_tokens": 4,
+                "cache_creation_input_tokens": 2,
+                "output_tokens": 3
+            }
+        }))
+        .await;
+
+        let response = generate(request("anthropic", endpoint))
+            .await
+            .expect("Anthropic response should succeed");
+        let captured_request = server.await.expect("mock server should finish");
+
+        assert!(captured_request.starts_with("POST /v1/messages "));
+        assert_eq!(response.output, "{\"identifier\":\"welcomeTitle\"}");
+        assert_eq!(response.provider, "anthropic");
+        assert_eq!(response.model, "claude-test");
+        assert_eq!(
+            response.usage,
+            Some(TokenUsage {
+                uncached_input_tokens: Some(10),
+                cache_read_input_tokens: Some(4),
+                cache_write_input_tokens: Some(2),
+                output_tokens: Some(3),
+                reasoning_tokens: None,
+                total_tokens: Some(19),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn preserves_missing_openai_usage_as_unavailable() {
+        let (endpoint, server) = serve_once(json!({
+            "id": "resp_test",
+            "object": "response",
+            "created_at": 1,
+            "status": "completed",
+            "error": null,
+            "incomplete_details": null,
+            "instructions": null,
+            "max_output_tokens": null,
+            "model": "gpt-test",
+            "usage": null,
+            "output": [{
+                "type": "message",
+                "id": "msg_test",
+                "role": "assistant",
+                "status": "completed",
+                "content": [{
+                    "type": "output_text",
+                    "text": "welcomeTitle"
+                }]
+            }],
+            "tools": []
+        }))
+        .await;
+
+        let response = generate(request("openai", endpoint))
+            .await
+            .expect("OpenAI response without usage should still succeed");
+        server.await.expect("mock server should finish");
+
+        assert_eq!(response.output, "welcomeTitle");
+        assert_eq!(response.usage, None);
+    }
+
+    #[tokio::test]
+    async fn returns_provider_errors_without_inventing_usage() {
+        let (endpoint, server) = serve_once_with_status(
+            "429 Too Many Requests",
+            json!({
+                "error": {
+                    "message": "rate limited",
+                    "type": "rate_limit_error"
+                }
+            }),
+        )
+        .await;
+
+        let error = generate(request("openai", endpoint))
+            .await
+            .expect_err("provider failure should fail generation");
+        server.await.expect("mock server should finish");
+
+        assert!(matches!(error, GenerateError::Request(_)));
+    }
+}

--- a/crates/cli/src/commands/jssg/run.rs
+++ b/crates/cli/src/commands/jssg/run.rs
@@ -256,6 +256,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
                 capabilities: capabilities_for_closure.clone(),
                 semantic_provider: semantic_provider.clone(),
                 metrics_context: Some(metrics_context_clone.clone()),
+                llm_request_handler: None,
                 shared_state_context: Some(shared_state_context_clone.clone()),
                 runtime_event_callback: Some(runtime_event_callback),
                 cancellation_flag: None,

--- a/crates/cli/src/commands/jssg/test.rs
+++ b/crates/cli/src/commands/jssg/test.rs
@@ -362,6 +362,7 @@ async fn handler_impl(args: &Command) -> Result<()> {
                     capabilities,
                     semantic_provider,
                     metrics_context: Some(metrics_context.clone()),
+                    llm_request_handler: None,
                     shared_state_context: None,
                     runtime_event_callback: Some(runtime_event_callback),
                     cancellation_flag: None,

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -33,6 +33,8 @@ use std::process::Command as ProcessCommand;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
+mod llm_usage;
+
 const WORKFLOW_FILE_NAME: &str = "workflow.yaml";
 
 fn telemetry_codemod_name(
@@ -147,6 +149,10 @@ pub struct Command {
     /// Output format: "text" (default) or "jsonl" for structured logging
     #[arg(long, default_value_t = OutputFormat::Text)]
     format: OutputFormat,
+
+    /// Write provider-reported nested LLM usage JSON to this path
+    #[arg(long, value_name = "PATH")]
+    llm_usage_output: Option<PathBuf>,
 
     /// Name of the workflow to run when the package defines multiple workflows
     #[arg(long, value_name = "NAME")]
@@ -370,9 +376,21 @@ pub async fn handler(
     let execution_started = std::time::Instant::now();
     let run_result = run_workflow(&mut engine, config).await;
     let duration_ms = (setup_duration + execution_started.elapsed()).as_millis();
+    let llm_usage_records = engine.llm_usage_context.get_all();
+    let llm_usage_output_error = match args.llm_usage_output.as_deref() {
+        Some(path) => llm_usage::write_llm_usage_output(path, &llm_usage_records),
+        None => Ok(()),
+    }
+    .err();
 
     if let Err(e) = run_result {
-        let error_msg = format!("Workflow execution failed: {}", e);
+        let error_msg = match llm_usage_output_error.as_ref() {
+            None => format!("Workflow execution failed: {e}"),
+            Some(usage_error) => format!(
+                "Workflow execution failed: {e}; additionally failed to write LLM usage: \
+                 {usage_error}"
+            ),
+        };
         send_completed_event(
             &telemetry,
             &run_telemetry,
@@ -387,7 +405,28 @@ pub async fn handler(
             let _ = std::fs::remove_dir_all(&resolved_package.package_dir);
         }
         send_failure_event(&telemetry, &canonical_codemod_name, &error_msg).await;
-        return Err(e);
+        return match llm_usage_output_error {
+            Some(_) => Err(anyhow!(error_msg)),
+            None => Err(e),
+        };
+    }
+
+    if let Some(usage_error) = llm_usage_output_error {
+        let error_msg = format!("Workflow completed but failed to write LLM usage: {usage_error}");
+        send_completed_event(
+            &telemetry,
+            &run_telemetry,
+            CodemodRunOutcome::Failed {
+                error_message: error_msg.clone(),
+            },
+            duration_ms,
+        )
+        .await;
+        if resolved_package.dry_run_only {
+            let _ = std::fs::remove_dir_all(&resolved_package.package_dir);
+        }
+        send_failure_event(&telemetry, &canonical_codemod_name, &error_msg).await;
+        return Err(anyhow!(error_msg));
     }
 
     let metrics_data = engine.metrics_context.get_all();

--- a/crates/cli/src/commands/run/llm_usage.rs
+++ b/crates/cli/src/commands/run/llm_usage.rs
@@ -1,0 +1,232 @@
+use anyhow::{Context, Result};
+use butterflow_core::llm_usage::{LlmRequestOutcome, LlmUsageRecord, TokenUsage};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::Path;
+
+#[derive(Debug, Serialize)]
+struct LlmUsageOutput {
+    schema_version: u8,
+    requests: Vec<CanonicalUsageRecord>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+struct CanonicalUsageRecord {
+    provider: String,
+    model: String,
+    outcome: LlmRequestOutcome,
+    usage_available: bool,
+    usage: Option<CanonicalTokenUsage>,
+    request_count: u64,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+struct CanonicalTokenUsage {
+    uncached_input_tokens: Option<u64>,
+    cache_read_input_tokens: Option<u64>,
+    cache_write_input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    reasoning_tokens: Option<u64>,
+    total_tokens: Option<u64>,
+}
+
+impl From<&TokenUsage> for CanonicalTokenUsage {
+    fn from(usage: &TokenUsage) -> Self {
+        Self {
+            uncached_input_tokens: usage.uncached_input_tokens,
+            cache_read_input_tokens: usage.cache_read_input_tokens,
+            cache_write_input_tokens: usage.cache_write_input_tokens,
+            output_tokens: usage.output_tokens,
+            reasoning_tokens: usage.reasoning_tokens,
+            total_tokens: usage.total_tokens,
+        }
+    }
+}
+
+fn canonical_records(records: &[LlmUsageRecord]) -> Vec<CanonicalUsageRecord> {
+    let mut grouped = BTreeMap::<
+        (
+            String,
+            String,
+            LlmRequestOutcome,
+            Option<CanonicalTokenUsage>,
+        ),
+        u64,
+    >::new();
+    for record in records {
+        let usage = record.usage.as_ref().map(CanonicalTokenUsage::from);
+        *grouped
+            .entry((
+                record.provider.clone(),
+                record.model.clone(),
+                record.outcome,
+                usage,
+            ))
+            .or_default() += 1;
+    }
+
+    grouped
+        .into_iter()
+        .map(
+            |((provider, model, outcome, usage), request_count)| CanonicalUsageRecord {
+                provider,
+                model,
+                outcome,
+                usage_available: usage.is_some(),
+                usage,
+                request_count,
+            },
+        )
+        .collect()
+}
+
+pub(crate) fn write_llm_usage_output(path: &Path, records: &[LlmUsageRecord]) -> Result<()> {
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("Failed to create LLM usage directory {}", parent.display()))?;
+
+    let output = LlmUsageOutput {
+        schema_version: 1,
+        requests: canonical_records(records),
+    };
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)
+        .with_context(|| format!("Failed to create LLM usage file in {}", parent.display()))?;
+    serde_json::to_writer_pretty(temporary.as_file_mut(), &output)
+        .with_context(|| format!("Failed to serialize LLM usage for {}", path.display()))?;
+    writeln!(temporary.as_file_mut())
+        .with_context(|| format!("Failed to finalize LLM usage for {}", path.display()))?;
+    temporary
+        .as_file_mut()
+        .sync_all()
+        .with_context(|| format!("Failed to flush LLM usage for {}", path.display()))?;
+    temporary
+        .persist(path)
+        .map_err(|error| error.error)
+        .with_context(|| format!("Failed to persist LLM usage to {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn usage(
+        uncached_input_tokens: u64,
+        cache_read_input_tokens: Option<u64>,
+        cache_write_input_tokens: Option<u64>,
+        output_tokens: u64,
+        reasoning_tokens: Option<u64>,
+        total_tokens: u64,
+    ) -> TokenUsage {
+        TokenUsage {
+            uncached_input_tokens: Some(uncached_input_tokens),
+            cache_read_input_tokens,
+            cache_write_input_tokens,
+            output_tokens: Some(output_tokens),
+            reasoning_tokens,
+            total_tokens: Some(total_tokens),
+        }
+    }
+
+    #[test]
+    fn writes_grouped_provider_reported_usage_without_sensitive_request_data() {
+        let directory = tempfile::tempdir().expect("temporary directory should exist");
+        let path = directory.path().join("nested/llm-usage.json");
+        let openai = LlmUsageRecord {
+            provider: "openai".to_string(),
+            model: "gpt-test".to_string(),
+            outcome: LlmRequestOutcome::Success,
+            usage: Some(usage(60, Some(40), None, 20, Some(5), 120)),
+        };
+        let records = vec![
+            openai.clone(),
+            openai,
+            LlmUsageRecord {
+                provider: "anthropic".to_string(),
+                model: "claude-test".to_string(),
+                outcome: LlmRequestOutcome::Success,
+                usage: Some(usage(10, Some(4), Some(2), 3, None, 19)),
+            },
+            LlmUsageRecord {
+                provider: "openai".to_string(),
+                model: "gpt-test".to_string(),
+                outcome: LlmRequestOutcome::Error,
+                usage: None,
+            },
+        ];
+
+        write_llm_usage_output(&path, &records).expect("usage output should write");
+        let actual: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).expect("usage output should be readable"))
+                .expect("usage output should be JSON");
+
+        assert_eq!(
+            actual,
+            json!({
+                "schema_version": 1,
+                "requests": [
+                    {
+                        "provider": "anthropic",
+                        "model": "claude-test",
+                        "outcome": "success",
+                        "usage_available": true,
+                        "usage": {
+                            "uncached_input_tokens": 10,
+                            "cache_read_input_tokens": 4,
+                            "cache_write_input_tokens": 2,
+                            "output_tokens": 3,
+                            "reasoning_tokens": null,
+                            "total_tokens": 19
+                        },
+                        "request_count": 1
+                    },
+                    {
+                        "provider": "openai",
+                        "model": "gpt-test",
+                        "outcome": "success",
+                        "usage_available": true,
+                        "usage": {
+                            "uncached_input_tokens": 60,
+                            "cache_read_input_tokens": 40,
+                            "cache_write_input_tokens": null,
+                            "output_tokens": 20,
+                            "reasoning_tokens": 5,
+                            "total_tokens": 120
+                        },
+                        "request_count": 2
+                    },
+                    {
+                        "provider": "openai",
+                        "model": "gpt-test",
+                        "outcome": "error",
+                        "usage_available": false,
+                        "usage": null,
+                        "request_count": 1
+                    }
+                ]
+            })
+        );
+        let serialized = std::fs::read_to_string(&path).expect("usage output should be text");
+        assert!(!serialized.contains("test-key"));
+        assert!(!serialized.contains("Generate an identifier"));
+    }
+
+    #[test]
+    fn replaces_an_existing_output_with_the_current_run() {
+        let directory = tempfile::tempdir().expect("temporary directory should exist");
+        let path = directory.path().join("llm-usage.json");
+        std::fs::write(&path, "stale data").expect("existing output should be created");
+
+        write_llm_usage_output(&path, &[]).expect("usage output should replace old content");
+
+        let actual: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).expect("usage output should be readable"))
+                .expect("usage output should be JSON");
+        assert_eq!(actual, json!({ "schema_version": 1, "requests": [] }));
+    }
+}

--- a/crates/codemod-sandbox/src/lib.rs
+++ b/crates/codemod-sandbox/src/lib.rs
@@ -1,5 +1,6 @@
 mod ast_grep;
 pub mod capabilities;
+pub mod llm;
 pub mod metrics;
 #[cfg(all(feature = "wasm", target_arch = "wasm32"))]
 mod plugins;

--- a/crates/codemod-sandbox/src/llm/mod.rs
+++ b/crates/codemod-sandbox/src/llm/mod.rs
@@ -1,0 +1,94 @@
+use rquickjs::module::{Declarations, Exports, ModuleDef};
+use rquickjs::{prelude::Async, Ctx, Exception, Function, JsLifetime, Result, Value};
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LlmRequest {
+    pub prompt: String,
+    pub system_prompt: Option<String>,
+    pub output_schema: Option<JsonValue>,
+    pub max_tokens: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LlmResponse {
+    pub output: String,
+}
+
+pub type LlmRequestFuture =
+    Pin<Box<dyn Future<Output = std::result::Result<LlmResponse, String>> + Send>>;
+pub type LlmRequestHandler = Arc<dyn Fn(LlmRequest) -> LlmRequestFuture + Send + Sync>;
+
+#[derive(Clone, Default)]
+pub struct LlmRuntimeContext {
+    handler: Option<LlmRequestHandler>,
+}
+
+unsafe impl<'js> JsLifetime<'js> for LlmRuntimeContext {
+    type Changed<'to> = LlmRuntimeContext;
+}
+
+impl LlmRuntimeContext {
+    pub fn new(handler: Option<LlmRequestHandler>) -> Self {
+        Self { handler }
+    }
+
+    async fn generate(&self, request: LlmRequest) -> std::result::Result<LlmResponse, String> {
+        let handler = self
+            .handler
+            .as_ref()
+            .ok_or_else(|| "Engine LLM client is not configured".to_string())?;
+        handler(request).await
+    }
+}
+
+pub struct LlmModule;
+
+impl ModuleDef for LlmModule {
+    fn declare(declare: &Declarations) -> Result<()> {
+        declare.declare("generate")?;
+        declare.declare("default")?;
+        Ok(())
+    }
+
+    fn evaluate<'js>(ctx: &Ctx<'js>, exports: &Exports<'js>) -> Result<()> {
+        let generate = Function::new(ctx.clone(), Async(generate))?;
+        exports.export("generate", generate.clone())?;
+        exports.export("default", generate)?;
+        Ok(())
+    }
+}
+
+async fn generate<'js>(ctx: Ctx<'js>, request: Value<'js>) -> Result<Value<'js>> {
+    let serialized = ctx
+        .json_stringify(request)?
+        .ok_or_else(|| Exception::throw_message(&ctx, "LLM request cannot be undefined"))?
+        .to_string()?;
+    let request: LlmRequest = serde_json::from_str(&serialized).map_err(|error| {
+        Exception::throw_message(&ctx, &format!("Invalid LLM request: {error}"))
+    })?;
+    if request.prompt.trim().is_empty() {
+        return Err(Exception::throw_message(
+            &ctx,
+            "LLM request prompt must not be empty",
+        ));
+    }
+
+    let runtime = ctx
+        .userdata::<LlmRuntimeContext>()
+        .ok_or_else(|| Exception::throw_message(&ctx, "LlmRuntimeContext not found in userdata"))?
+        .clone();
+    let response = runtime
+        .generate(request)
+        .await
+        .map_err(|error| Exception::throw_message(&ctx, &error))?;
+    let serialized = serde_json::to_string(&response)
+        .map_err(|error| Exception::throw_message(&ctx, &error.to_string()))?;
+    ctx.json_parse(serialized)
+}

--- a/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
@@ -380,6 +380,10 @@ where
     // Track whether the caller opted into llrt's real-disk fs capability
     // so we know whether to install the curated fs below instead.
     let mut fs_capability_enabled = false;
+    let llm_capability_enabled = options
+        .capabilities
+        .as_ref()
+        .is_some_and(|capabilities| capabilities.contains(&LlrtSupportedModules::Fetch));
 
     // Set up built-in modules
     let mut module_builder = LlrtModuleBuilder::build();
@@ -425,9 +429,12 @@ where
     built_in_resolver = built_in_resolver.add_name("codemod:metrics");
     built_in_loader = built_in_loader.with_module("codemod:metrics", MetricsModule);
 
-    // Add LlmModule (engine-owned model access)
-    built_in_resolver = built_in_resolver.add_name("codemod:llm");
-    built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+    // Engine-owned model access can make network requests, so expose it only
+    // when the caller explicitly grants the fetch capability.
+    if llm_capability_enabled {
+        built_in_resolver = built_in_resolver.add_name("codemod:llm");
+        built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+    }
 
     // Add RuntimeModule (progress/failure hooks)
     built_in_resolver = built_in_resolver.add_name("codemod:runtime");
@@ -461,7 +468,11 @@ where
 
     // Capture metrics context and shared state context for use inside async block
     let metrics_context = options.metrics_context.clone();
-    let llm_runtime_context = LlmRuntimeContext::new(options.llm_request_handler.clone());
+    let llm_runtime_context = LlmRuntimeContext::new(
+        llm_capability_enabled
+            .then(|| options.llm_request_handler.clone())
+            .flatten(),
+    );
     let shared_state_context = options.shared_state_context.clone();
     let runtime_hooks_context = RuntimeHooksContext::new(
         options.runtime_event_callback.clone(),
@@ -1271,7 +1282,7 @@ export default async function transform() {
             selector_config: None,
             params: None,
             matrix_values: None,
-            capabilities: None,
+            capabilities: Some([LlrtSupportedModules::Fetch].into_iter().collect()),
             semantic_provider: None,
             metrics_context: None,
             llm_request_handler: Some(handler),
@@ -1305,6 +1316,62 @@ export default async function transform() {
                 .and_then(|schema| schema["properties"]["identifier"]["type"].as_str()),
             Some("string")
         );
+    }
+
+    #[tokio::test]
+    async fn test_codemod_llm_is_unavailable_without_fetch_capability() {
+        let codemod_content = r#"
+import { generate } from "codemod:llm";
+
+export default async function transform() {
+  return (await generate({ prompt: "Send source code" })).output;
+}
+        "#
+        .trim();
+        let (temp_dir, codemod_path) = setup_test_codemod(codemod_content);
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured_requests = Arc::clone(&requests);
+        let handler: LlmRequestHandler = Arc::new(move |request| {
+            captured_requests
+                .lock()
+                .expect("request capture should lock")
+                .push(request);
+            Box::pin(async {
+                Ok(crate::llm::LlmResponse {
+                    output: "unexpected".to_string(),
+                })
+            })
+        });
+        let options = JssgExecutionOptions {
+            script_path: &codemod_path,
+            resolver,
+            language: js_lang(),
+            file_path: Path::new("test.js"),
+            content: "const secret = true;",
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            capabilities: None,
+            semantic_provider: None,
+            metrics_context: None,
+            llm_request_handler: Some(handler),
+            shared_state_context: None,
+            runtime_event_callback: None,
+            cancellation_flag: None,
+            test_mode: false,
+            dry_run: false,
+            target_directory: Path::new("."),
+        };
+
+        let error = execute_codemod_with_quickjs(options)
+            .await
+            .expect_err("codemod:llm should not resolve without fetch capability");
+        assert!(format!("{error:?}").contains("codemod:llm"));
+        assert!(requests
+            .lock()
+            .expect("request capture should lock")
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/execution_engine.rs
@@ -9,6 +9,7 @@ use super::transform_helpers::{
 };
 use crate::ast_grep::sg_node::{SgNodeRjs, SgRootRjs};
 use crate::ast_grep::AstGrepModule;
+use crate::llm::{LlmModule, LlmRequestHandler, LlmRuntimeContext};
 use crate::metrics::{MetricsContext, MetricsModule};
 use crate::sandbox::errors::ExecutionError;
 use crate::sandbox::resolvers::ModuleResolver;
@@ -237,6 +238,8 @@ pub struct JssgExecutionOptions<'a, R> {
     pub semantic_provider: Option<Arc<dyn SemanticProvider>>,
     /// Optional metrics context for tracking metrics across execution
     pub metrics_context: Option<MetricsContext>,
+    /// Optional engine-owned LLM request handler exposed through codemod:llm
+    pub llm_request_handler: Option<LlmRequestHandler>,
     /// Optional shared state context for cross-thread state communication
     pub shared_state_context: Option<SharedStateContext>,
     /// Optional runtime event callback for codemod:runtime hook emissions
@@ -422,6 +425,10 @@ where
     built_in_resolver = built_in_resolver.add_name("codemod:metrics");
     built_in_loader = built_in_loader.with_module("codemod:metrics", MetricsModule);
 
+    // Add LlmModule (engine-owned model access)
+    built_in_resolver = built_in_resolver.add_name("codemod:llm");
+    built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+
     // Add RuntimeModule (progress/failure hooks)
     built_in_resolver = built_in_resolver.add_name("codemod:runtime");
     built_in_loader = built_in_loader.with_module("codemod:runtime", RuntimeModule);
@@ -454,6 +461,7 @@ where
 
     // Capture metrics context and shared state context for use inside async block
     let metrics_context = options.metrics_context.clone();
+    let llm_runtime_context = LlmRuntimeContext::new(options.llm_request_handler.clone());
     let shared_state_context = options.shared_state_context.clone();
     let runtime_hooks_context = RuntimeHooksContext::new(
         options.runtime_event_callback.clone(),
@@ -509,6 +517,12 @@ where
                 },
             })?;
         }
+
+        ctx.store_userdata(llm_runtime_context.clone()).map_err(|e| ExecutionError::Runtime {
+            source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                message: format!("Failed to store LlmRuntimeContext: {:?}", e),
+            },
+        })?;
 
         // Always store a SharedStateContext so codemod:workflow functions work
         ctx.store_userdata(shared_state_context.unwrap_or_default()).map_err(|e| ExecutionError::Runtime {
@@ -1186,6 +1200,7 @@ function example() {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1209,6 +1224,87 @@ function example() {
             },
             Err(e) => panic!("Expected success, got error: {:?}", e),
         }
+    }
+
+    #[tokio::test]
+    async fn test_codemod_llm_delegates_generation_to_engine_handler() {
+        let codemod_content = r#"
+import { generate } from "codemod:llm";
+
+export default async function transform() {
+  const response = await generate({
+    prompt: "Generate an identifier",
+    systemPrompt: "Return JSON",
+    outputSchema: {
+      type: "object",
+      properties: { identifier: { type: "string" } },
+      required: ["identifier"],
+      additionalProperties: false,
+    },
+    maxTokens: 128,
+  });
+  return response.output;
+}
+        "#
+        .trim();
+        let (temp_dir, codemod_path) = setup_test_codemod(codemod_content);
+        let resolver = Arc::new(OxcResolver::new(temp_dir.path().to_path_buf(), None).unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured_requests = Arc::clone(&requests);
+        let handler: LlmRequestHandler = Arc::new(move |request| {
+            captured_requests
+                .lock()
+                .expect("request capture should lock")
+                .push(request);
+            Box::pin(async {
+                Ok(crate::llm::LlmResponse {
+                    output: "{\"identifier\":\"welcomeTitle\"}".to_string(),
+                })
+            })
+        });
+        let options = JssgExecutionOptions {
+            script_path: &codemod_path,
+            resolver,
+            language: js_lang(),
+            file_path: Path::new("test.js"),
+            content: "const value = true;",
+            selector_config: None,
+            params: None,
+            matrix_values: None,
+            capabilities: None,
+            semantic_provider: None,
+            metrics_context: None,
+            llm_request_handler: Some(handler),
+            shared_state_context: None,
+            runtime_event_callback: None,
+            cancellation_flag: None,
+            test_mode: false,
+            dry_run: false,
+            target_directory: Path::new("."),
+        };
+
+        let output = execute_codemod_with_quickjs(options)
+            .await
+            .expect("LLM-backed codemod should succeed");
+        match output.primary {
+            ExecutionResult::Modified(modified) => {
+                assert_eq!(modified.content, "{\"identifier\":\"welcomeTitle\"}");
+            }
+            other => panic!("Expected modified result, got: {other:?}"),
+        }
+
+        let requests = requests.lock().expect("request capture should lock");
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].prompt, "Generate an identifier");
+        assert_eq!(requests[0].system_prompt.as_deref(), Some("Return JSON"));
+        assert_eq!(requests[0].max_tokens, Some(128));
+        assert_eq!(
+            requests[0]
+                .output_schema
+                .as_ref()
+                .and_then(|schema| schema["properties"]["identifier"]["type"].as_str()),
+            Some("string")
+        );
     }
 
     #[tokio::test]
@@ -1267,6 +1363,7 @@ export default function transform(root, options) {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1342,6 +1439,7 @@ export default function transform(root, options) {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1404,6 +1502,7 @@ function example() {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1456,6 +1555,7 @@ function example() {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1508,6 +1608,7 @@ function example() {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1552,6 +1653,7 @@ function example() {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1601,6 +1703,7 @@ function example() {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1711,6 +1814,7 @@ function example() {
             capabilities: None,
             semantic_provider: None,
             metrics_context: Some(metrics_ctx.clone()),
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1790,6 +1894,7 @@ export default function transform(root) {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: Some(runtime_event_callback),
             cancellation_flag: None,
@@ -1837,6 +1942,7 @@ export default function transform(root) {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1884,6 +1990,7 @@ export default function transform(root) {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,
@@ -1931,6 +2038,7 @@ export default async function transform(root) {
             capabilities: None,
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             runtime_event_callback: None,
             cancellation_flag: None,

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -213,8 +213,12 @@ where
     built_in_resolver = built_in_resolver.add_name("codemod:metrics");
     built_in_loader = built_in_loader.with_module("codemod:metrics", MetricsModule);
 
-    built_in_resolver = built_in_resolver.add_name("codemod:llm");
-    built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+    // In-memory callers have no capability set; supplying the engine-owned
+    // handler is their explicit authorization to expose model access.
+    if options.llm_request_handler.is_some() {
+        built_in_resolver = built_in_resolver.add_name("codemod:llm");
+        built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+    }
 
     built_in_resolver = built_in_resolver.add_name("codemod:workflow");
     built_in_loader = built_in_loader.with_module("codemod:workflow", WorkflowGlobalModule);

--- a/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/in_memory_engine.rs
@@ -7,6 +7,7 @@ use super::transform_helpers::{
 };
 use crate::ast_grep::sg_node::{SgNodeRjs, SgRootRjs};
 use crate::ast_grep::AstGrepModule;
+use crate::llm::{LlmModule, LlmRequestHandler, LlmRuntimeContext};
 use crate::metrics::{MetricsContext, MetricsModule};
 use crate::sandbox::errors::ExecutionError;
 use crate::sandbox::resolvers::{InMemoryLoader, InMemoryResolver, ModuleResolver};
@@ -97,6 +98,8 @@ pub struct InMemoryExecutionOptions<'a, R> {
     pub semantic_provider: Option<Arc<dyn SemanticProvider>>,
     /// Optional metrics context for tracking metrics across execution
     pub metrics_context: Option<MetricsContext>,
+    /// Optional engine-owned LLM request handler exposed through codemod:llm
+    pub llm_request_handler: Option<LlmRequestHandler>,
     /// Optional shared state context for cross-thread state communication
     pub shared_state_context: Option<SharedStateContext>,
     /// Execution timeout in milliseconds (default: 200ms)
@@ -210,6 +213,9 @@ where
     built_in_resolver = built_in_resolver.add_name("codemod:metrics");
     built_in_loader = built_in_loader.with_module("codemod:metrics", MetricsModule);
 
+    built_in_resolver = built_in_resolver.add_name("codemod:llm");
+    built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+
     built_in_resolver = built_in_resolver.add_name("codemod:workflow");
     built_in_loader = built_in_loader.with_module("codemod:workflow", WorkflowGlobalModule);
 
@@ -243,6 +249,7 @@ where
 
     // Capture metrics context and shared state context for use inside async block
     let metrics_context = options.metrics_context.clone();
+    let llm_runtime_context = LlmRuntimeContext::new(options.llm_request_handler.clone());
     let shared_state_context = options.shared_state_context.clone();
     let process_sandbox = options.process_sandbox.clone();
     let fs_sandbox = options.fs_sandbox.clone();
@@ -257,6 +264,12 @@ where
                 },
             })?;
         }
+
+        ctx.store_userdata(llm_runtime_context.clone()).map_err(|e| ExecutionError::Runtime {
+            source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                message: format!("Failed to store LlmRuntimeContext: {:?}", e),
+            },
+        })?;
 
         // Always store a SharedStateContext so codemod:workflow functions work
         ctx.store_userdata(shared_state_context.unwrap_or_default()).map_err(|e| ExecutionError::Runtime {
@@ -500,6 +513,7 @@ export default function transform(root) {
             target_directory: ".",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: Some(50), // 50ms timeout for faster test
             memory_limit: None,
@@ -560,6 +574,7 @@ export default function transform(root) {
             target_directory: ".",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -616,6 +631,7 @@ export default function transform(root, options) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -690,6 +706,7 @@ export default function transform(root) {
             target_directory: ".",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -767,6 +784,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -843,6 +861,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -920,6 +939,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -1019,6 +1039,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -1385,6 +1406,7 @@ export default function transform(root) {
                 target_directory: "/app",
                 semantic_provider: None,
                 metrics_context: None,
+                llm_request_handler: None,
                 shared_state_context: None,
                 timeout_ms: None,
                 memory_limit: None,
@@ -1456,6 +1478,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -1564,6 +1587,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -1655,6 +1679,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -1723,6 +1748,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,
@@ -1761,6 +1787,7 @@ export default function transform(root) {
             target_directory: "/app",
             semantic_provider: None,
             metrics_context: None,
+            llm_request_handler: None,
             shared_state_context: None,
             timeout_ms: None,
             memory_limit: None,

--- a/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
@@ -65,6 +65,10 @@ where
     // Track whether the caller opted into llrt's real-disk fs capability
     // so we know whether to install the curated fs below instead.
     let mut fs_capability_enabled = false;
+    let llm_capability_enabled = options
+        .capabilities
+        .as_ref()
+        .is_some_and(|capabilities| capabilities.contains(&LlrtSupportedModules::Fetch));
 
     // Set up built-in modules
     let mut module_builder = LlrtModuleBuilder::build();
@@ -113,8 +117,10 @@ where
     built_in_resolver = built_in_resolver.add_name("codemod:metrics");
     built_in_loader = built_in_loader.with_module("codemod:metrics", MetricsModule);
 
-    built_in_resolver = built_in_resolver.add_name("codemod:llm");
-    built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+    if llm_capability_enabled {
+        built_in_resolver = built_in_resolver.add_name("codemod:llm");
+        built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+    }
 
     // Register the curated `fs` / `fs/promises` modules when applicable.
     if curated_fs_target.is_some() {

--- a/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
+++ b/crates/codemod-sandbox/src/sandbox/engine/selector_engine.rs
@@ -2,6 +2,7 @@ use super::codemod_lang::CodemodLang;
 use super::curated_fs::{CuratedFsConfig, CuratedFsModule, CuratedFsPromisesModule};
 use super::quickjs_adapters::{QuickJSLoader, QuickJSResolver};
 use crate::ast_grep::AstGrepModule;
+use crate::llm::{LlmModule, LlmRuntimeContext};
 use crate::metrics::{MetricsContext, MetricsModule};
 use crate::sandbox::errors::ExecutionError;
 use crate::sandbox::resolvers::ModuleResolver;
@@ -112,6 +113,9 @@ where
     built_in_resolver = built_in_resolver.add_name("codemod:metrics");
     built_in_loader = built_in_loader.with_module("codemod:metrics", MetricsModule);
 
+    built_in_resolver = built_in_resolver.add_name("codemod:llm");
+    built_in_loader = built_in_loader.with_module("codemod:llm", LlmModule);
+
     // Register the curated `fs` / `fs/promises` modules when applicable.
     if curated_fs_target.is_some() {
         built_in_resolver = built_in_resolver.add_name("fs").add_name("fs/promises");
@@ -166,6 +170,12 @@ where
             .map_err(|e| ExecutionError::Runtime {
                 source: crate::sandbox::errors::RuntimeError::InitializationFailed {
                     message: format!("Failed to store MetricsContext: {:?}", e),
+                },
+            })?;
+        ctx.store_userdata(LlmRuntimeContext::default())
+            .map_err(|e| ExecutionError::Runtime {
+                source: crate::sandbox::errors::RuntimeError::InitializationFailed {
+                    message: format!("Failed to store LlmRuntimeContext: {:?}", e),
                 },
             })?;
 

--- a/crates/codemod-sandbox/tests/integration/semantic/fixtures/mod.rs
+++ b/crates/codemod-sandbox/tests/integration/semantic/fixtures/mod.rs
@@ -237,6 +237,7 @@ pub async fn run_test(config: TestConfig<'_>) -> Result<Option<String>, String> 
         capabilities: None,
         semantic_provider: provider,
         metrics_context: None,
+        llm_request_handler: None,
         shared_state_context: None,
         runtime_event_callback: None,
         cancellation_flag: None,

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -1,6 +1,6 @@
 use butterflow_models::schema::resolve_values_with_default;
 use codemod_ai::execute::{execute_ai_step, ExecuteAiStepConfig};
-use codemod_ai::llm::{generate as generate_llm, GenerateRequest};
+use codemod_ai::llm::{generate as generate_llm, GenerateError, GenerateRequest, GenerateResponse};
 use futures_util::FutureExt;
 use serde::Deserialize;
 use std::any::Any;
@@ -626,6 +626,26 @@ impl Default for Engine {
     }
 }
 
+fn record_llm_result(
+    usage_context: &LlmUsageContext,
+    configured_provider: &str,
+    configured_model: &str,
+    result: std::result::Result<GenerateResponse, GenerateError>,
+) -> std::result::Result<LlmResponse, String> {
+    match result {
+        Ok(response) => {
+            usage_context.record_success(&response.provider, &response.model, response.usage);
+            Ok(LlmResponse {
+                output: response.output,
+            })
+        }
+        Err(error) => {
+            usage_context.record_error(configured_provider, configured_model);
+            Err(error.to_string())
+        }
+    }
+}
+
 pub struct CapabilitiesData {
     pub capabilities: Option<Vec<LlrtSupportedModules>>,
     pub capabilities_security_callback: Option<CapabilitiesSecurityCallback>,
@@ -1146,22 +1166,7 @@ impl Engine {
                 })
                 .await;
 
-                match result {
-                    Ok(response) => {
-                        usage_context.record_success(
-                            &response.provider,
-                            &response.model,
-                            response.usage,
-                        );
-                        Ok(LlmResponse {
-                            output: response.output,
-                        })
-                    }
-                    Err(error) => {
-                        usage_context.record_error(&provider, &model);
-                        Err(error.to_string())
-                    }
-                }
+                record_llm_result(&usage_context, &provider, &model, result)
             })
         })
     }
@@ -4421,6 +4426,46 @@ author: test
         assert!(merged.contains(&LlrtSupportedModules::Fs));
         assert!(!merged.contains(&LlrtSupportedModules::ChildProcess));
         assert_eq!(merged.len(), 1);
+    }
+
+    #[test]
+    fn openai_compatible_success_and_error_share_one_provider_name() {
+        let usage_context = LlmUsageContext::new();
+
+        let response = record_llm_result(
+            &usage_context,
+            "openai_compatible",
+            "compatible-model",
+            Ok(GenerateResponse {
+                output: "welcomeTitle".to_string(),
+                provider: "openai_compatible".to_string(),
+                model: "compatible-model".to_string(),
+                usage: Some(codemod_ai::llm::TokenUsage {
+                    uncached_input_tokens: Some(10),
+                    cache_read_input_tokens: None,
+                    cache_write_input_tokens: None,
+                    output_tokens: Some(2),
+                    reasoning_tokens: None,
+                    total_tokens: Some(12),
+                }),
+            }),
+        )
+        .expect("successful response should be returned");
+        assert_eq!(response.output, "welcomeTitle");
+
+        record_llm_result(
+            &usage_context,
+            "openai_compatible",
+            "compatible-model",
+            Err(GenerateError::Request("rate limited".to_string())),
+        )
+        .expect_err("provider error should be returned");
+
+        let records = usage_context.get_all();
+        assert_eq!(records.len(), 2);
+        assert!(records
+            .iter()
+            .all(|record| record.provider == "openai_compatible"));
     }
 
     struct EnvVarGuard {

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -1,5 +1,6 @@
 use butterflow_models::schema::resolve_values_with_default;
 use codemod_ai::execute::{execute_ai_step, ExecuteAiStepConfig};
+use codemod_ai::llm::{generate as generate_llm, GenerateRequest};
 use futures_util::FutureExt;
 use serde::Deserialize;
 use std::any::Any;
@@ -33,6 +34,7 @@ use crate::execution::{CodemodExecutionConfig, ProgressCallback};
 use crate::execution_stats::ExecutionStats;
 use crate::file_ops::AsyncFileWriter;
 use crate::jssg_execution_service::{JssgExecutionRequest, JssgExecutionService};
+use crate::llm_usage::LlmUsageContext;
 use crate::managed_git_service::{ManagedGitService, WorktreeCleanup};
 use crate::nested_codemod_service::NestedCodemodService;
 use crate::progress_output::{
@@ -45,6 +47,7 @@ use crate::task_state_service::TaskStateService;
 use crate::utils::validate_workflow;
 use crate::workflow_runtime::{publish_event, WorkflowEvent};
 use chrono::Utc;
+use codemod_sandbox::llm::{LlmRequestHandler, LlmResponse};
 use codemod_sandbox::sandbox::engine::CodemodOutput;
 use codemod_sandbox::sandbox::runtime_module::{
     RuntimeEvent, RuntimeEventKind, RuntimeFailure, RuntimeFailureKind,
@@ -586,6 +589,9 @@ pub struct Engine {
     /// Metrics context for tracking metrics across all JSSG steps
     pub metrics_context: MetricsContext,
 
+    /// Provider-reported usage from engine-owned nested LLM calls
+    pub llm_usage_context: LlmUsageContext,
+
     /// Async file writer for batched I/O operations
     file_writer: Arc<AsyncFileWriter>,
 
@@ -1050,6 +1056,7 @@ impl Engine {
             workflow_run_config: WorkflowRunConfig::default(),
             execution_stats: Arc::new(ExecutionStats::default()),
             metrics_context: MetricsContext::new(),
+            llm_usage_context: LlmUsageContext::new(),
             file_writer: Arc::new(AsyncFileWriter::new()),
             task_completion_notify: Arc::new(Notify::new()),
             scheduler_wake_notify,
@@ -1078,6 +1085,7 @@ impl Engine {
             workflow_run_config,
             execution_stats: Arc::new(ExecutionStats::default()),
             metrics_context: MetricsContext::new(),
+            llm_usage_context: LlmUsageContext::new(),
             file_writer: Arc::new(AsyncFileWriter::new()),
             task_completion_notify: Arc::new(Notify::new()),
             scheduler_wake_notify,
@@ -1094,6 +1102,68 @@ impl Engine {
 
     pub(crate) fn workflow_run_config(&self) -> &WorkflowRunConfig {
         &self.workflow_run_config
+    }
+
+    pub(crate) fn llm_request_handler(&self) -> LlmRequestHandler {
+        let usage_context = self.llm_usage_context.clone();
+        let provider = std::env::var("LLM_PROVIDER")
+            .unwrap_or_else(|_| "openai".to_string())
+            .trim()
+            .to_ascii_lowercase();
+        let model = std::env::var("LLM_MODEL").unwrap_or_default();
+        let endpoint = std::env::var("LLM_BASE_URL").unwrap_or_else(|_| match provider.as_str() {
+            "anthropic" => "https://api.anthropic.com".to_string(),
+            _ => "https://api.openai.com/v1".to_string(),
+        });
+        let api_key = std::env::var("LLM_API_KEY").unwrap_or_default();
+
+        Arc::new(move |request| {
+            let usage_context = usage_context.clone();
+            let provider = provider.clone();
+            let model = model.clone();
+            let endpoint = endpoint.clone();
+            let api_key = api_key.clone();
+
+            Box::pin(async move {
+                if api_key.trim().is_empty() {
+                    usage_context.record_error(&provider, &model);
+                    return Err("Engine LLM client requires LLM_API_KEY".to_string());
+                }
+                if model.trim().is_empty() {
+                    usage_context.record_error(&provider, &model);
+                    return Err("Engine LLM client requires LLM_MODEL".to_string());
+                }
+
+                let result = generate_llm(GenerateRequest {
+                    endpoint,
+                    api_key,
+                    model: model.clone(),
+                    provider: provider.clone(),
+                    system_prompt: request.system_prompt,
+                    prompt: request.prompt,
+                    output_schema: request.output_schema,
+                    max_tokens: request.max_tokens,
+                })
+                .await;
+
+                match result {
+                    Ok(response) => {
+                        usage_context.record_success(
+                            &response.provider,
+                            &response.model,
+                            response.usage,
+                        );
+                        Ok(LlmResponse {
+                            output: response.output,
+                        })
+                    }
+                    Err(error) => {
+                        usage_context.record_error(&provider, &model);
+                        Err(error.to_string())
+                    }
+                }
+            })
+        })
     }
 
     pub(crate) fn state_adapter(&self) -> Arc<Mutex<Box<dyn StateAdapter>>> {
@@ -1127,6 +1197,7 @@ impl Engine {
             workflow_run_config,
             execution_stats: Arc::new(ExecutionStats::default()),
             metrics_context: MetricsContext::new(),
+            llm_usage_context: LlmUsageContext::new(),
             file_writer: Arc::new(AsyncFileWriter::new()),
             task_completion_notify: Arc::new(Notify::new()),
             scheduler_wake_notify,
@@ -4227,6 +4298,7 @@ impl Clone for Engine {
             workflow_run_config: self.workflow_run_config.clone(),
             execution_stats: Arc::clone(&self.execution_stats),
             metrics_context: self.metrics_context.clone(),
+            llm_usage_context: self.llm_usage_context.clone(),
             file_writer: Arc::clone(&self.file_writer),
             task_completion_notify: Arc::clone(&self.task_completion_notify),
             scheduler_wake_notify: Arc::clone(&self.scheduler_wake_notify),

--- a/crates/core/src/jssg_execution_service.rs
+++ b/crates/core/src/jssg_execution_service.rs
@@ -13,6 +13,7 @@ use butterflow_models::{
     DiffOperation, FieldDiff, Result, StateDiff, TaskExpressionContext,
 };
 use chrono::Utc;
+use codemod_llrt_capabilities::types::LlrtSupportedModules;
 use codemod_sandbox::sandbox::{
     engine::{
         codemod_lang::CodemodLang, execution_engine::execute_codemod_with_quickjs,
@@ -455,7 +456,11 @@ impl<'a> JssgExecutionService<'a> {
             SharedStateContext::new()
         };
         let metrics_context_clone = metrics_context.clone();
-        let llm_request_handler = self.engine.llm_request_handler();
+        let llm_request_handler = config
+            .capabilities
+            .as_ref()
+            .is_some_and(|capabilities| capabilities.contains(&LlrtSupportedModules::Fetch))
+            .then(|| self.engine.llm_request_handler());
         let shared_state_context_clone = shared_state_context.clone();
         let logger = request.logger.clone();
         let modified_files_collector_clone = request.modified_files_collector.clone();
@@ -792,7 +797,7 @@ impl<'a> JssgExecutionService<'a> {
                                         capabilities: capabilities_owned,
                                         semantic_provider: semantic_provider_owned,
                                         metrics_context: Some(metrics_context_owned),
-                                        llm_request_handler: Some(llm_request_handler_owned),
+                                        llm_request_handler: llm_request_handler_owned,
                                         shared_state_context: Some(shared_state_context_owned),
                                         runtime_event_callback: Some(runtime_event_callback),
                                         cancellation_flag: Some(cancellation_flag_for_execution),

--- a/crates/core/src/jssg_execution_service.rs
+++ b/crates/core/src/jssg_execution_service.rs
@@ -455,6 +455,7 @@ impl<'a> JssgExecutionService<'a> {
             SharedStateContext::new()
         };
         let metrics_context_clone = metrics_context.clone();
+        let llm_request_handler = self.engine.llm_request_handler();
         let shared_state_context_clone = shared_state_context.clone();
         let logger = request.logger.clone();
         let modified_files_collector_clone = request.modified_files_collector.clone();
@@ -769,6 +770,7 @@ impl<'a> JssgExecutionService<'a> {
                         let capabilities_owned = config.capabilities.clone();
                         let semantic_provider_owned = semantic_provider.clone();
                         let metrics_context_owned = metrics_context_clone.clone();
+                        let llm_request_handler_owned = llm_request_handler.clone();
                         let shared_state_context_owned = shared_state_context_clone.clone();
                         let target_path_owned = target_path.clone();
                         let idle_timed_out = Arc::clone(&idle_timed_out_for_closure);
@@ -790,6 +792,7 @@ impl<'a> JssgExecutionService<'a> {
                                         capabilities: capabilities_owned,
                                         semantic_provider: semantic_provider_owned,
                                         metrics_context: Some(metrics_context_owned),
+                                        llm_request_handler: Some(llm_request_handler_owned),
                                         shared_state_context: Some(shared_state_context_owned),
                                         runtime_event_callback: Some(runtime_event_callback),
                                         cancellation_flag: Some(cancellation_flag_for_execution),

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod execution_stats;
 pub mod file_ops;
 pub mod git_ops;
 pub(crate) mod jssg_execution_service;
+pub mod llm_usage;
 pub(crate) mod managed_git_service;
 pub(crate) mod nested_codemod_service;
 pub(crate) mod progress_output;

--- a/crates/core/src/llm_usage.rs
+++ b/crates/core/src/llm_usage.rs
@@ -1,0 +1,111 @@
+pub use codemod_ai::llm::TokenUsage;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlmRequestOutcome {
+    Success,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LlmUsageRecord {
+    pub provider: String,
+    pub model: String,
+    pub outcome: LlmRequestOutcome,
+    pub usage: Option<TokenUsage>,
+}
+
+#[derive(Clone, Default)]
+pub struct LlmUsageContext {
+    records: Arc<Mutex<Vec<LlmUsageRecord>>>,
+}
+
+impl std::fmt::Debug for LlmUsageContext {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("LlmUsageContext")
+            .field("records", &self.get_all())
+            .finish()
+    }
+}
+
+impl LlmUsageContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_success(
+        &self,
+        provider: impl Into<String>,
+        model: impl Into<String>,
+        usage: Option<TokenUsage>,
+    ) {
+        self.record(LlmUsageRecord {
+            provider: provider.into(),
+            model: model.into(),
+            outcome: LlmRequestOutcome::Success,
+            usage,
+        });
+    }
+
+    pub fn record_error(&self, provider: impl Into<String>, model: impl Into<String>) {
+        self.record(LlmUsageRecord {
+            provider: provider.into(),
+            model: model.into(),
+            outcome: LlmRequestOutcome::Error,
+            usage: None,
+        });
+    }
+
+    pub fn get_all(&self) -> Vec<LlmUsageRecord> {
+        self.records
+            .lock()
+            .map(|records| records.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.records
+            .lock()
+            .map(|records| records.is_empty())
+            .unwrap_or(true)
+    }
+
+    fn record(&self, record: LlmUsageRecord) {
+        if let Ok(mut records) = self.records.lock() {
+            records.push(record);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clone_shares_usage_records() {
+        let context = LlmUsageContext::new();
+        let clone = context.clone();
+
+        clone.record_success(
+            "anthropic",
+            "claude-test",
+            Some(TokenUsage {
+                uncached_input_tokens: Some(10),
+                cache_read_input_tokens: Some(4),
+                cache_write_input_tokens: Some(2),
+                output_tokens: Some(3),
+                reasoning_tokens: None,
+                total_tokens: Some(19),
+            }),
+        );
+        context.record_error("openai", "gpt-test");
+
+        let records = context.get_all();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].provider, "anthropic");
+        assert_eq!(records[1].outcome, LlmRequestOutcome::Error);
+    }
+}

--- a/crates/mcp/src/handlers/jssg_test.rs
+++ b/crates/mcp/src/handlers/jssg_test.rs
@@ -316,6 +316,7 @@ impl JssgTestHandler {
                         capabilities: capabilities.clone(),
                         semantic_provider: None,
                         metrics_context: Some(metrics_context),
+                        llm_request_handler: None,
                         shared_state_context: None,
                         runtime_event_callback: None,
                         cancellation_flag: None,

--- a/packages/jssg-types/package.json
+++ b/packages/jssg-types/package.json
@@ -26,6 +26,10 @@
       "types": "./src/langs/*.d.ts",
       "default": "./src/langs/*.d.ts"
     },
+    "./llm": {
+      "types": "./src/llm.d.ts",
+      "default": "./src/llm.d.ts"
+    },
     "./main": {
       "types": "./src/main.d.ts",
       "default": "./src/main.d.ts"

--- a/packages/jssg-types/src/index.d.ts
+++ b/packages/jssg-types/src/index.d.ts
@@ -1,6 +1,7 @@
 // oxlint-disable triple-slash-reference
 /// <reference path="llrt/index.d.ts" />
 /// <reference path="modules/ast-grep.d.ts" />
+/// <reference path="modules/llm.d.ts" />
 /// <reference path="modules/metrics.d.ts" />
 /// <reference path="modules/runtime.d.ts" />
 /// <reference path="modules/workflow.d.ts" />

--- a/packages/jssg-types/src/llm.d.ts
+++ b/packages/jssg-types/src/llm.d.ts
@@ -1,0 +1,5 @@
+// oxlint-disable triple-slash-reference
+/// <reference path="modules/llm.d.ts" />
+
+export type { LlmRequest, LlmResponse } from "codemod:llm";
+export { default, generate } from "codemod:llm";

--- a/packages/jssg-types/src/modules/llm.d.ts
+++ b/packages/jssg-types/src/modules/llm.d.ts
@@ -1,0 +1,23 @@
+declare module "codemod:llm" {
+  export interface LlmRequest {
+    prompt: string;
+    systemPrompt?: string;
+    outputSchema?: Record<string, unknown> | boolean;
+    maxTokens?: number;
+  }
+
+  export interface LlmResponse {
+    output: string;
+  }
+
+  /**
+   * Generate text through the engine-owned LLM client.
+   *
+   * Provider credentials and model selection come from the engine. The engine
+   * records provider-reported usage automatically; codemods never submit usage
+   * telemetry themselves.
+   */
+  export function generate(request: LlmRequest): Promise<LlmResponse>;
+
+  export default generate;
+}

--- a/packages/jssg-types/src/modules/llm.d.ts
+++ b/packages/jssg-types/src/modules/llm.d.ts
@@ -15,7 +15,7 @@ declare module "codemod:llm" {
    *
    * Provider credentials and model selection come from the engine. The engine
    * records provider-reported usage automatically; codemods never submit usage
-   * telemetry themselves.
+   * telemetry themselves. The codemod must declare the `fetch` capability.
    */
   export function generate(request: LlmRequest): Promise<LlmResponse>;
 


### PR DESCRIPTION
#### 📚 Description

Adds an engine-owned `codemod:llm` module backed by Rig for OpenAI and Anthropic.

The engine now records provider-reported token usage for nested codemod model calls. `codemod run --llm-usage-output <path>` writes that usage to a separate JSON file without adding noise to normal CLI output.

We need this for the codemod benchmark. Harbor measures the main Codex or Claude Code session, but it cannot see model calls made inside an AI-assisted codemod. This change lets us compare agent-only and codemod-assisted runs using complete usage data, without adding benchmark-specific tracking to each codemod.

A patch changeset ensures the updated `@codemod.com/jssg-types` package is released.

#### 🔗 Linked Issue

- Related to CDMD-4868

#### 🧪 Test Plan

- `cargo fmt --all --check`
- `cargo test -p codemod-ai llm`
- `cargo test -p butterflow-core llm_usage`
- `cargo test -p codemod llm_usage`
- `cargo test -p codemod-sandbox llm`
- `pnpm --filter @codemod.com/jssg-types typecheck`
- `pnpm changeset status`
- Verified OpenAI and Anthropic responses with local mock servers; no paid requests.

#### 📄 Documentation to Update

The runtime type declarations document `codemod:llm`. Benchmark usage will be documented in the benchmark repository after this is released.
