### PR TITLE
fix(cli): count nested codemod runs

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod package_skill;
 pub mod publish;
 pub mod run;
 mod run_telemetry;
+pub(crate) use run_telemetry::nested_codemod_run_observer;
 pub mod search;
 pub mod unpublish;
 pub mod whoami;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -16,7 +16,7 @@ pub mod package_skill;
 pub mod publish;
 pub mod run;
 mod run_telemetry;
-pub(crate) use run_telemetry::nested_codemod_run_observer;
+pub(crate) use run_telemetry::{nested_codemod_run_observer, persisted_workflow_root_name};
 pub mod search;
 pub mod unpublish;
 pub mod whoami;

--- a/crates/cli/src/commands/run.rs
+++ b/crates/cli/src/commands/run.rs
@@ -1,6 +1,6 @@
 use crate::commands::run_telemetry::{
     send_completed_event, send_event as send_telemetry_event, send_started_event,
-    send_success_events, CodemodRunOutcome, CodemodRunTelemetry,
+    send_success_events, CodemodRunOutcome, CodemodRunStats, CodemodRunTelemetry,
 };
 use crate::engine::{create_engine, create_registry_client};
 use crate::pro_dry_run::{
@@ -370,6 +370,10 @@ pub async fn handler(
         selected_workflow_name.clone(),
         dry_run,
     );
+    engine
+        .workflow_run_config_mut()
+        .execution
+        .nested_codemod_run_observer = Some(run_telemetry.nested_observer(telemetry.clone()));
     let setup_duration = setup_started.elapsed();
     send_started_event(&telemetry, &run_telemetry).await;
 
@@ -439,12 +443,11 @@ pub async fn handler(
     send_success_events(
         &telemetry,
         &run_telemetry,
-        CodemodRunOutcome::Succeeded {
+        Some(CodemodRunStats {
             files_modified,
             files_unmodified,
             files_with_errors,
-        },
-        files_modified,
+        }),
         duration_ms,
     )
     .await;

--- a/crates/cli/src/commands/run_telemetry.rs
+++ b/crates/cli/src/commands/run_telemetry.rs
@@ -1,7 +1,11 @@
 use crate::commands::TelemetrySenderExt;
 use crate::{TelemetrySenderMutex, CLI_VERSION};
+use butterflow_core::nested_codemod_run::{
+    NestedCodemodRun, NestedCodemodRunEvent, NestedCodemodRunObserver, NestedCodemodRunOutcome,
+};
 use codemod_telemetry::send_event::BaseEvent;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub(super) struct CodemodRunTelemetry {
     codemod_name: String,
@@ -9,17 +13,25 @@ pub(super) struct CodemodRunTelemetry {
     execution_id: String,
     workflow_name: Option<String>,
     dry_run: bool,
+    nested: Option<NestedRunProperties>,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct CodemodRunStats {
+    pub(super) files_modified: usize,
+    pub(super) files_unmodified: usize,
+    pub(super) files_with_errors: usize,
 }
 
 pub(super) enum CodemodRunOutcome {
-    Succeeded {
-        files_modified: usize,
-        files_unmodified: usize,
-        files_with_errors: usize,
-    },
-    Failed {
-        error_message: String,
-    },
+    Succeeded { stats: Option<CodemodRunStats> },
+    Failed { error_message: String },
+}
+
+struct NestedRunProperties {
+    root_execution_id: String,
+    root_codemod_name: String,
+    dependency_path: Vec<String>,
 }
 
 impl CodemodRunTelemetry {
@@ -36,7 +48,40 @@ impl CodemodRunTelemetry {
             execution_id,
             workflow_name,
             dry_run,
+            nested: None,
         }
+    }
+
+    fn for_nested(
+        run: &NestedCodemodRun,
+        root_execution_id: String,
+        root_codemod_name: String,
+        dry_run: bool,
+    ) -> Self {
+        Self {
+            codemod_name: run.codemod_name.clone(),
+            package_version: run.package_version.clone(),
+            execution_id: run.execution_id.clone(),
+            workflow_name: None,
+            dry_run,
+            nested: Some(NestedRunProperties {
+                root_execution_id,
+                root_codemod_name,
+                dependency_path: run.dependency_path.clone(),
+            }),
+        }
+    }
+
+    pub(super) fn nested_observer(
+        &self,
+        telemetry: TelemetrySenderMutex,
+    ) -> Arc<dyn NestedCodemodRunObserver> {
+        nested_codemod_run_observer(
+            telemetry,
+            self.execution_id.clone(),
+            self.codemod_name.clone(),
+            self.dry_run,
+        )
     }
 
     fn common_properties(&self) -> HashMap<String, String> {
@@ -48,9 +93,36 @@ impl CodemodRunTelemetry {
             ("cliVersion".to_string(), CLI_VERSION.to_string()),
             ("os".to_string(), std::env::consts::OS.to_string()),
             ("arch".to_string(), std::env::consts::ARCH.to_string()),
+            ("isNested".to_string(), self.nested.is_some().to_string()),
         ]);
         if let Some(workflow_name) = &self.workflow_name {
             properties.insert("workflowName".to_string(), workflow_name.clone());
+        }
+        if let Some(nested) = &self.nested {
+            properties.insert(
+                "rootExecutionId".to_string(),
+                nested.root_execution_id.clone(),
+            );
+            properties.insert(
+                "rootCodemodName".to_string(),
+                nested.root_codemod_name.clone(),
+            );
+            properties.insert(
+                "dependencyDepth".to_string(),
+                nested.dependency_path.len().to_string(),
+            );
+            properties.insert(
+                "dependencyPath".to_string(),
+                nested.dependency_path.join(" > "),
+            );
+            let parent_codemod_name = nested
+                .dependency_path
+                .iter()
+                .rev()
+                .nth(1)
+                .cloned()
+                .unwrap_or_else(|| nested.root_codemod_name.clone());
+            properties.insert("parentCodemodName".to_string(), parent_codemod_name);
         }
         properties
     }
@@ -66,15 +138,22 @@ impl CodemodRunTelemetry {
         let mut properties = self.common_properties();
         properties.insert("durationMs".to_string(), duration_ms.to_string());
         match outcome {
-            CodemodRunOutcome::Succeeded {
-                files_modified,
-                files_unmodified,
-                files_with_errors,
-            } => {
+            CodemodRunOutcome::Succeeded { stats } => {
                 properties.insert("outcome".to_string(), "succeeded".to_string());
-                properties.insert("filesModified".to_string(), files_modified.to_string());
-                properties.insert("filesUnmodified".to_string(), files_unmodified.to_string());
-                properties.insert("filesWithErrors".to_string(), files_with_errors.to_string());
+                if let Some(stats) = stats {
+                    properties.insert(
+                        "filesModified".to_string(),
+                        stats.files_modified.to_string(),
+                    );
+                    properties.insert(
+                        "filesUnmodified".to_string(),
+                        stats.files_unmodified.to_string(),
+                    );
+                    properties.insert(
+                        "filesWithErrors".to_string(),
+                        stats.files_with_errors.to_string(),
+                    );
+                }
             }
             CodemodRunOutcome::Failed { error_message } => {
                 properties.insert("outcome".to_string(), "failed".to_string());
@@ -87,9 +166,15 @@ impl CodemodRunTelemetry {
         }
     }
 
-    fn legacy_executed_event(&self, files_modified: usize, duration_ms: u128) -> BaseEvent {
+    fn legacy_executed_event(
+        &self,
+        stats: Option<CodemodRunStats>,
+        duration_ms: u128,
+    ) -> BaseEvent {
         let mut properties = self.common_properties();
-        properties.insert("fileCount".to_string(), files_modified.to_string());
+        if let Some(stats) = stats {
+            properties.insert("fileCount".to_string(), stats.files_modified.to_string());
+        }
         properties.insert("durationMs".to_string(), duration_ms.to_string());
         BaseEvent {
             kind: "codemodExecuted".to_string(),
@@ -125,17 +210,86 @@ pub(super) async fn send_completed_event(
 pub(super) async fn send_success_events(
     telemetry: &TelemetrySenderMutex,
     run_telemetry: &CodemodRunTelemetry,
-    outcome: CodemodRunOutcome,
-    files_modified: usize,
+    stats: Option<CodemodRunStats>,
     duration_ms: u128,
 ) {
     tokio::join!(
         send_event(
             telemetry,
-            run_telemetry.legacy_executed_event(files_modified, duration_ms),
+            run_telemetry.legacy_executed_event(stats, duration_ms),
         ),
-        send_completed_event(telemetry, run_telemetry, outcome, duration_ms),
+        send_completed_event(
+            telemetry,
+            run_telemetry,
+            CodemodRunOutcome::Succeeded { stats },
+            duration_ms,
+        ),
     );
+}
+
+pub(crate) fn nested_codemod_run_observer(
+    telemetry: TelemetrySenderMutex,
+    root_execution_id: String,
+    root_codemod_name: String,
+    dry_run: bool,
+) -> Arc<dyn NestedCodemodRunObserver> {
+    Arc::new(NestedCodemodTelemetryObserver {
+        telemetry,
+        root_execution_id,
+        root_codemod_name,
+        dry_run,
+    })
+}
+
+struct NestedCodemodTelemetryObserver {
+    telemetry: TelemetrySenderMutex,
+    root_execution_id: String,
+    root_codemod_name: String,
+    dry_run: bool,
+}
+
+impl NestedCodemodTelemetryObserver {
+    fn run_telemetry(&self, run: &NestedCodemodRun) -> CodemodRunTelemetry {
+        CodemodRunTelemetry::for_nested(
+            run,
+            self.root_execution_id.clone(),
+            self.root_codemod_name.clone(),
+            self.dry_run,
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl NestedCodemodRunObserver for NestedCodemodTelemetryObserver {
+    async fn record(&self, event: NestedCodemodRunEvent) {
+        match event {
+            NestedCodemodRunEvent::Started(run) => {
+                send_started_event(&self.telemetry, &self.run_telemetry(&run)).await;
+            }
+            NestedCodemodRunEvent::Completed {
+                run,
+                outcome,
+                duration_ms,
+            } => {
+                let run_telemetry = self.run_telemetry(&run);
+                match outcome {
+                    NestedCodemodRunOutcome::Succeeded => {
+                        send_success_events(&self.telemetry, &run_telemetry, None, duration_ms)
+                            .await;
+                    }
+                    NestedCodemodRunOutcome::Failed { error_message } => {
+                        send_completed_event(
+                            &self.telemetry,
+                            &run_telemetry,
+                            CodemodRunOutcome::Failed { error_message },
+                            duration_ms,
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -174,9 +328,11 @@ mod tests {
         let started = telemetry.started_event();
         let completed = telemetry.completed_event(
             CodemodRunOutcome::Succeeded {
-                files_modified: 4,
-                files_unmodified: 2,
-                files_with_errors: 0,
+                stats: Some(CodemodRunStats {
+                    files_modified: 4,
+                    files_unmodified: 2,
+                    files_with_errors: 0,
+                }),
             },
             1250,
         );
@@ -201,6 +357,10 @@ mod tests {
             assert_eq!(
                 event.properties.get("dryRun").map(String::as_str),
                 Some("true")
+            );
+            assert_eq!(
+                event.properties.get("isNested").map(String::as_str),
+                Some("false")
             );
         }
         assert_eq!(started.kind, "codemodRunStarted");
@@ -254,12 +414,11 @@ mod tests {
         send_success_events(
             &sender,
             &telemetry,
-            CodemodRunOutcome::Succeeded {
+            Some(CodemodRunStats {
                 files_modified: 1,
                 files_unmodified: 0,
                 files_with_errors: 0,
-            },
-            1,
+            }),
             10,
         )
         .await;
@@ -280,5 +439,197 @@ mod tests {
                 .expect("telemetry event");
             assert!(position < report_position);
         }
+    }
+
+    struct RecordingEventSender {
+        events: Arc<Mutex<Vec<BaseEvent>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl TelemetrySender for RecordingEventSender {
+        async fn send_event(
+            &self,
+            event: BaseEvent,
+            _options_override: Option<PartialTelemetrySenderOptions>,
+        ) {
+            self.events.lock().expect("events lock").push(event);
+        }
+
+        async fn initialize_panic_telemetry(&self) {}
+    }
+
+    fn nested_run() -> NestedCodemodRun {
+        NestedCodemodRun {
+            codemod_name: "@codemod/child-b".to_string(),
+            package_version: "2.0.0".to_string(),
+            execution_id: "child-execution".to_string(),
+            dependency_path: vec![
+                "@codemod/child-a".to_string(),
+                "@codemod/child-b".to_string(),
+            ],
+        }
+    }
+
+    #[test]
+    fn direct_child_uses_root_codemod_as_parent() {
+        let mut run = nested_run();
+        run.dependency_path = vec!["@codemod/child-b".to_string()];
+        let event = CodemodRunTelemetry::for_nested(
+            &run,
+            "root-execution".to_string(),
+            "@codemod/root".to_string(),
+            false,
+        )
+        .started_event();
+
+        assert_eq!(
+            event
+                .properties
+                .get("parentCodemodName")
+                .map(String::as_str),
+            Some("@codemod/root")
+        );
+        assert_eq!(
+            event.properties.get("dependencyDepth").map(String::as_str),
+            Some("1")
+        );
+    }
+
+    #[tokio::test]
+    async fn nested_success_emits_correlated_run_events_without_invented_file_counts() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sender: TelemetrySenderMutex = Arc::new(Box::new(RecordingEventSender {
+            events: Arc::clone(&events),
+        }));
+        let observer = nested_codemod_run_observer(
+            sender,
+            "root-execution".to_string(),
+            "@codemod/root".to_string(),
+            true,
+        );
+        let run = nested_run();
+
+        observer
+            .record(NestedCodemodRunEvent::Started(run.clone()))
+            .await;
+        observer
+            .record(NestedCodemodRunEvent::Completed {
+                run,
+                outcome: NestedCodemodRunOutcome::Succeeded,
+                duration_ms: 250,
+            })
+            .await;
+
+        let events = events.lock().expect("events lock");
+        assert_eq!(events.len(), 3);
+        for kind in [
+            "codemodRunStarted",
+            "codemodExecuted",
+            "codemodRunCompleted",
+        ] {
+            let event = events
+                .iter()
+                .find(|event| event.kind == kind)
+                .expect("nested telemetry event");
+            assert_eq!(
+                event.properties.get("codemodName").map(String::as_str),
+                Some("@codemod/child-b")
+            );
+            assert_eq!(
+                event.properties.get("executionId").map(String::as_str),
+                Some("child-execution")
+            );
+            assert_eq!(
+                event.properties.get("isNested").map(String::as_str),
+                Some("true")
+            );
+            assert_eq!(
+                event.properties.get("rootExecutionId").map(String::as_str),
+                Some("root-execution")
+            );
+            assert_eq!(
+                event.properties.get("rootCodemodName").map(String::as_str),
+                Some("@codemod/root")
+            );
+            assert_eq!(
+                event
+                    .properties
+                    .get("parentCodemodName")
+                    .map(String::as_str),
+                Some("@codemod/child-a")
+            );
+            assert_eq!(
+                event.properties.get("dependencyDepth").map(String::as_str),
+                Some("2")
+            );
+            assert_eq!(
+                event.properties.get("dependencyPath").map(String::as_str),
+                Some("@codemod/child-a > @codemod/child-b")
+            );
+            assert_eq!(
+                event.properties.get("dryRun").map(String::as_str),
+                Some("true")
+            );
+        }
+
+        let executed = events
+            .iter()
+            .find(|event| event.kind == "codemodExecuted")
+            .expect("legacy nested event");
+        assert!(!executed.properties.contains_key("fileCount"));
+
+        let completed = events
+            .iter()
+            .find(|event| event.kind == "codemodRunCompleted")
+            .expect("nested completion event");
+        assert_eq!(
+            completed.properties.get("outcome").map(String::as_str),
+            Some("succeeded")
+        );
+        assert!(!completed.properties.contains_key("filesModified"));
+    }
+
+    #[tokio::test]
+    async fn nested_failure_emits_failed_completion_without_legacy_success_event() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sender: TelemetrySenderMutex = Arc::new(Box::new(RecordingEventSender {
+            events: Arc::clone(&events),
+        }));
+        let observer = nested_codemod_run_observer(
+            sender,
+            "root-execution".to_string(),
+            "@codemod/root".to_string(),
+            false,
+        );
+        let run = nested_run();
+
+        observer
+            .record(NestedCodemodRunEvent::Started(run.clone()))
+            .await;
+        observer
+            .record(NestedCodemodRunEvent::Completed {
+                run,
+                outcome: NestedCodemodRunOutcome::Failed {
+                    error_message: "child failed".to_string(),
+                },
+                duration_ms: 50,
+            })
+            .await;
+
+        let events = events.lock().expect("events lock");
+        assert_eq!(events.len(), 2);
+        assert!(events.iter().all(|event| event.kind != "codemodExecuted"));
+        let completed = events
+            .iter()
+            .find(|event| event.kind == "codemodRunCompleted")
+            .expect("nested completion event");
+        assert_eq!(
+            completed.properties.get("outcome").map(String::as_str),
+            Some("failed")
+        );
+        assert_eq!(
+            completed.properties.get("errorMessage").map(String::as_str),
+            Some("child failed")
+        );
     }
 }

--- a/crates/cli/src/commands/run_telemetry.rs
+++ b/crates/cli/src/commands/run_telemetry.rs
@@ -3,6 +3,7 @@ use crate::{TelemetrySenderMutex, CLI_VERSION};
 use butterflow_core::nested_codemod_run::{
     NestedCodemodRun, NestedCodemodRunEvent, NestedCodemodRunObserver, NestedCodemodRunOutcome,
 };
+use butterflow_models::WorkflowRun;
 use codemod_telemetry::send_event::BaseEvent;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -12,7 +13,7 @@ pub(super) struct CodemodRunTelemetry {
     package_version: String,
     execution_id: String,
     workflow_name: Option<String>,
-    dry_run: bool,
+    dry_run: Option<bool>,
     nested: Option<NestedRunProperties>,
 }
 
@@ -47,7 +48,7 @@ impl CodemodRunTelemetry {
             package_version,
             execution_id,
             workflow_name,
-            dry_run,
+            dry_run: Some(dry_run),
             nested: None,
         }
     }
@@ -56,7 +57,7 @@ impl CodemodRunTelemetry {
         run: &NestedCodemodRun,
         root_execution_id: String,
         root_codemod_name: String,
-        dry_run: bool,
+        dry_run: Option<bool>,
     ) -> Self {
         Self {
             codemod_name: run.codemod_name.clone(),
@@ -89,12 +90,14 @@ impl CodemodRunTelemetry {
             ("codemodName".to_string(), self.codemod_name.clone()),
             ("packageVersion".to_string(), self.package_version.clone()),
             ("executionId".to_string(), self.execution_id.clone()),
-            ("dryRun".to_string(), self.dry_run.to_string()),
             ("cliVersion".to_string(), CLI_VERSION.to_string()),
             ("os".to_string(), std::env::consts::OS.to_string()),
             ("arch".to_string(), std::env::consts::ARCH.to_string()),
             ("isNested".to_string(), self.nested.is_some().to_string()),
         ]);
+        if let Some(dry_run) = self.dry_run {
+            properties.insert("dryRun".to_string(), dry_run.to_string());
+        }
         if let Some(workflow_name) = &self.workflow_name {
             properties.insert("workflowName".to_string(), workflow_name.clone());
         }
@@ -231,21 +234,40 @@ pub(crate) fn nested_codemod_run_observer(
     telemetry: TelemetrySenderMutex,
     root_execution_id: String,
     root_codemod_name: String,
-    dry_run: bool,
+    dry_run: impl Into<Option<bool>>,
 ) -> Arc<dyn NestedCodemodRunObserver> {
     Arc::new(NestedCodemodTelemetryObserver {
         telemetry,
         root_execution_id,
         root_codemod_name,
-        dry_run,
+        dry_run: dry_run.into(),
     })
+}
+
+pub(crate) fn persisted_workflow_root_name(workflow_run: &WorkflowRun) -> String {
+    workflow_run
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            workflow_run
+                .bundle_path
+                .as_deref()
+                .and_then(|path| path.file_name())
+                .and_then(|name| name.to_str())
+                .filter(|name| !name.is_empty())
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| format!("workflow:{}", workflow_run.id))
 }
 
 struct NestedCodemodTelemetryObserver {
     telemetry: TelemetrySenderMutex,
     root_execution_id: String,
     root_codemod_name: String,
-    dry_run: bool,
+    dry_run: Option<bool>,
 }
 
 impl NestedCodemodTelemetryObserver {
@@ -295,8 +317,12 @@ impl NestedCodemodRunObserver for NestedCodemodTelemetryObserver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use butterflow_models::{workflow::Workflow, WorkflowStatus};
+    use chrono::Utc;
     use codemod_telemetry::send_event::{PartialTelemetrySenderOptions, TelemetrySender};
+    use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
+    use uuid::Uuid;
 
     struct RecordingTelemetrySender {
         events: Arc<Mutex<Vec<String>>>,
@@ -470,6 +496,54 @@ mod tests {
         }
     }
 
+    fn persisted_workflow_run(
+        id: Uuid,
+        name: Option<&str>,
+        bundle_path: Option<&str>,
+    ) -> WorkflowRun {
+        WorkflowRun {
+            id,
+            workflow: Workflow {
+                version: "1".to_string(),
+                state: None,
+                params: None,
+                templates: vec![],
+                nodes: vec![],
+            },
+            status: WorkflowStatus::Running,
+            params: Default::default(),
+            tasks: vec![],
+            started_at: Utc::now(),
+            ended_at: None,
+            bundle_path: bundle_path.map(PathBuf::from),
+            capabilities: None,
+            name: name.map(str::to_owned),
+            target_path: None,
+        }
+    }
+
+    #[test]
+    fn persisted_workflow_name_uses_name_then_bundle_basename_then_id() {
+        let run_id = Uuid::new_v4();
+
+        let named = persisted_workflow_run(
+            run_id,
+            Some("  persisted migration  "),
+            Some("/private/source/bundle-name"),
+        );
+        assert_eq!(persisted_workflow_root_name(&named), "persisted migration");
+
+        let bundled =
+            persisted_workflow_run(run_id, Some("   "), Some("/private/source/bundle-name"));
+        assert_eq!(persisted_workflow_root_name(&bundled), "bundle-name");
+
+        let anonymous = persisted_workflow_run(run_id, None, None);
+        assert_eq!(
+            persisted_workflow_root_name(&anonymous),
+            format!("workflow:{run_id}")
+        );
+    }
+
     #[test]
     fn direct_child_uses_root_codemod_as_parent() {
         let mut run = nested_run();
@@ -478,7 +552,7 @@ mod tests {
             &run,
             "root-execution".to_string(),
             "@codemod/root".to_string(),
-            false,
+            Some(false),
         )
         .started_event();
 
@@ -493,6 +567,37 @@ mod tests {
             event.properties.get("dependencyDepth").map(String::as_str),
             Some("1")
         );
+    }
+
+    #[tokio::test]
+    async fn nested_run_omits_dry_run_when_attach_context_is_unknown() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let sender: TelemetrySenderMutex = Arc::new(Box::new(RecordingEventSender {
+            events: Arc::clone(&events),
+        }));
+        let observer = nested_codemod_run_observer(
+            sender,
+            "root-execution".to_string(),
+            "@codemod/root".to_string(),
+            None,
+        );
+
+        observer
+            .record(NestedCodemodRunEvent::Started(nested_run()))
+            .await;
+        observer
+            .record(NestedCodemodRunEvent::Completed {
+                run: nested_run(),
+                outcome: NestedCodemodRunOutcome::Succeeded,
+                duration_ms: 10,
+            })
+            .await;
+
+        let events = events.lock().expect("events lock");
+        assert_eq!(events.len(), 3);
+        assert!(events
+            .iter()
+            .all(|event| !event.properties.contains_key("dryRun")));
     }
 
     #[tokio::test]

--- a/crates/cli/src/commands/workflow/resume.rs
+++ b/crates/cli/src/commands/workflow/resume.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use crate::commands::run_telemetry::nested_codemod_run_observer;
 use crate::engine::create_engine;
 use crate::utils::path_safety::normalize_target_path;
 use crate::utils::resolve_capabilities::{resolve_capabilities, ResolveCapabilitiesArgs};
@@ -116,7 +117,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         .parse()
         .map_err(|e: String| anyhow::anyhow!(e))?;
 
-    let (engine, _) = create_engine(
+    let (mut engine, _) = create_engine(
         workflow_file_path,
         target_path,
         args.dry_run,
@@ -131,8 +132,17 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         output_format,
         None,
         None,
-        Some(crate::commands::package_skill::create_install_skill_executor(telemetry)),
+        Some(crate::commands::package_skill::create_install_skill_executor(telemetry.clone())),
     )?;
+    engine
+        .workflow_run_config_mut()
+        .execution
+        .nested_codemod_run_observer = Some(nested_codemod_run_observer(
+        telemetry,
+        args.id.to_string(),
+        args.workflow.clone(),
+        args.dry_run,
+    ));
 
     let tracked_task_ids = if args.trigger_all {
         engine

--- a/crates/cli/src/commands/workflow/resume.rs
+++ b/crates/cli/src/commands/workflow/resume.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::commands::run_telemetry::nested_codemod_run_observer;
+use crate::commands::run_telemetry::{nested_codemod_run_observer, persisted_workflow_root_name};
 use crate::engine::create_engine;
 use crate::utils::path_safety::normalize_target_path;
 use crate::utils::resolve_capabilities::{resolve_capabilities, ResolveCapabilitiesArgs};
@@ -134,13 +134,18 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         None,
         Some(crate::commands::package_skill::create_install_skill_executor(telemetry.clone())),
     )?;
+    let workflow_run = engine
+        .get_workflow_run(args.id)
+        .await
+        .context("Failed to load persisted workflow run")?;
+    let root_codemod_name = persisted_workflow_root_name(&workflow_run);
     engine
         .workflow_run_config_mut()
         .execution
         .nested_codemod_run_observer = Some(nested_codemod_run_observer(
         telemetry,
         args.id.to_string(),
-        args.workflow.clone(),
+        root_codemod_name,
         args.dry_run,
     ));
 

--- a/crates/cli/src/commands/workflow/run.rs
+++ b/crates/cli/src/commands/workflow/run.rs
@@ -16,6 +16,7 @@ use clap::Args;
 use codemod_telemetry::send_event::BaseEvent;
 use std::sync::atomic::Ordering;
 
+use crate::commands::run_telemetry::nested_codemod_run_observer;
 use crate::commands::TelemetrySenderExt;
 use crate::engine::{create_engine, create_registry_client};
 use crate::pro_dry_run::{
@@ -155,6 +156,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         .and_then(|value| value.to_str())
         .map(str::to_string)
         .unwrap_or_else(|| args.workflow.clone());
+    let execution_id = generate_execution_id();
     let workflow_definition = utils::parse_workflow_file(&workflow_file_path).context(format!(
         "Failed to parse workflow file: {}",
         workflow_file_path.display()
@@ -204,7 +206,16 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
         Some(crate::commands::package_skill::create_install_skill_executor(telemetry.clone())),
     )?;
 
-    engine.set_name(Some(workflow_label));
+    engine.set_name(Some(workflow_label.clone()));
+    engine
+        .workflow_run_config_mut()
+        .execution
+        .nested_codemod_run_observer = Some(nested_codemod_run_observer(
+        telemetry.clone(),
+        execution_id.clone(),
+        workflow_label,
+        dry_run,
+    ));
     apply_workflow_run_mode_to_config(engine.workflow_run_config_mut(), auto_launch_tui);
     if pro_dry_run_required {
         apply_pro_dry_run_execution_settings(engine.workflow_run_config_mut());
@@ -266,7 +277,7 @@ pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<
             BaseEvent {
                 kind: "localWorkflowExecuted".to_string(),
                 properties: HashMap::from([
-                    ("executionId".to_string(), generate_execution_id()),
+                    ("executionId".to_string(), execution_id),
                     ("runTimeSeconds".to_string(), seconds.to_string()),
                     ("dirtyRun".to_string(), args.allow_dirty.to_string()),
                     ("dryRun".to_string(), dry_run.to_string()),

--- a/crates/cli/src/commands/workflow/tui.rs
+++ b/crates/cli/src/commands/workflow/tui.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use crate::engine::create_engine;
 use crate::tui::run_workflow_tui;
+use crate::TelemetrySenderMutex;
 
 #[derive(Args, Debug)]
 pub struct Command {
@@ -16,7 +17,7 @@ pub struct Command {
     pub limit: usize,
 }
 
-pub async fn handler(args: &Command) -> Result<()> {
+pub async fn handler(args: &Command, telemetry: TelemetrySenderMutex) -> Result<()> {
     let (engine, _) = create_engine(
         Default::default(),
         Default::default(),
@@ -34,5 +35,5 @@ pub async fn handler(args: &Command) -> Result<()> {
         None,
     )?;
 
-    run_workflow_tui(engine, args.id, args.limit).await
+    run_workflow_tui(engine, telemetry, args.id, args.limit).await
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -464,7 +464,7 @@ async fn run_cli() -> Result<()> {
                 commands::workflow::cancel::handler(args).await?;
             }
             WorkflowCommands::Tui(args) => {
-                commands::workflow::tui::handler(args).await?;
+                commands::workflow::tui::handler(args, telemetry_sender.clone()).await?;
             }
         },
         Some(Commands::Jssg(args)) => match &args.command {

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -24,7 +24,7 @@ use ratatui::Terminal;
 use tokio::sync::{broadcast, mpsc};
 use uuid::Uuid;
 
-use crate::commands::nested_codemod_run_observer;
+use crate::commands::{nested_codemod_run_observer, persisted_workflow_root_name};
 use crate::tui::app::{ApprovalPrompt, Screen, TuiState};
 use crate::tui::event::AppEvent;
 use crate::TelemetrySenderMutex;
@@ -810,14 +810,7 @@ async fn attach_run(
 
     if let Some(telemetry) = telemetry {
         let workflow_run = engine.get_workflow_run(run_id).await?;
-        let root_codemod_name = workflow_run
-            .bundle_path
-            .as_deref()
-            .and_then(|path| path.file_name())
-            .and_then(|name| name.to_str())
-            .map(str::to_owned)
-            .unwrap_or_else(|| format!("workflow:{run_id}"));
-        let dry_run = engine.workflow_run_config_mut().execution.dry_run;
+        let root_codemod_name = persisted_workflow_root_name(&workflow_run);
         engine
             .workflow_run_config_mut()
             .execution
@@ -825,7 +818,7 @@ async fn attach_run(
             telemetry.clone(),
             run_id.to_string(),
             root_codemod_name,
-            dry_run,
+            None,
         ));
     }
 

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -24,8 +24,10 @@ use ratatui::Terminal;
 use tokio::sync::{broadcast, mpsc};
 use uuid::Uuid;
 
+use crate::commands::nested_codemod_run_observer;
 use crate::tui::app::{ApprovalPrompt, Screen, TuiState};
 use crate::tui::event::AppEvent;
+use crate::TelemetrySenderMutex;
 
 struct TerminalGuard;
 
@@ -225,6 +227,7 @@ pub(crate) fn create_tui_progress_callback(workflow_run_id: Uuid) -> ProgressCal
 
 pub async fn run_workflow_tui(
     mut engine: Engine,
+    telemetry: TelemetrySenderMutex,
     run_id: Option<Uuid>,
     limit: usize,
 ) -> Result<()> {
@@ -245,11 +248,19 @@ pub async fn run_workflow_tui(
     let mut perf_counters = TuiPerfCounters::from_env();
 
     if let Some(run_id) = run_id {
-        attach_run(&mut engine, run_id, &mut state, &mut runtime).await?;
+        attach_run(
+            &mut engine,
+            Some(&telemetry),
+            run_id,
+            &mut state,
+            &mut runtime,
+        )
+        .await?;
     }
 
     let result = run_tui_loop(
         &mut engine,
+        Some(&telemetry),
         &mut terminal,
         &mut state,
         limit,
@@ -294,6 +305,7 @@ pub async fn run_workflow_tui_with_session(
 
     let result = run_tui_loop(
         &mut engine,
+        None,
         &mut terminal,
         &mut state,
         limit,
@@ -416,6 +428,7 @@ async fn wait_for_next_wake(
 
 async fn run_tui_loop(
     engine: &mut Engine,
+    telemetry: Option<&TelemetrySenderMutex>,
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     state: &mut TuiState,
     limit: usize,
@@ -631,7 +644,7 @@ async fn run_tui_loop(
                         }
                         KeyCode::Enter => {
                             if let Some(run_id) = state.selected_run_id() {
-                                attach_run(engine, run_id, state, runtime).await?;
+                                attach_run(engine, telemetry, run_id, state, runtime).await?;
                             }
                         }
                         _ => {}
@@ -763,6 +776,7 @@ fn spawn_command(
 
 async fn attach_run(
     engine: &mut Engine,
+    telemetry: Option<&TelemetrySenderMutex>,
     run_id: Uuid,
     state: &mut TuiState,
     runtime: &mut TuiRuntime,
@@ -792,6 +806,27 @@ async fn attach_run(
         runtime.receiver = None;
         runtime.session = None;
         state.clear_approvals();
+    }
+
+    if let Some(telemetry) = telemetry {
+        let workflow_run = engine.get_workflow_run(run_id).await?;
+        let root_codemod_name = workflow_run
+            .bundle_path
+            .as_deref()
+            .and_then(|path| path.file_name())
+            .and_then(|name| name.to_str())
+            .map(str::to_owned)
+            .unwrap_or_else(|| format!("workflow:{run_id}"));
+        let dry_run = engine.workflow_run_config_mut().execution.dry_run;
+        engine
+            .workflow_run_config_mut()
+            .execution
+            .nested_codemod_run_observer = Some(nested_codemod_run_observer(
+            telemetry.clone(),
+            run_id.to_string(),
+            root_codemod_name,
+            dry_run,
+        ));
     }
 
     let session = WorkflowSession::attach(engine.clone(), run_id);

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use crate::{
     ai_handoff::AgentOption,
     execution::{CodemodExecutionConfig, ProgressCallback},
+    nested_codemod_run::NestedCodemodRunObserver,
     registry::RegistryClient,
     structured_log::OutputFormat,
 };
@@ -159,6 +160,7 @@ pub struct WorkflowExecutionSettings {
     pub pre_run_callback: Arc<Option<PreRunCallback>>,
     pub dry_run: bool,
     pub registry_client: RegistryClient,
+    pub nested_codemod_run_observer: Option<Arc<dyn NestedCodemodRunObserver>>,
     pub capabilities: Option<HashSet<LlrtSupportedModules>>,
     pub capabilities_security_callback: Option<CapabilitiesSecurityCallback>,
     /// Auto-trigger manual steps instead of waiting for user input (used by pro codemod dry-run)
@@ -183,6 +185,7 @@ impl Default for WorkflowExecutionSettings {
             pre_run_callback: Arc::new(None),
             dry_run: false,
             registry_client: RegistryClient::default(),
+            nested_codemod_run_observer: None,
             capabilities: None,
             capabilities_security_callback: None,
             auto_trigger_manual_steps: false,

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -36,6 +36,7 @@ use crate::file_ops::AsyncFileWriter;
 use crate::jssg_execution_service::{JssgExecutionRequest, JssgExecutionService};
 use crate::llm_usage::LlmUsageContext;
 use crate::managed_git_service::{ManagedGitService, WorktreeCleanup};
+use crate::nested_codemod_run::{observe_nested_codemod_run, NestedCodemodRun};
 use crate::nested_codemod_service::NestedCodemodService;
 use crate::progress_output::{
     append_buffered_diagnostic, append_buffered_log, flush_buffered_execution_output,
@@ -3473,7 +3474,13 @@ impl Engine {
             resolved.package.package_dir.display()
         );
 
-        self.run_codemod_workflow_with_chain(
+        let run = registry_nested_codemod_run(&resolved.package, &resolved.dependency_chain);
+        let observer = self
+            .workflow_run_config
+            .execution
+            .nested_codemod_run_observer
+            .clone();
+        let operation = self.run_codemod_workflow_with_chain(
             &resolved.package,
             &resolved.workflow,
             codemod,
@@ -3488,8 +3495,12 @@ impl Engine {
             &resolved.dependency_chain,
             capabilities,
             logger,
-        )
-        .await
+        );
+
+        match run {
+            Some(run) => observe_nested_codemod_run(observer.as_ref(), run, operation).await,
+            None => operation.await,
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -4294,6 +4305,22 @@ impl Engine {
     }
 }
 
+fn registry_nested_codemod_run(
+    package: &ResolvedPackage,
+    dependency_chain: &[CodemodDependency],
+) -> Option<NestedCodemodRun> {
+    let metadata = package.registry_metadata.as_ref()?;
+    Some(NestedCodemodRun {
+        codemod_name: metadata.package_web_path.clone(),
+        package_version: package.version.clone(),
+        execution_id: Uuid::new_v4().to_string(),
+        dependency_path: dependency_chain
+            .iter()
+            .map(|dependency| dependency.source.clone())
+            .collect(),
+    })
+}
+
 impl Clone for Engine {
     fn clone(&self) -> Self {
         Self {
@@ -4319,6 +4346,7 @@ mod tests {
     use crate::config::{
         InstallSkillExecutionRequest, InstallSkillExecutor, SelectionPrompt, SelectionPromptOption,
     };
+    use crate::registry::{PackageSpec, RegistryPackageMetadata};
     use anyhow::Result as AnyhowResult;
     use butterflow_models::step::{
         BuiltinShardMethod, BuiltinShardType, SemanticAnalysisConfig, SemanticAnalysisMode,
@@ -4328,6 +4356,47 @@ mod tests {
     use serial_test::serial;
     use std::sync::Arc;
     use tokio::sync::mpsc;
+
+    fn resolved_package(registry_metadata: Option<RegistryPackageMetadata>) -> ResolvedPackage {
+        ResolvedPackage {
+            spec: PackageSpec {
+                scope: None,
+                name: "child".to_string(),
+                version: Some("1.2.3".to_string()),
+            },
+            version: "1.2.3".to_string(),
+            package_dir: PathBuf::from("/tmp/child"),
+            dry_run_only: false,
+            registry_metadata,
+        }
+    }
+
+    #[test]
+    fn nested_run_is_created_only_for_registry_packages() {
+        let dependency_chain = vec![
+            CodemodDependency {
+                source: "@codemod/child-a".to_string(),
+            },
+            CodemodDependency {
+                source: "@alias/child-b".to_string(),
+            },
+        ];
+        let registry_package = resolved_package(Some(RegistryPackageMetadata {
+            registry_base_url: "https://app.codemod.com".to_string(),
+            package_web_path: "@codemod/child-b".to_string(),
+            access: Some("public".to_string()),
+        }));
+
+        let run = registry_nested_codemod_run(&registry_package, &dependency_chain)
+            .expect("registry package run");
+        assert_eq!(run.codemod_name, "@codemod/child-b");
+        assert_eq!(run.package_version, "1.2.3");
+        assert_eq!(
+            run.dependency_path,
+            vec!["@codemod/child-a", "@alias/child-b"]
+        );
+        assert!(registry_nested_codemod_run(&resolved_package(None), &dependency_chain).is_none());
+    }
 
     #[test]
     fn nested_manifest_capabilities_merge_with_parent_capabilities() {

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -4316,7 +4316,16 @@ fn registry_nested_codemod_run(
         execution_id: Uuid::new_v4().to_string(),
         dependency_path: dependency_chain
             .iter()
-            .map(|dependency| dependency.source.clone())
+            .map(|dependency| {
+                if dependency.source.starts_with("./")
+                    || dependency.source.starts_with("../")
+                    || dependency.source.starts_with("/")
+                {
+                    "<local>".to_string()
+                } else {
+                    dependency.source.clone()
+                }
+            })
             .collect(),
     })
 }
@@ -4378,6 +4387,15 @@ mod tests {
                 source: "@codemod/child-a".to_string(),
             },
             CodemodDependency {
+                source: "/Users/example/private/absolute-child".to_string(),
+            },
+            CodemodDependency {
+                source: "./private/relative-child".to_string(),
+            },
+            CodemodDependency {
+                source: "../private/sibling-child".to_string(),
+            },
+            CodemodDependency {
                 source: "@alias/child-b".to_string(),
             },
         ];
@@ -4393,8 +4411,19 @@ mod tests {
         assert_eq!(run.package_version, "1.2.3");
         assert_eq!(
             run.dependency_path,
-            vec!["@codemod/child-a", "@alias/child-b"]
+            vec![
+                "@codemod/child-a",
+                "<local>",
+                "<local>",
+                "<local>",
+                "@alias/child-b"
+            ]
         );
+        assert_eq!(run.dependency_path.len(), dependency_chain.len());
+        assert!(!run
+            .dependency_path
+            .iter()
+            .any(|segment| segment.contains("private")));
         assert!(registry_nested_codemod_run(&resolved_package(None), &dependency_chain).is_none());
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod git_ops;
 pub(crate) mod jssg_execution_service;
 pub mod llm_usage;
 pub(crate) mod managed_git_service;
+pub mod nested_codemod_run;
 pub(crate) mod nested_codemod_service;
 pub(crate) mod progress_output;
 pub mod registry;

--- a/crates/core/src/nested_codemod_run.rs
+++ b/crates/core/src/nested_codemod_run.rs
@@ -1,0 +1,195 @@
+use std::{future::Future, sync::Arc, time::Instant};
+
+use async_trait::async_trait;
+use butterflow_models::Result;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NestedCodemodRun {
+    pub codemod_name: String,
+    pub package_version: String,
+    pub execution_id: String,
+    pub dependency_path: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NestedCodemodRunOutcome {
+    Succeeded,
+    Failed { error_message: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NestedCodemodRunEvent {
+    Started(NestedCodemodRun),
+    Completed {
+        run: NestedCodemodRun,
+        outcome: NestedCodemodRunOutcome,
+        duration_ms: u128,
+    },
+}
+
+#[async_trait]
+pub trait NestedCodemodRunObserver: Send + Sync {
+    async fn record(&self, event: NestedCodemodRunEvent);
+}
+
+pub(crate) async fn observe_nested_codemod_run<T, F>(
+    observer: Option<&Arc<dyn NestedCodemodRunObserver>>,
+    run: NestedCodemodRun,
+    operation: F,
+) -> Result<T>
+where
+    F: Future<Output = Result<T>>,
+{
+    if let Some(observer) = observer {
+        observer
+            .record(NestedCodemodRunEvent::Started(run.clone()))
+            .await;
+    }
+
+    let started = Instant::now();
+    let result = operation.await;
+    let outcome = match &result {
+        Ok(_) => NestedCodemodRunOutcome::Succeeded,
+        Err(error) => NestedCodemodRunOutcome::Failed {
+            error_message: error.to_string(),
+        },
+    };
+
+    if let Some(observer) = observer {
+        observer
+            .record(NestedCodemodRunEvent::Completed {
+                run,
+                outcome,
+                duration_ms: started.elapsed().as_millis(),
+            })
+            .await;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use butterflow_models::Error;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        events: Mutex<Vec<NestedCodemodRunEvent>>,
+    }
+
+    #[async_trait]
+    impl NestedCodemodRunObserver for RecordingObserver {
+        async fn record(&self, event: NestedCodemodRunEvent) {
+            self.events.lock().expect("events lock").push(event);
+        }
+    }
+
+    fn test_run() -> NestedCodemodRun {
+        NestedCodemodRun {
+            codemod_name: "@codemod/react/child".to_string(),
+            package_version: "1.2.3".to_string(),
+            execution_id: "child-execution".to_string(),
+            dependency_path: vec!["@codemod/react/child".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn observer_receives_started_and_successful_completion() {
+        let observer = Arc::new(RecordingObserver::default());
+        let observer_trait: Arc<dyn NestedCodemodRunObserver> = observer.clone();
+
+        let result = observe_nested_codemod_run(Some(&observer_trait), test_run(), async {
+            Ok::<_, Error>(())
+        })
+        .await;
+
+        assert!(result.is_ok());
+        let events = observer.events.lock().expect("events lock");
+        assert!(matches!(
+            events.as_slice(),
+            [
+                NestedCodemodRunEvent::Started(_),
+                NestedCodemodRunEvent::Completed {
+                    outcome: NestedCodemodRunOutcome::Succeeded,
+                    ..
+                }
+            ]
+        ));
+    }
+
+    #[tokio::test]
+    async fn observer_receives_failed_completion_without_swallowing_error() {
+        let observer = Arc::new(RecordingObserver::default());
+        let observer_trait: Arc<dyn NestedCodemodRunObserver> = observer.clone();
+
+        let result = observe_nested_codemod_run(Some(&observer_trait), test_run(), async {
+            Err::<(), _>(Error::Other("child failed".to_string()))
+        })
+        .await;
+
+        assert!(result.is_err());
+        let events = observer.events.lock().expect("events lock");
+        assert!(matches!(
+            events.first(),
+            Some(NestedCodemodRunEvent::Started(_))
+        ));
+        let Some(NestedCodemodRunEvent::Completed {
+            outcome: NestedCodemodRunOutcome::Failed { error_message },
+            ..
+        }) = events.get(1)
+        else {
+            panic!("expected failed completion event");
+        };
+        assert!(error_message.contains("child failed"));
+    }
+
+    #[tokio::test]
+    async fn recursive_children_each_emit_one_lifecycle_pair() {
+        let observer = Arc::new(RecordingObserver::default());
+        let observer_trait: Arc<dyn NestedCodemodRunObserver> = observer.clone();
+        let mut child = test_run();
+        child.codemod_name = "@codemod/react/child-a".to_string();
+        child.dependency_path = vec!["@codemod/react/child-a".to_string()];
+        let mut grandchild = test_run();
+        grandchild.codemod_name = "@codemod/react/child-b".to_string();
+        grandchild.dependency_path = vec![
+            "@codemod/react/child-a".to_string(),
+            "@codemod/react/child-b".to_string(),
+        ];
+
+        let result = observe_nested_codemod_run(Some(&observer_trait), child, async {
+            observe_nested_codemod_run(Some(&observer_trait), grandchild, async {
+                Ok::<_, Error>(())
+            })
+            .await
+        })
+        .await;
+
+        assert!(result.is_ok());
+        let events = observer.events.lock().expect("events lock");
+        assert_eq!(events.len(), 4);
+        let paths = events
+            .iter()
+            .filter_map(|event| match event {
+                NestedCodemodRunEvent::Started(run) => Some(run.dependency_path.as_slice()),
+                NestedCodemodRunEvent::Completed { .. } => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paths,
+            vec![
+                ["@codemod/react/child-a"].as_slice(),
+                ["@codemod/react/child-a", "@codemod/react/child-b"].as_slice(),
+            ]
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, NestedCodemodRunEvent::Completed { .. }))
+                .count(),
+            2
+        );
+    }
+}


### PR DESCRIPTION
#### 📚 Description

Bundle executions now contribute usage for every registry-backed child codemod, including recursively nested dependencies, instead of counting only the root bundle.

Child runs use the canonical registry package and version, receive their own execution ID, and include root, parent, dependency-path, dry-run, outcome, and duration context. They use the existing telemetry sender, so the stored external identity and best-effort delivery behavior remain unchanged. Local filesystem packages are excluded from registry usage counts, and telemetry failures do not replace workflow results.

#### 🔗 Linked Issue

None.

#### 🧪 Test Plan

- `cargo test -p butterflow-core --lib` — 119 passed
- `cargo test -p codemod` — 464 passed, 3 ignored
- `cargo test -p butterflow-models -p butterflow-state` — 57 passed
- `cargo fmt --all -- --check`
- `cargo clippy --tests --no-deps -- -D warnings`
- `bash ./scripts/check-single-crossterm.sh`

#### 📄 Documentation to Update

None. This changes internal analytics emission without changing user-facing commands.
