### PR TITLE
fix(cli): allow publishing codemod llm imports

### DIFF
--- a/crates/cli/src/commands/publish.rs
+++ b/crates/cli/src/commands/publish.rs
@@ -1059,8 +1059,9 @@ import { format } from "node:util";
 import path from "path";
 import { readFile } from "fs/promises";
 import { parse } from "codemod:ast-grep";
+import { generate } from "codemod:llm";
 export default function transform() {
-  return [format("%s", "ok"), path.sep, readFile, parse];
+  return [format("%s", "ok"), path.sep, readFile, parse, generate];
 }
 "#,
         )
@@ -1074,5 +1075,6 @@ export default function transform() {
         assert!(bundled.contains("path"));
         assert!(bundled.contains("fs/promises"));
         assert!(bundled.contains("codemod:ast-grep"));
+        assert!(bundled.contains("codemod:llm"));
     }
 }

--- a/crates/llrt-capabilities/src/module_builder.rs
+++ b/crates/llrt-capabilities/src/module_builder.rs
@@ -12,6 +12,7 @@ pub const CODEMOD_RUNTIME_MODULES: &[&str] = &[
     "codemod:workflow",
     "codemod:metrics",
     "codemod:runtime",
+    "codemod:llm",
 ];
 
 const LLRT_RUNTIME_MODULES: &[&str] = &[


### PR DESCRIPTION
#### 📚 Description

Allow the publish bundler to keep `codemod:llm` as an engine-provided external module.

The runtime already supports this module, but the publish allowlist did not include it. As a result, codemods using the engine-owned LLM client—such as the i18n benchmark treatment—worked locally but failed before upload with an unresolved import.

Runtime capability enforcement is unchanged; `codemod:llm` still requires the `fetch` capability.

#### 🧪 Test Plan

- `cargo fmt --check`
- `cargo test -p codemod commands::publish::tests`
- `cargo test -p codemod-llrt-capabilities`
- `cargo clippy -p codemod -p codemod-llrt-capabilities --tests --no-deps -- -D warnings`

The publish bundling test now imports and preserves `codemod:llm`.

#### 📄 Documentation to Update

None.
